### PR TITLE
feat: Add ignored resources parameter to terraform-plan-comment

### DIFF
--- a/terraform-plan-comment/action.yml
+++ b/terraform-plan-comment/action.yml
@@ -27,6 +27,9 @@ inputs:
   footer:
     description: Custom footer message to add after plan outputs. Can contain Markdown.
     required: false
+  ignored-resources-regexp:
+    description: Pattern of resource names for ignore in pull request comment if only those resources are planned to change.
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/terraform-plan-comment/src/index.js
+++ b/terraform-plan-comment/src/index.js
@@ -74,6 +74,7 @@ const action = async () => {
   const repository = core.getInput('repository') || process.env.GITHUB_REPOSITORY;
   const pullRequestNumber = core.getInput('pull-request-number');
   const footer = core.getInput('footer');
+  const ignoredResourcesRegexp = core.getInput('ignored-resources-regexp');
 
   if (repository !== process.env.GITHUB_REPOSITORY && !pullRequestNumber) {
     throw new Error('pull-request-number must be provided for remote repository.');
@@ -92,7 +93,7 @@ const action = async () => {
     }
   }
 
-  const comment = await generateOutputs(workingDirectory, planFile)
+  const comment = await generateOutputs(workingDirectory, planFile, ignoredResourcesRegexp)
     .then((outputs) => outputs.map(outputToMarkdown))
     .then((outputs) => createComment(outputs, workingDirectory, footer));
 


### PR DESCRIPTION
This PR provides an additional parameter to specify the name of resource or regexp pattern for multiple ones to ignore in generated pull request comment.
The output doesn't omit if other resources also changed in the plan.

Adding next parameter
```
ignored-resources-regexp: 'module.project_factory.module.project-factory.module.gcloud_deprivilege.null_resource.run_command\[0\]'
```
to `tf-infra-gcp` repo organization pipeline will prevent of generating an annoying list of changes