### PR TITLE
fix: Add --no-use-http2 argument to gcloud if disable-http2 option set

### DIFF
--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -5525,7 +5525,9 @@ const runDeploy = async (
     `--labels=service_project_id=${projectId},service_project=${project},service_env=${env}`,
   ];
 
-  if (!disableHttp2) {
+  if (disableHttp2) {
+    args.push('--no-use-http2');
+  } else {
     args.push('--use-http2');
   }
 

--- a/cloud-run/src/run-deploy.js
+++ b/cloud-run/src/run-deploy.js
@@ -147,7 +147,9 @@ const runDeploy = async (
     `--labels=service_project_id=${projectId},service_project=${project},service_env=${env}`,
   ];
 
-  if (!disableHttp2) {
+  if (disableHttp2) {
+    args.push('--no-use-http2');
+  } else {
     args.push('--use-http2');
   }
 

--- a/cloud-run/test/run-deploy.test.js
+++ b/cloud-run/test/run-deploy.test.js
@@ -105,6 +105,31 @@ describe('Run Deploy', () => {
     ]);
   });
 
+  test('It can deploy with disabled http/2', async () => {
+    exec.exec.mockResolvedValueOnce(0);
+    setupGcloud.mockResolvedValueOnce('test-project');
+    const service = {
+      name: 'my-service',
+      memory: '256Mi',
+      cpu: 1,
+      platform: {
+        managed: {
+          region: 'eu-west1',
+          'allow-unauthenticated': false,
+        },
+      },
+    };
+    const returnValue = await runDeploy(
+      serviceAccountKey,
+      service,
+      'gcr.io/test-project/my-service:tag',
+      true,
+      false,
+    );
+    expect(returnValue.gcloudExitCode).toEqual(0);
+    expect(exec.exec.mock.calls[0][1]).toEqual(expect.arrayContaining(['--no-use-http2']));
+  });
+
   test('It can deploy with verbose logging', async () => {
     exec.exec.mockResolvedValueOnce(0);
     setupGcloud.mockResolvedValueOnce('test-project');
@@ -123,7 +148,7 @@ describe('Run Deploy', () => {
       serviceAccountKey,
       service,
       'gcr.io/test-project/my-service:tag',
-      'policy.rego',
+      false,
       true,
     );
     expect(returnValue.gcloudExitCode).toEqual(0);


### PR DESCRIPTION
This PR fixes issue that cloud run deploy is kinda stateful, i.e. if once deployed with --use-http2 removing this flag in following deploys actually doesn't disable http/2 