### PR TITLE
build: Remove scripts from sub-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,16 +429,15 @@ Same as `npm run build`, but builds the project in a Docker container to ensure 
 
 #### Tips
 
-  * Remember to always run `npm run build` before committing changes to packages.
-    Failing to do so will not pass CI/CD checks.
+  * Remember to always run `npm run build` before committing changes to packages. Failing to do so will not pass CI/CD checks
   * If you've run `npm run build` and your build still fails, try `npm ci && npm run build`
-  * If developing a package, run `jest` within that package instead of the root to only test your changes.
-  * Do not add dependencies to the root package unless you are making global changes, for example to the build process.
+  * While developing, run `npm test -- -o` to only run tests on changed files
+  * Do not add dependencies to the root package unless you are making global changes, for example to the build process
 
 ### CI/CD Pipeline
 
-The project is built with a [GitHub Actions pipeline](.github/workflows/commit.yml).
-Every successful commit to `master` will
+A [GitHub Actions pipeline](.github/workflows/commit.yml) will run tests on every commit.
+Every successful commit to `master` will automatically:
 
   * Be tagged to a semantic release version
   * Update the `v{MAJOR}` branch to point to the new release

--- a/cloud-run/package.json
+++ b/cloud-run/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Deploy to Cloud Run",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/jest/bin/jest.js --config ../jest.config.js",
-    "build": "node ../node_modules/@zeit/ncc/dist/ncc/cli.js build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.3",
     "@actions/exec": "^1.0.3",

--- a/conventional-release/package.json
+++ b/conventional-release/package.json
@@ -4,10 +4,6 @@
   "description": "Create a release based on conventional commit conventions and historic releases",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/github": "^1.1.0"

--- a/conventional-version/package.json
+++ b/conventional-version/package.json
@@ -4,10 +4,6 @@
   "description": "Determine the project version based on conventional commit conventions",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc -m build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0"
   }

--- a/docker/package.json
+++ b/docker/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Docker build, tag, and push with default registry URL",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0"
   }

--- a/gcp-secret-manager/package.json
+++ b/gcp-secret-manager/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "GCP Secret Manager",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "google-auth-library": "^5.10.1",

--- a/jira-release/package.json
+++ b/jira-release/package.json
@@ -4,10 +4,6 @@
   "description": "Create and populate a JIRA release from conventional commit conventions",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc -m build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "jira-client": "^6.14.0",

--- a/jira-releasenotes/package.json
+++ b/jira-releasenotes/package.json
@@ -4,10 +4,6 @@
   "description": "Populate JIRA release notes from conventional commit conventions",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc -m build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "jira-client": "^6.14.0"

--- a/maven/package.json
+++ b/maven/package.json
@@ -4,10 +4,6 @@
   "description": "Maven with Extenda Retail Settings",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc -m build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",

--- a/rs-create-installerpkg/package.json
+++ b/rs-create-installerpkg/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Build RS installer package",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1"

--- a/rs-permission-converter/package.json
+++ b/rs-permission-converter/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Wrap permission converter cmd line utility",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1"

--- a/setup-gcloud/package.json
+++ b/setup-gcloud/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Setup GCloud CLI",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.3",
     "@actions/exec": "^1.0.3",

--- a/setup-git/package.json
+++ b/setup-git/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Setup the Git CLI with credentials.",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0"
   }

--- a/setup-msbuild/package.json
+++ b/setup-msbuild/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Prepare MSBuild for use in GitHub Actions",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1"

--- a/setup-nuget-sources/package.json
+++ b/setup-nuget-sources/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "description": "Setting nuget sources in NuGet.Config file",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",

--- a/slack-message/package.json
+++ b/slack-message/package.json
@@ -4,10 +4,6 @@
   "description": "Send a message to Slack through the GitHub Slack Integration",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "",
-    "build": "node ../node_modules/.bin/ncc -m build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "node-fetch": "^2.6.0"

--- a/sonar-scanner/package.json
+++ b/sonar-scanner/package.json
@@ -4,10 +4,6 @@
   "description": "Perform a Sonar analysis on a project",
   "private": true,
   "main": "dist/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": "node ../node_modules/.bin/ncc build src/index.js"
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -4,10 +4,6 @@
   "description": "Utilities for Extenda Retail GitHub Actions",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "test": "node ../node_modules/.bin/jest --config ../jest.config.js",
-    "build": ""
-  },
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",


### PR DESCRIPTION
Continued effort to make the project easier to work with on Windows. This PR removes all the scripts from the sub-packages to focus on a working root build. Test, build and lint should now work on all platforms.