### PR TITLE
fix: Disable HTTP/2 by default. Add flag to enable it

### DIFF
--- a/cloud-run/action.yml
+++ b/cloud-run/action.yml
@@ -26,11 +26,16 @@ inputs:
       If set to 'none', DNS records will not be updated.
     required: false
     default: dns
-  disable-http2:
+  enable-http2:
     description: |
-      Flag to disable HTTP/2 for legacy applications
+      Flag to enable HTTP/2. Application must support h2c to work correctly with HTTP/2
     required: false
     default: 'false'
+  disable-http2:
+    description: |
+      Flag for disabling HTTP/2. Deprecated, use enable-http2 flag instead
+    required: false
+    default: 'true'
   verbose:
     description: |
       Flag to enable verbose debug logging on gcloud.

--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -2924,11 +2924,11 @@ const action = async () => {
   const image = core.getInput('image', { required: true });
   const domainBindingsEnv = core.getInput('domain-mappings-env') || '';
   const dnsProjectLabel = core.getInput('dns-project-label') || 'dns';
-  const disableHttp2 = (core.getInput('disable-http2') || 'false');
+  const enableHttp2 = (core.getInput('enable-http2') || 'false');
   const verbose = (core.getInput('verbose') || 'false');
 
   const service = loadServiceDefinition(serviceFile);
-  await runDeploy(serviceAccountKey, service, image, disableHttp2 === 'true', verbose === 'true')
+  await runDeploy(serviceAccountKey, service, image, enableHttp2 === 'true', verbose === 'true')
     .then(({ cluster }) => configureDomains(service, cluster, domainBindingsEnv, dnsProjectLabel));
 };
 
@@ -5498,7 +5498,7 @@ const gkeArguments = async (args, service, projectId) => {
 };
 
 const runDeploy = async (
-  serviceAccountKey, service, image, disableHttp2 = false, verbose = false) => {
+  serviceAccountKey, service, image, enableHttp2 = false, verbose = false) => {
   // Authenticate gcloud with our service-account
   const projectId = await gcloudAuth(serviceAccountKey);
 
@@ -5525,10 +5525,10 @@ const runDeploy = async (
     `--labels=service_project_id=${projectId},service_project=${project},service_env=${env}`,
   ];
 
-  if (disableHttp2) {
-    args.push('--no-use-http2');
-  } else {
+  if (enableHttp2) {
     args.push('--use-http2');
+  } else {
+    args.push('--no-use-http2');
   }
 
   if (verbose) {

--- a/cloud-run/src/index.js
+++ b/cloud-run/src/index.js
@@ -10,11 +10,11 @@ const action = async () => {
   const image = core.getInput('image', { required: true });
   const domainBindingsEnv = core.getInput('domain-mappings-env') || '';
   const dnsProjectLabel = core.getInput('dns-project-label') || 'dns';
-  const disableHttp2 = (core.getInput('disable-http2') || 'false');
+  const enableHttp2 = (core.getInput('enable-http2') || 'false');
   const verbose = (core.getInput('verbose') || 'false');
 
   const service = loadServiceDefinition(serviceFile);
-  await runDeploy(serviceAccountKey, service, image, disableHttp2 === 'true', verbose === 'true')
+  await runDeploy(serviceAccountKey, service, image, enableHttp2 === 'true', verbose === 'true')
     .then(({ cluster }) => configureDomains(service, cluster, domainBindingsEnv, dnsProjectLabel));
 };
 

--- a/cloud-run/src/run-deploy.js
+++ b/cloud-run/src/run-deploy.js
@@ -120,7 +120,7 @@ const gkeArguments = async (args, service, projectId) => {
 };
 
 const runDeploy = async (
-  serviceAccountKey, service, image, disableHttp2 = false, verbose = false) => {
+  serviceAccountKey, service, image, enableHttp2 = false, verbose = false) => {
   // Authenticate gcloud with our service-account
   const projectId = await gcloudAuth(serviceAccountKey);
 
@@ -147,10 +147,10 @@ const runDeploy = async (
     `--labels=service_project_id=${projectId},service_project=${project},service_env=${env}`,
   ];
 
-  if (disableHttp2) {
-    args.push('--no-use-http2');
-  } else {
+  if (enableHttp2) {
     args.push('--use-http2');
+  } else {
+    args.push('--no-use-http2');
   }
 
   if (verbose) {

--- a/cloud-run/test/index.test.js
+++ b/cloud-run/test/index.test.js
@@ -56,7 +56,7 @@ describe('Cloud Run Action', () => {
     );
   });
 
-  test('It can run with disable-http2 flag set', async () => {
+  test('It can run with enable-http2 flag set', async () => {
     serviceDef.mockReturnValueOnce({});
     core.getInput.mockReturnValueOnce('service-account')
       .mockReturnValueOnce('')

--- a/cloud-run/test/run-deploy.test.js
+++ b/cloud-run/test/run-deploy.test.js
@@ -56,7 +56,7 @@ describe('Run Deploy', () => {
       '--max-instances=default',
       '--set-env-vars=SERVICE_PROJECT_ID=test-project',
       '--labels=service_project_id=test-project,service_project=test-project,service_env=undefined',
-      '--use-http2',
+      '--no-use-http2',
       '--service-account=cloudrun-runtime@test-project.iam.gserviceaccount.com',
       '--cpu=1',
       '--platform=managed',
@@ -96,7 +96,7 @@ describe('Run Deploy', () => {
       '--max-instances=default',
       '--set-env-vars=SERVICE_PROJECT_ID=test-project-staging-ab12',
       '--labels=service_project_id=test-project-staging-ab12,service_project=test-project,service_env=staging',
-      '--use-http2',
+      '--no-use-http2',
       '--service-account=cloudrun-runtime@test-project-staging-ab12.iam.gserviceaccount.com',
       '--cpu=1',
       '--platform=managed',
@@ -105,7 +105,7 @@ describe('Run Deploy', () => {
     ]);
   });
 
-  test('It can deploy with disabled http/2', async () => {
+  test('It can deploy with enabled http/2', async () => {
     exec.exec.mockResolvedValueOnce(0);
     setupGcloud.mockResolvedValueOnce('test-project');
     const service = {
@@ -127,7 +127,7 @@ describe('Run Deploy', () => {
       false,
     );
     expect(returnValue.gcloudExitCode).toEqual(0);
-    expect(exec.exec.mock.calls[0][1]).toEqual(expect.arrayContaining(['--no-use-http2']));
+    expect(exec.exec.mock.calls[0][1]).toEqual(expect.arrayContaining(['--use-http2']));
   });
 
   test('It can deploy with verbose logging', async () => {
@@ -189,7 +189,7 @@ describe('Run Deploy', () => {
       '--max-instances=default',
       '--set-env-vars=KEY1=value,KEY2=sm://test-project/my-secret,SERVICE_PROJECT_ID=test-project',
       '--labels=service_project_id=test-project,service_project=test-project,service_env=undefined',
-      '--use-http2',
+      '--no-use-http2',
       '--service-account=cloudrun-runtime@test-project.iam.gserviceaccount.com',
       '--cpu=1',
       '--platform=managed',
@@ -311,7 +311,7 @@ describe('Run Deploy', () => {
       '--max-instances=default',
       '--set-env-vars=SERVICE_PROJECT_ID=test-project',
       '--labels=service_project_id=test-project,service_project=test-project,service_env=undefined',
-      '--use-http2',
+      '--no-use-http2',
       '--cpu=400m',
       '--min-instances=default',
       '--platform=gke',
@@ -359,7 +359,7 @@ describe('Run Deploy', () => {
       '--max-instances=default',
       '--set-env-vars=SERVICE_PROJECT_ID=test-project',
       '--labels=service_project_id=test-project,service_project=test-project,service_env=undefined',
-      '--use-http2',
+      '--no-use-http2',
       '--cpu=100m',
       '--min-instances=default',
       '--platform=gke',
@@ -412,7 +412,7 @@ describe('Run Deploy', () => {
       '--max-instances=100',
       '--set-env-vars=SERVICE_PROJECT_ID=test-project',
       '--labels=service_project_id=test-project,service_project=test-project,service_env=undefined',
-      '--use-http2',
+      '--no-use-http2',
       '--cpu=400m',
       '--min-instances=1',
       '--platform=gke',
@@ -507,7 +507,7 @@ describe('Run Deploy', () => {
       '--max-instances=default',
       '--set-env-vars=SERVICE_PROJECT_ID=test-project',
       '--labels=service_project_id=test-project,service_project=test-project,service_env=undefined',
-      '--use-http2',
+      '--no-use-http2',
       '--cpu=233m',
       '--min-instances=default',
       '--platform=gke',


### PR DESCRIPTION
This PR rollback breaking change that was made by enabling http/2 by default.
New flag `enable-http2` was provided to enable HTTP/2.
Old flag `disable-http2` was kept to not break pipelines, that already implemented to fix the services