### PR TITLE
feat: Add footer in terraform-plan-comment

### DIFF
--- a/terraform-plan-comment/action.yml
+++ b/terraform-plan-comment/action.yml
@@ -24,6 +24,9 @@ inputs:
   working-directory:
     description: The working directory. Defaults to the current working directory.
     required: false
+  footer:
+    description: Custom footer message to add after plan outputs. Can contain Markdown.
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/terraform-plan-comment/src/index.js
+++ b/terraform-plan-comment/src/index.js
@@ -4,40 +4,61 @@ const { run } = require('../../utils');
 const { getPullRequestInfo } = require('../../utils/src/pull-request-info');
 const generateOutputs = require('./generate-outputs');
 
-const outputToMarkdown = ({ module, output }) => [
-  `:arrow_forward: **${module}**`,
-  '```hcl',
-  output,
-  '```',
-].join('\n');
+const moduleEmoji = (summary) => {
+  if (!summary.includes('0 to destroy')) {
+    return ':closed_book:';
+  }
+  if (!summary.includes('0 to change')) {
+    return ':orange_book:';
+  }
+  return ':green_book:';
+};
 
-const createComment = (changes, workingDirectory) => {
+const outputToMarkdown = ({ module, output }) => {
+  const summary = output.trim().split('\n').pop();
+  const emoji = moduleEmoji(summary);
+  return [
+    `#### ${emoji} \`${module}\``,
+    '',
+    '<details>',
+    `<summary>${summary}</summary>`,
+    '',
+    '```hcl',
+    output,
+    '```',
+    '',
+    '</details>',
+    '',
+  ].join('\n');
+};
+
+const createComment = (changes, workingDirectory, footer) => {
   const comment = [];
-
-
   if (changes.length === 0) {
     comment.push(
-      '**:white_check_mark: No changes**',
+      '### :white_check_mark: Terraform plan with no changes',
       '',
       'Terraform plan reported no changes.',
+      '',
     );
   } else {
     comment.push(
-      '**:earth_americas: Terraform plan changes**',
+      '### :mag: Terraform plan changes',
       '',
       'The output only includes modules with changes.',
       '',
-      '<details>',
-      `<summary>Show output from ${changes.length} ${changes.length > 1 ? 'modules' : 'module'}</summary>`,
-      '',
       ...changes,
+    );
+  }
+
+  if (footer) {
+    comment.push(
+      footer,
       '',
-      '</details>',
     );
   }
 
   comment.push(
-    '',
     `*Workflow: \`${process.env.GITHUB_WORKFLOW}\`*`,
     `*Working directory: \`${workingDirectory}\`*`,
   );
@@ -51,6 +72,7 @@ const action = async () => {
   const githubToken = core.getInput('github-token') || process.env.GITHUB_TOKEN;
   const repository = core.getInput('repository') || process.env.GITHUB_REPOSITORY;
   const pullRequestNumber = core.getInput('pull-request-number');
+  const footer = core.getInput('footer');
 
   if (repository !== process.env.GITHUB_REPOSITORY && !pullRequestNumber) {
     throw new Error('pull-request-number must be provided for remote repository.');
@@ -71,7 +93,7 @@ const action = async () => {
 
   const comment = await generateOutputs(workingDirectory, planFile)
     .then((outputs) => outputs.map(outputToMarkdown))
-    .then((outputs) => createComment(outputs, workingDirectory));
+    .then((outputs) => createComment(outputs, workingDirectory, footer));
 
   const client = new GitHub(githubToken);
   const [owner, repo] = repository.split('/');


### PR DESCRIPTION
This PR also reformats the output to collapse each module output individually.