### PR TITLE
fix: Limit terraform show concurency run

### DIFF
--- a/terraform-plan-comment/action.yml
+++ b/terraform-plan-comment/action.yml
@@ -27,6 +27,10 @@ inputs:
   footer:
     description: Custom footer message to add after plan outputs. Can contain Markdown.
     required: false
+  max-terraform-processes:
+    description: Maximum number of terraform processes running at the same time
+    required: false
+    default: 10
   ignored-resources-regexp:
     description: Pattern of resource names for ignore in pull request comment if only those resources are planned to change.
     required: false

--- a/terraform-plan-comment/package-lock.json
+++ b/terraform-plan-comment/package-lock.json
@@ -439,6 +439,19 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
+    "p-limit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
+      "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",

--- a/terraform-plan-comment/package.json
+++ b/terraform-plan-comment/package.json
@@ -8,7 +8,8 @@
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.4",
     "@actions/github": "^2.1.1",
-    "fast-glob": "^3.2.2"
+    "fast-glob": "^3.2.2",
+    "p-limit": "^3.0.1"
   },
   "devDependencies": {
     "mock-fs": "^4.12.0"

--- a/terraform-plan-comment/src/index.js
+++ b/terraform-plan-comment/src/index.js
@@ -74,6 +74,7 @@ const action = async () => {
   const repository = core.getInput('repository') || process.env.GITHUB_REPOSITORY;
   const pullRequestNumber = core.getInput('pull-request-number');
   const footer = core.getInput('footer');
+  const maxThreads = core.getInput('max-terraform-processes');
   const ignoredResourcesRegexp = core.getInput('ignored-resources-regexp');
 
   if (repository !== process.env.GITHUB_REPOSITORY && !pullRequestNumber) {
@@ -93,8 +94,9 @@ const action = async () => {
     }
   }
 
-  const comment = await generateOutputs(workingDirectory, planFile, ignoredResourcesRegexp)
-    .then((outputs) => outputs.map(outputToMarkdown))
+  const comment = await generateOutputs(
+    workingDirectory, planFile, maxThreads, ignoredResourcesRegexp,
+  ).then((outputs) => outputs.map(outputToMarkdown))
     .then((outputs) => createComment(outputs, workingDirectory, footer));
 
   const client = new GitHub(githubToken);

--- a/terraform-plan-comment/test/generate-outputs.test.js
+++ b/terraform-plan-comment/test/generate-outputs.test.js
@@ -108,7 +108,7 @@ describe('Generate Terraform plan output', () => {
       + 'Module B Plan: 1 to add, 0 to change, 1 to destroy.\n',
       opts,
     ));
-    const outputs = await generateOutputs('/work', 'plan.out', 'module.module_b.resource.ignored_resource_b');
+    const outputs = await generateOutputs('/work', 'plan.out', 1, 'module.module_b.resource.ignored_resource_b');
     expect(exec.exec).toHaveBeenCalledTimes(2);
     expect(outputs).toHaveLength(1);
     expect(outputs).toEqual([


### PR DESCRIPTION
Without limits, the action runs `terraform show` for every found plan file in parallel. All terraform instances query GCP API, and requests are throttled resulting the lots of errors.
This PR adds the parameter to specify the maximum number of running terraform processes in parallel.