### PR TITLE
feat: Require CPU in cloud-run.yaml

### DIFF
--- a/cloud-run/README.md
+++ b/cloud-run/README.md
@@ -40,40 +40,39 @@ By default, the action will load `cloud-run.yaml` from the repository base direc
 The YAML syntax is formally defined with [JSON Schema](src/cloud-run-schema.js). The following table explains what
 properties are required and not.
 
-| Property        | Description                                                                                                                                                       | Required | Default Value |
-|:----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:--------------|
-| `name`          | The service name.                                                                                                                                                 | Yes      |               |
-| `memory`        | Set a memory limit, for example `256Mi`, `512Mi` or `1Gi`.                                                                                                        | Yes      |               |
-| `concurrency`   | The max concurrent requests per container. Set to `-1` to use the default concurrency for the platform (recommended).                                             | No       | `-1`          |
-| `max-instances` | The maximum number of container instances to run. Set to `-1` to use the platform default (recommended).                                                          | No       | `-1`          |
-| `environment`*  | A map of environment variables. The values can be Secret Manager URLs on the form `sm://*/my-secret` where `*` will be replaced by the project ID at deploy time. | No       | -             |
+| Property                   | Description                                                                                                                                                       | Required | Default Value |
+|:---------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:--------------|
+| `name`                     | The service name.                                                                                                                                                 | Yes      |               |
+| `memory`                   | Set a memory limit, for example `256Mi`, `512Mi` or `1Gi`.                                                                                                        | Yes      |               |
+| `concurrency`              | The max concurrent requests per container. Set to `-1` to use the default concurrency for the platform (recommended).                                             | No       | `-1`          |
+| `cpu`                      | The CPU limit for the service. For managed Cloud Run, use core count `1` or `2`. For Cloud Run on GKE, use millicpu (e.g., `200m`).                               | Yes      |               |
+| `max-instances`            | The maximum number of container instances to run. Set to `-1` to use the platform default (recommended).                                                          | No       | `-1`          |
+| `environment`<top>\*</top> | A map of environment variables. The values can be Secret Manager URLs on the form `sm://*/my-secret` where `*` will be replaced by the project ID at deploy time. | No       | -             |
 
 <top>\*</top> Once set, this value can only be unset by passing `[]` (empty array) as value.
 
 These properties only apply to Managed Cloud Run:
 
-| Property                                          | Description                                                                                                                                                      | Required | Default Value      |
-|:--------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:-------------------|
-| `platform.managed.allow-unauthenticated`          | Whether to enable unauthenticated access to the publicly available service.                                                                                      | Yes      |                    |
-| `platform.managed.region`                         | The region in which to run the service.                                                                                                                          | Yes      |                    |
-| `platform.managed.cloudsql-instances`<top>*</top> | A list of [Cloud SQL instance names](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--add-cloudsql-instances) this service can connect to.             | No       | -                  |
-| `platform.managed.cpu`                            | The CPU limit for the service. Default is 1. Can be set to 2.                                                                                                    | No       | 1                  |
-| `platform.managed.service-account`                | The runtime service account used by the Cloud Run service. Either a fully-qualified email or a prefix where the default project email is appended automatically. | No       | `cloudrun-runtime` |
+| Property                                           | Description                                                                                                                                                      | Required | Default Value      |
+|:---------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:-------------------|
+| `platform.managed.allow-unauthenticated`           | Whether to enable unauthenticated access to the publicly available service.                                                                                      | Yes      |                    |
+| `platform.managed.region`                          | The region in which to run the service.                                                                                                                          | Yes      |                    |
+| `platform.managed.cloudsql-instances`<top>\*</top> | A list of [Cloud SQL instance names](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--add-cloudsql-instances) this service can connect to.             | No       | -                  |
+| `platform.managed.service-account`                 | The runtime service account used by the Cloud Run service. Either a fully-qualified email or a prefix where the default project email is appended automatically. | No       | `cloudrun-runtime` |
 
 <top>\*</top> Once set, this value can only be unset by passing `[]` (empty array) as value.
 
 These properties only apply to Cloud Run on GKE:
 
-| Property                               | Description                                                                                                | Required | Default Value                   |
-|:---------------------------------------|:-----------------------------------------------------------------------------------------------------------|:---------|:--------------------------------|
-| `min-instances`                        | The minimum number of container instances to run. Set to `-1` to use the platform default (recommended).   | No       | `-1`                            |
-| `platform.gke.cluster`                 | The name of the cluster to deploy to.                                                                      | No       | The `k8s-cluster` in Tribe GKE. |
-| `platform.gke.connectivity`            | Determines if the service can be invoked through internet. Can be set to `external` or `internal`.         | Yes      |                                 |
-| `platform.gke.cpu`                     | The CPU limit for the service in Kubernetes CPU units, for example 300m.                                   | Yes      |                                 |
-| `platform.gke.domain-mappings.prod`    | List of fully qualified domains to map in the `prod` environment. Only applies to `external` services.     | No       |                                 |
-| `platform.gke.domain-mappings.staging` | List of fully qualified domains to map in the `staging` environment. Only applies to `external` services.  | No       |                                 |
-| `platform.gke.namespace`               | The Kubernetes namespace to use.                                                                           | No       | The service `name`              |
-| `platform.gke.opa-enabled`             | Flag to enable OPA and Istio injection on service.                                                         | No       | `true`                          |
+| Property                               | Description                                                                                               | Required | Default Value                   |
+|:---------------------------------------|:----------------------------------------------------------------------------------------------------------|:---------|:--------------------------------|
+| `min-instances`                        | The minimum number of container instances to run. Set to `-1` to use the platform default (recommended).  | No       | `-1`                            |
+| `platform.gke.cluster`                 | The name of the cluster to deploy to.                                                                     | No       | The `k8s-cluster` in Tribe GKE. |
+| `platform.gke.connectivity`            | Determines if the service can be invoked through internet. Can be set to `external` or `internal`.        | Yes      |                                 |
+| `platform.gke.domain-mappings.prod`    | List of fully qualified domains to map in the `prod` environment. Only applies to `external` services.    | No       |                                 |
+| `platform.gke.domain-mappings.staging` | List of fully qualified domains to map in the `staging` environment. Only applies to `external` services. | No       |                                 |
+| `platform.gke.namespace`               | The Kubernetes namespace to use.                                                                          | No       | The service `name`              |
+| `platform.gke.opa-enabled`             | Flag to enable OPA and Istio injection on service.                                                        | No       | `true`                          |
 
 ### YAML Examples
 
@@ -83,6 +82,7 @@ This example defines a Cloud Run service that runs in managed Cloud Run.
 ```yaml
 name: my-service
 memory: 256Mi
+cpu: 1
 environment:
   DEBUG_LOG: 'false'
   SECRET_NAME: sm://*/secret-name
@@ -98,10 +98,10 @@ This example defines a Cloud Run service that runs on Cloud Run on GKE.
 ```yaml
 name: my-service
 memory: 256Mi
+cpu: 200m
 platform:
   gke:
     connectivity: external
-    cpu: 300m
 ```
 
 ### Cloud Run on GKE with domain-mappings
@@ -110,10 +110,10 @@ This example defines a Cloud Run service that is bound to a public domain.
 ```yaml
 name: my-service
 memory: 256Mi
+cpu: 300m
 platform:
   gke:
     connectivity: external
-    cpu: 300m
     domains-mappings:
       prod:
         - my-service.retailsvc.com
@@ -127,10 +127,10 @@ This example defines a Cloud Run service that runs on Cloud Run on GKE.
 ```yaml
 name: my-service
 memory: 256Mi
+cpu: 200m
 platform:
   gke:
     connectivity: external
-    cpu: 300m
     cluster: k8s-cluster
     namespace: default
 ```
@@ -146,6 +146,7 @@ Given the following `cloud-run.yaml`:
 ```yaml
 name: my-service
 memory: 256Mi
+cpu: 1
 platform:
   managed:
     allow-unauthenticated: true
@@ -176,6 +177,7 @@ Given the following `cloud-run.yaml`:
 ```yaml
 name: my-service
 memory: 256Mi
+cpu: 1
 platform:
   managed:
     allow-unauthenticated: true

--- a/cloud-run/README.md
+++ b/cloud-run/README.md
@@ -69,7 +69,7 @@ These properties only apply to Cloud Run on GKE:
 | `min-instances`                        | The minimum number of container instances to run. Set to `-1` to use the platform default (recommended).   | No       | `-1`                            |
 | `platform.gke.cluster`                 | The name of the cluster to deploy to.                                                                      | No       | The `k8s-cluster` in Tribe GKE. |
 | `platform.gke.connectivity`            | Determines if the service can be invoked through internet. Can be set to `external` or `internal`.         | Yes      |                                 |
-| `platform.gke.cpu`                     | The CPU limit for the service in Kubernetes CPU units, for example 500m.                                   | No       | `1`                             |
+| `platform.gke.cpu`                     | The CPU limit for the service in Kubernetes CPU units, for example 300m.                                   | Yes      |                                 |
 | `platform.gke.domain-mappings.prod`    | List of fully qualified domains to map in the `prod` environment. Only applies to `external` services.     | No       |                                 |
 | `platform.gke.domain-mappings.staging` | List of fully qualified domains to map in the `staging` environment. Only applies to `external` services.  | No       |                                 |
 | `platform.gke.namespace`               | The Kubernetes namespace to use.                                                                           | No       | The service `name`              |
@@ -101,6 +101,7 @@ memory: 256Mi
 platform:
   gke:
     connectivity: external
+    cpu: 300m
 ```
 
 ### Cloud Run on GKE with domain-mappings
@@ -112,6 +113,7 @@ memory: 256Mi
 platform:
   gke:
     connectivity: external
+    cpu: 300m
     domains-mappings:
       prod:
         - my-service.retailsvc.com
@@ -128,6 +130,7 @@ memory: 256Mi
 platform:
   gke:
     connectivity: external
+    cpu: 300m
     cluster: k8s-cluster
     namespace: default
 ```

--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -5279,6 +5279,7 @@ function _evaluateVersions(versions, versionSpec) {
 /* 193 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
+const core = __webpack_require__(793);
 const exec = __webpack_require__(266);
 const setupGcloud = __webpack_require__(217);
 const getRuntimeAccount = __webpack_require__(838);
@@ -5295,16 +5296,20 @@ const numericOrDefault = (value) => (value >= 0 ? value : 'default');
 
 const managedArguments = async (args, service, projectId) => {
   const {
+    cpu,
     platform: {
       managed: {
         'allow-unauthenticated': allowUnauthenticated,
         'cloudsql-instances': cloudSqlInstances = undefined,
         region,
-        cpu = 1,
         'runtime-account': runtimeAccountEmail = 'cloudrun-runtime',
       },
     },
   } = service;
+
+  if (typeof cpu === 'string' && cpu.endsWith('m')) {
+    throw new Error('Managed Cloud Run must be configured with CPU count [1,2]. Use of millicpu is not supported.');
+  }
 
   const runtimeAccount = await getRuntimeAccount(runtimeAccountEmail, projectId);
   args.push(`--service-account=${runtimeAccount}`);
@@ -5333,17 +5338,21 @@ const managedArguments = async (args, service, projectId) => {
 const gkeArguments = async (args, service, projectId, regoFile) => {
   const {
     name,
+    cpu,
     'min-instances': minInstances = -1,
     platform: {
       gke: {
         cluster: configuredCluster = undefined,
-        cpu = '1',
         connectivity,
         namespace = name,
         'opa-enabled': opaEnabled = true,
       },
     },
   } = service;
+
+  if (typeof cpu === 'number') {
+    throw new Error('Cloud Run GKE must be configured with millicpu. Use of CPU count is not supported.');
+  }
 
   const cluster = await getClusterInfo(projectId, configuredCluster);
 
@@ -9010,19 +9019,38 @@ function getPrettyContext({
 module.exports = {
   type: 'object',
   properties: {
-    name: {
-      type: 'string',
-    },
-    memory: {
-      type: 'string',
-    },
     concurrency: {
       type: 'integer',
       default: -1,
     },
+    cpu: {
+      oneOf: [
+        {
+          type: 'string',
+          title: 'millicpu',
+          description: 'Kubernetes CPU request in millicpu',
+          pattern: '^[0-9]{1,4}m$',
+        },
+        {
+          type: 'integer',
+          title: 'CPU cores',
+          description: 'CPU cores for managed cloud run',
+          minimum: 1,
+          maximum: 2,
+        },
+      ],
+      default: '200m',
+    },
+    name: {
+      type: 'string',
+    },
     'max-instances': {
       type: 'integer',
       default: -1,
+    },
+    memory: {
+      type: 'string',
+      pattern: '^[0-9]+(M|G)i',
     },
     'min-instances': {
       type: 'integer',
@@ -9045,11 +9073,6 @@ module.exports = {
               items: {
                 type: 'string',
               },
-            },
-            cpu: {
-              type: 'integer',
-              minimum: 1,
-              maximum: 2,
             },
             region: {
               type: 'string',
@@ -9078,9 +9101,6 @@ module.exports = {
                 'internal',
               ],
             },
-            cpu: {
-              type: 'string',
-            },
             'domain-mappings': {
               type: 'object',
               properties: {
@@ -9108,19 +9128,25 @@ module.exports = {
           },
           required: [
             'connectivity',
-            'cpu',
           ],
           additionalProperties: false,
         },
       },
       oneOf: [
-        { required: ['managed'] },
-        { required: ['gke'] },
+        {
+          title: 'managed',
+          required: ['managed'],
+        },
+        {
+          title: 'gke',
+          required: ['gke'],
+        },
       ],
       additionalProperties: false,
     },
   },
   required: [
+    'cpu',
     'name',
     'memory',
     'platform',

--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -9108,6 +9108,7 @@ module.exports = {
           },
           required: [
             'connectivity',
+            'cpu',
           ],
           additionalProperties: false,
         },

--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -5279,7 +5279,6 @@ function _evaluateVersions(versions, versionSpec) {
 /* 193 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
-const core = __webpack_require__(793);
 const exec = __webpack_require__(266);
 const setupGcloud = __webpack_require__(217);
 const getRuntimeAccount = __webpack_require__(838);

--- a/cloud-run/src/cloud-run-schema.js
+++ b/cloud-run/src/cloud-run-schema.js
@@ -1,19 +1,38 @@
 module.exports = {
   type: 'object',
   properties: {
-    name: {
-      type: 'string',
-    },
-    memory: {
-      type: 'string',
-    },
     concurrency: {
       type: 'integer',
       default: -1,
     },
+    cpu: {
+      oneOf: [
+        {
+          type: 'string',
+          title: 'millicpu',
+          description: 'Kubernetes CPU request in millicpu',
+          pattern: '^[0-9]{1,4}m$',
+        },
+        {
+          type: 'integer',
+          title: 'CPU cores',
+          description: 'CPU cores for managed cloud run',
+          minimum: 1,
+          maximum: 2,
+        },
+      ],
+      default: '200m',
+    },
+    name: {
+      type: 'string',
+    },
     'max-instances': {
       type: 'integer',
       default: -1,
+    },
+    memory: {
+      type: 'string',
+      pattern: '^[0-9]+(M|G)i',
     },
     'min-instances': {
       type: 'integer',
@@ -36,11 +55,6 @@ module.exports = {
               items: {
                 type: 'string',
               },
-            },
-            cpu: {
-              type: 'integer',
-              minimum: 1,
-              maximum: 2,
             },
             region: {
               type: 'string',
@@ -69,9 +83,6 @@ module.exports = {
                 'internal',
               ],
             },
-            cpu: {
-              type: 'string',
-            },
             'domain-mappings': {
               type: 'object',
               properties: {
@@ -99,19 +110,25 @@ module.exports = {
           },
           required: [
             'connectivity',
-            'cpu',
           ],
           additionalProperties: false,
         },
       },
       oneOf: [
-        { required: ['managed'] },
-        { required: ['gke'] },
+        {
+          title: 'managed',
+          required: ['managed'],
+        },
+        {
+          title: 'gke',
+          required: ['gke'],
+        },
       ],
       additionalProperties: false,
     },
   },
   required: [
+    'cpu',
     'name',
     'memory',
     'platform',

--- a/cloud-run/src/cloud-run-schema.js
+++ b/cloud-run/src/cloud-run-schema.js
@@ -99,6 +99,7 @@ module.exports = {
           },
           required: [
             'connectivity',
+            'cpu',
           ],
           additionalProperties: false,
         },

--- a/cloud-run/src/run-deploy.js
+++ b/cloud-run/src/run-deploy.js
@@ -1,4 +1,3 @@
-const core = require('@actions/core');
 const exec = require('@actions/exec');
 const setupGcloud = require('../../setup-gcloud/src/setup-gcloud');
 const getRuntimeAccount = require('./runtime-account');

--- a/cloud-run/src/run-deploy.js
+++ b/cloud-run/src/run-deploy.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core');
 const exec = require('@actions/exec');
 const setupGcloud = require('../../setup-gcloud/src/setup-gcloud');
 const getRuntimeAccount = require('./runtime-account');
@@ -14,16 +15,20 @@ const numericOrDefault = (value) => (value >= 0 ? value : 'default');
 
 const managedArguments = async (args, service, projectId) => {
   const {
+    cpu,
     platform: {
       managed: {
         'allow-unauthenticated': allowUnauthenticated,
         'cloudsql-instances': cloudSqlInstances = undefined,
         region,
-        cpu = 1,
         'runtime-account': runtimeAccountEmail = 'cloudrun-runtime',
       },
     },
   } = service;
+
+  if (typeof cpu === 'string' && cpu.endsWith('m')) {
+    throw new Error('Managed Cloud Run must be configured with CPU count [1,2]. Use of millicpu is not supported.');
+  }
 
   const runtimeAccount = await getRuntimeAccount(runtimeAccountEmail, projectId);
   args.push(`--service-account=${runtimeAccount}`);
@@ -52,17 +57,21 @@ const managedArguments = async (args, service, projectId) => {
 const gkeArguments = async (args, service, projectId, regoFile) => {
   const {
     name,
+    cpu,
     'min-instances': minInstances = -1,
     platform: {
       gke: {
         cluster: configuredCluster = undefined,
-        cpu = '1',
         connectivity,
         namespace = name,
         'opa-enabled': opaEnabled = true,
       },
     },
   } = service;
+
+  if (typeof cpu === 'number') {
+    throw new Error('Cloud Run GKE must be configured with millicpu. Use of CPU count is not supported.');
+  }
 
   const cluster = await getClusterInfo(projectId, configuredCluster);
 

--- a/cloud-run/test/service-definition.test.js
+++ b/cloud-run/test/service-definition.test.js
@@ -81,6 +81,7 @@ platform:
   gke:
     cluster: test
     connectivity: external
+    cpu: 300m
 `,
       });
       expect(() => loadServiceDefinition('cloud-run.yaml'))

--- a/cloud-run/test/service-definition.test.js
+++ b/cloud-run/test/service-definition.test.js
@@ -17,6 +17,7 @@ describe('Service Definition', () => {
       mockFs({
         'cloud-run.yaml': `
 memory: 256Mi
+cpu: 1
 `,
       });
       expect(() => loadServiceDefinition('cloud-run.yaml'))
@@ -29,6 +30,7 @@ memory: 256Mi
       mockFs({
         'cloud-run.yaml': `
 name: service
+cpu: 1
 platform:
   managed:
     allow-unauthenticated: true
@@ -40,11 +42,28 @@ platform:
 0: instance requires property "memory"`);
     });
 
+    test('It throws for invalid memory', () => {
+      mockFs({
+        'cloud-run.yaml': `
+name: service
+memory: 256m
+cpu: 1
+platform:
+  managed:
+    allow-unauthenticated: true
+    region: eu-west1
+`,
+      });
+      expect(() => loadServiceDefinition('cloud-run.yaml'))
+        .toThrow(`cloud-run.yaml is not valid.
+0: instance.memory does not match pattern "^[0-9]+(M|G)i"`);
+    });
+
     test('It throws for missing allow-unauthenticated', () => {
       mockFs({
         'cloud-run.yaml': `
 name: service
-memory: 256Mi
+memory: 1Gi
 platform:
   managed:
     region: eu-west1
@@ -61,6 +80,7 @@ platform:
         'cloud-run.yaml': `
 name: test-service
 memory: 256Mi
+cpu: 100m
 `,
       });
       expect(() => loadServiceDefinition('cloud-run.yaml'))
@@ -69,7 +89,7 @@ memory: 256Mi
 `);
     });
 
-    test('It throws for both platform', () => {
+    test('It throws for missing cpu', () => {
       mockFs({
         'cloud-run.yaml': `
 name: test-service
@@ -78,15 +98,66 @@ platform:
   managed:
     region: eu-west1
     allow-unauthenticated: true
-  gke:
-    cluster: test
-    connectivity: external
-    cpu: 300m
 `,
       });
       expect(() => loadServiceDefinition('cloud-run.yaml'))
         .toThrow(`cloud-run.yaml is not valid.
-0: instance.platform is not exactly one from [subschema 0],[subschema 1]`);
+0: instance requires property "cpu"
+`);
+    });
+
+    test('It throws for both platform', () => {
+      mockFs({
+        'cloud-run.yaml': `
+name: test-service
+memory: 64Mi
+cpu: 300m
+platform:
+  managed:
+    region: eu-west1
+    allow-unauthenticated: true
+  gke:
+    cluster: test
+    connectivity: external
+`,
+      });
+      expect(() => loadServiceDefinition('cloud-run.yaml'))
+        .toThrow(`cloud-run.yaml is not valid.
+0: instance.platform is not exactly one from "managed","gke"`);
+    });
+
+    test('It throws for invalid core count', () => {
+      mockFs({
+        'cloud-run.yaml': `
+name: test-service
+memory: 256Mi
+cpu: 3
+platform:
+  managed:
+    region: eu-west1
+    allow-unauthenticated: true
+`,
+      });
+      expect(() => loadServiceDefinition('cloud-run.yaml'))
+        .toThrow(`cloud-run.yaml is not valid.
+0: instance.cpu is not exactly one from "millicpu","CPU cores"`);
+    });
+
+    test('It throws for invalid millicpu', () => {
+      mockFs({
+        'cloud-run.yaml': `
+name: test-service
+memory: 256Mi
+cpu: 10000m
+platform:
+  managed:
+    region: eu-west1
+    allow-unauthenticated: true
+`,
+      });
+      expect(() => loadServiceDefinition('cloud-run.yaml'))
+        .toThrow(`cloud-run.yaml is not valid.
+0: instance.cpu is not exactly one from "millicpu","CPU cores"`);
     });
   });
 
@@ -96,6 +167,7 @@ platform:
       'cloud-run.yaml': `
 name: service
 memory: 256Mi
+cpu: 1
 
 environment:
   NAME: value
@@ -120,6 +192,7 @@ platform:
       'cloud-run.yaml': `
 name: test-service
 memory: 256Mi
+cpu: 1
 platform:
   managed:
     allow-unauthenticated: true
@@ -139,6 +212,7 @@ platform:
 name: test-service
 memory: 256Mi
 concurrency: 20
+cpu: 2
 max-instances: 3
 environment:
   FOO: bar
@@ -146,7 +220,6 @@ platform:
   managed:
     region: eu-west1
     allow-unauthenticated: true
-    cpu: 2
     cloudsql-instances:
       - Postgres-RANDOM123
 `,
@@ -156,6 +229,7 @@ platform:
       name: 'test-service',
       memory: '256Mi',
       concurrency: 20,
+      cpu: 2,
       'max-instances': 3,
       environment: {
         FOO: 'bar',
@@ -163,7 +237,6 @@ platform:
       platform: {
         managed: {
           region: 'eu-west1',
-          cpu: 2,
           'cloudsql-instances': [
             'Postgres-RANDOM123',
           ],
@@ -177,6 +250,7 @@ platform:
       'cloud-run.yaml': `
 name: test-service
 memory: 256Mi
+cpu: 400m
 concurrency: 80
 max-instances: 20
 min-instances: 1
@@ -184,7 +258,6 @@ platform:
   gke:
     cluster: test
     connectivity: internal
-    cpu: 400m
     domain-mappings:
       staging:
         - test-service.domain.dev
@@ -197,6 +270,7 @@ platform:
     expect(service).toMatchObject({
       name: 'test-service',
       memory: '256Mi',
+      cpu: '400m',
       concurrency: 80,
       'max-instances': 20,
       'min-instances': 1,
@@ -204,7 +278,6 @@ platform:
         gke: {
           cluster: 'test',
           connectivity: 'internal',
-          cpu: '400m',
           'opa-enabled': true,
           'domain-mappings': {
             staging: ['test-service.domain.dev'],


### PR DESCRIPTION
This is a breaking change for existing cloud-run configs. The motivation for the change is that we want teams to be aware of what memory and CPU they consume at all times.