### PR TITLE
feat: Wait for revision if gcloud fails while cluster scales out

### DIFF
--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -20610,6 +20610,7 @@ const parseConditions = (conditions) => {
     revisionStatus[type] = {
       status,
       lastTransitionTime: condition.lastTransitionTime,
+      reason: condition.reason || null,
     };
   });
 
@@ -20646,17 +20647,20 @@ const getRevisionStatus = async (revision, args) => {
 const timer = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const isRevisionCompleted = (revisionStatus) => {
-  const {
-    active,
-    ready,
-    containerHealthy,
-    resourcesAvailable,
-  } = revisionStatus;
+  const keys = ['active', 'ready', 'containerHealthy', 'resourcesAvailable'];
+  const success = keys.map((key) => revisionStatus[key].status)
+    .reduce((prev, status) => prev && status, true);
 
-  return active.status
-    && ready.status
-    && containerHealthy.status
-    && resourcesAvailable.status;
+  if (!success) {
+    // Check if we should fail fast
+    keys.map((key) => ({ key, reason: revisionStatus[key].reason }))
+      .forEach(({ key, reason }) => {
+        if (typeof reason === 'string' && reason.startsWith('ExitCode')) {
+          throw new Error(`Revision failed "${key}" condition with reason: ${reason}`);
+        }
+      });
+  }
+  return success;
 };
 
 const printStatus = (revisionStatus) => {

--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -20676,30 +20676,27 @@ const waitForRevision = async (
   sleepMs = 10000,
   timeoutMs = FIVE_MINUTES,
 ) => {
-  if (status === 0) {
-    return status;
-  }
-
-  if (!args.includes('--platform=gke')) {
-    throw new Error('Wait is not supported for managed cloud run');
-  }
-
-  const revision = findRevision(output);
-
-  let revisionStatus = {};
-
-  /* eslint-disable no-await-in-loop */
-  const t0 = Date.now();
-  do {
-    if (Date.now() - t0 > timeoutMs) {
-      throw new Error(`Timed out after while for revision "${revision}".`);
+  if (status !== 0) {
+    if (!args.includes('--platform=gke')) {
+      throw new Error('Wait is not supported for managed cloud run');
     }
-    await timer(sleepMs);
-    revisionStatus = await getRevisionStatus(revision, args);
-    core.info(`Deploy status is: ${printStatus(revisionStatus)}`);
-  } while (!isRevisionCompleted(revisionStatus));
-  /* eslint-enable no-await-in-loop */
 
+    const revision = findRevision(output);
+
+    let revisionStatus = {};
+
+    /* eslint-disable no-await-in-loop */
+    const t0 = Date.now();
+    do {
+      if (Date.now() - t0 > timeoutMs) {
+        throw new Error(`Timed out after while for revision "${revision}".`);
+      }
+      await timer(sleepMs);
+      revisionStatus = await getRevisionStatus(revision, args);
+      core.info(`Deploy status is: ${printStatus(revisionStatus)}`);
+    } while (!isRevisionCompleted(revisionStatus));
+    /* eslint-enable no-await-in-loop */
+  }
   return 0;
 };
 

--- a/cloud-run/src/run-deploy.js
+++ b/cloud-run/src/run-deploy.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core');
 const exec = require('@actions/exec');
 const setupGcloud = require('../../setup-gcloud/src/setup-gcloud');
 const getRuntimeAccount = require('./runtime-account');
@@ -5,6 +6,7 @@ const createEnvironmentArgs = require('./environment-args');
 const getClusterInfo = require('./cluster-info');
 const createNamespace = require('./create-namespace');
 const projectInfo = require('./project-info');
+const waitForRevision = require('./wait-revision');
 
 const gcloudAuth = async (serviceAccountKey) => setupGcloud(
   serviceAccountKey,
@@ -126,7 +128,36 @@ const gkeArguments = async (args, service, projectId) => {
   return cluster;
 };
 
-const runDeploy = async (serviceAccountKey, service, image, verbose = false) => {
+const execWithOutput = async (args) => {
+  let stdout = '';
+  let stderr = '';
+  const status = await exec.exec('gcloud', args, {
+    listeners: {
+      stdout: (data) => {
+        stdout += data.toString('utf8');
+      },
+      stderr: (data) => {
+        stderr += data.toString('utf8');
+      },
+    },
+  }).catch((err) => {
+    core.error(`gcloud execution failed: ${err.message}`);
+    stdout += stderr;
+  });
+
+  return {
+    status,
+    output: stdout ? stdout.trim() : '',
+  };
+};
+
+const runDeploy = async (
+  serviceAccountKey,
+  service,
+  image,
+  verbose = false,
+  retryInterval = 5000,
+) => {
   // Authenticate gcloud with our service-account
   const projectId = await gcloudAuth(serviceAccountKey);
 
@@ -167,7 +198,9 @@ const runDeploy = async (serviceAccountKey, service, image, verbose = false) => 
     cluster = await gkeArguments(args, service, projectId);
   }
 
-  const gcloudExitCode = await exec.exec('gcloud', args);
+  const gcloudExitCode = await execWithOutput(args)
+    .then((response) => waitForRevision(response, args, retryInterval));
+
 
   return {
     gcloudExitCode,

--- a/cloud-run/src/wait-revision.js
+++ b/cloud-run/src/wait-revision.js
@@ -1,0 +1,118 @@
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+const FIVE_MINUTES = 300000;
+
+const findRevision = (output) => {
+  const matches = output.match(/ERROR: \(gcloud\.run\.deploy\) Revision "([^"]+)" failed with message: 0\/\d+ nodes/);
+  if (matches && matches.length >= 2) {
+    return matches[1];
+  }
+  throw new Error('Deploy failed for other reasons than node scaling out');
+};
+
+const parseConditions = (conditions) => {
+  // Default status flags.
+  const revisionStatus = {
+    active: { status: false },
+    ready: { status: false },
+    containerHealthy: { status: false },
+    resourcesAvailable: { status: false },
+  };
+
+  conditions.forEach((condition) => {
+    const type = condition.type.charAt(0).toLowerCase() + condition.type.slice(1);
+    const status = condition.status === 'True';
+    revisionStatus[type] = {
+      status,
+      lastTransitionTime: condition.lastTransitionTime,
+    };
+  });
+
+  return revisionStatus;
+};
+
+const getRevisionStatus = async (revision, args) => {
+  const findArg = (match) => args.find((a) => a.startsWith(match));
+  let stdout = '';
+  await exec.exec('gcloud', [
+    'run', 'revisions', 'describe', revision,
+    findArg('--project='),
+    findArg('--cluster='),
+    findArg('--cluster-location='),
+    findArg('--namespace='),
+    '--format=json',
+  ], {
+    listeners: {
+      stdout: (data) => {
+        stdout += data.toString('utf8');
+      },
+    },
+  });
+
+  try {
+    const { status: { conditions } } = JSON.parse(stdout.trim());
+    core.debug(JSON.stringify(conditions, null, 2));
+    return parseConditions(conditions);
+  } catch (err) {
+    throw new Error(`Invalid JSON: Failed to load status for revision "${revision}". Reason: ${err.message}`);
+  }
+};
+
+const timer = (ms) => new Promise((res) => setTimeout(res, ms));
+
+const isRevisionCompleted = (revisionStatus) => {
+  const {
+    active,
+    ready,
+    containerHealthy,
+    resourcesAvailable,
+  } = revisionStatus;
+
+  return active.status
+    && ready.status
+    && containerHealthy.status
+    && resourcesAvailable.status;
+};
+
+const printStatus = (revisionStatus) => {
+  const completed = isRevisionCompleted(revisionStatus);
+  const values = Object.keys(revisionStatus)
+    .map((k) => `${k}=${revisionStatus[k].status}`).join(', ');
+  return `${completed} (${values})`;
+};
+
+const waitForRevision = async (
+  { status, output },
+  args,
+  sleepMs = 10000,
+  timeoutMs = FIVE_MINUTES,
+) => {
+  if (status === 0) {
+    return status;
+  }
+
+  if (!args.includes('--platform=gke')) {
+    throw new Error('Wait is not supported for managed cloud run');
+  }
+
+  const revision = findRevision(output);
+
+  let revisionStatus = {};
+
+  /* eslint-disable no-await-in-loop */
+  const t0 = Date.now();
+  do {
+    if (Date.now() - t0 > timeoutMs) {
+      throw new Error(`Timed out after while for revision "${revision}".`);
+    }
+    await timer(sleepMs);
+    revisionStatus = await getRevisionStatus(revision, args);
+    core.info(`Deploy status is: ${printStatus(revisionStatus)}`);
+  } while (!isRevisionCompleted(revisionStatus));
+  /* eslint-enable no-await-in-loop */
+
+  return 0;
+};
+
+module.exports = waitForRevision;

--- a/cloud-run/src/wait-revision.js
+++ b/cloud-run/src/wait-revision.js
@@ -92,30 +92,27 @@ const waitForRevision = async (
   sleepMs = 10000,
   timeoutMs = FIVE_MINUTES,
 ) => {
-  if (status === 0) {
-    return status;
-  }
-
-  if (!args.includes('--platform=gke')) {
-    throw new Error('Wait is not supported for managed cloud run');
-  }
-
-  const revision = findRevision(output);
-
-  let revisionStatus = {};
-
-  /* eslint-disable no-await-in-loop */
-  const t0 = Date.now();
-  do {
-    if (Date.now() - t0 > timeoutMs) {
-      throw new Error(`Timed out after while for revision "${revision}".`);
+  if (status !== 0) {
+    if (!args.includes('--platform=gke')) {
+      throw new Error('Wait is not supported for managed cloud run');
     }
-    await timer(sleepMs);
-    revisionStatus = await getRevisionStatus(revision, args);
-    core.info(`Deploy status is: ${printStatus(revisionStatus)}`);
-  } while (!isRevisionCompleted(revisionStatus));
-  /* eslint-enable no-await-in-loop */
 
+    const revision = findRevision(output);
+
+    let revisionStatus = {};
+
+    /* eslint-disable no-await-in-loop */
+    const t0 = Date.now();
+    do {
+      if (Date.now() - t0 > timeoutMs) {
+        throw new Error(`Timed out after while for revision "${revision}".`);
+      }
+      await timer(sleepMs);
+      revisionStatus = await getRevisionStatus(revision, args);
+      core.info(`Deploy status is: ${printStatus(revisionStatus)}`);
+    } while (!isRevisionCompleted(revisionStatus));
+    /* eslint-enable no-await-in-loop */
+  }
   return 0;
 };
 

--- a/cloud-run/test/wait-revision.test.js
+++ b/cloud-run/test/wait-revision.test.js
@@ -1,0 +1,153 @@
+const exec = require('@actions/exec');
+const core = require('@actions/core');
+const waitForRevision = require('../src/wait-revision');
+
+jest.mock('@actions/exec');
+
+const GCLOUD_ERROR_MSG = `
+Deploying container to Cloud Run for Anthos service [xxxxxxx] in namespace [default] of cluster [k8s-cluster]
+Deploying...
+Creating Revision.................failed
+Deployment failed
+ERROR: (gcloud.run.deploy) Revision "xxxxxxx-00013-loc" failed with message: 0/3 nodes are available: 3 Insufficient cpu..
+`;
+
+const GCLOUD_ARGS = [
+  '--platform=gke',
+  '--cluster=k8s-cluster',
+  '--project=test',
+  '--cluster-location=europe-west1',
+  '--namespace=test',
+];
+
+let debugSpy;
+
+describe('Wait for revision', () => {
+  beforeEach(() => {
+    // Reduce noise in the tests.
+    debugSpy = jest.spyOn(core, 'debug').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    debugSpy.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  test('Wait for revision success', async () => {
+    const revisionStatus = {
+      status: {
+        conditions: [
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            severity: 'Info',
+            status: 'True',
+            type: 'Active',
+          },
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            status: 'True',
+            type: 'ContainerHealthy',
+          },
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            status: 'True',
+            type: 'Ready',
+          },
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            status: 'True',
+            type: 'ResourcesAvailable',
+          },
+        ],
+      },
+    };
+    exec.exec.mockImplementationOnce((cmd, args, opts) => {
+      opts.listeners.stdout(Buffer.from(JSON.stringify(revisionStatus), 'utf8'));
+      return Promise.resolve(0);
+    });
+    const response = await waitForRevision(
+      { status: 1, output: GCLOUD_ERROR_MSG },
+      GCLOUD_ARGS,
+      10,
+    );
+    expect(response).toEqual(0);
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('It returns immediately for successful deploy', async () => {
+    const response = await waitForRevision({ status: 0, output: '' }, GCLOUD_ARGS);
+    expect(response).toEqual(0);
+    expect(exec.exec).not.toHaveBeenCalled();
+  });
+
+  test('It does not wait for managed cloud run', async () => {
+    await expect(waitForRevision(
+      { status: 1, output: GCLOUD_ERROR_MSG },
+      ['--platform=managed'],
+      10,
+    )).rejects.toEqual(new Error('Wait is not supported for managed cloud run'));
+    expect(exec.exec).not.toHaveBeenCalled();
+  });
+
+  test('It fails on unrecognized deployment error (no wait)', async () => {
+    await expect(waitForRevision(
+      { status: 1, output: 'ERROR: Unexpected error for revision: "abc-123"' },
+      GCLOUD_ARGS,
+      10,
+    )).rejects.toEqual(new Error('Deploy failed for other reasons than node scaling out'));
+    expect(exec.exec).not.toHaveBeenCalled();
+  });
+
+  test('It fails on bad JSON', async () => {
+    exec.exec.mockImplementationOnce((cmd, args, opts) => {
+      opts.listeners.stdout(Buffer.from('ERROR: No JSON', 'utf8'));
+      return Promise.resolve(0);
+    });
+    await expect(waitForRevision(
+      { status: 1, output: GCLOUD_ERROR_MSG },
+      GCLOUD_ARGS,
+      10,
+    )).rejects.toEqual(new Error('Invalid JSON: Failed to load status for revision "xxxxxxx-00013-loc". Reason: Unexpected token E in JSON at position 0'));
+    expect(exec.exec).toHaveBeenCalled();
+  });
+
+  test('It times out after X minutes', async () => {
+    const revisionStatus = {
+      status: {
+        conditions: [
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            severity: 'Info',
+            status: 'False',
+            type: 'Active',
+          },
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            status: 'True',
+            type: 'ContainerHealthy',
+          },
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            status: 'True',
+            type: 'Ready',
+          },
+          {
+            lastTransitionTime: '2020-08-31T09:45:11Z',
+            status: 'True',
+            type: 'ResourcesAvailable',
+          },
+        ],
+      },
+    };
+    exec.exec.mockImplementation((cmd, args, opts) => {
+      opts.listeners.stdout(Buffer.from(JSON.stringify(revisionStatus), 'utf8'));
+      return Promise.resolve(0);
+    });
+    await expect(waitForRevision(
+      { status: 1, output: GCLOUD_ERROR_MSG },
+      GCLOUD_ARGS,
+      10,
+      100,
+    )).rejects.toEqual(new Error('Timed out after while for revision "xxxxxxx-00013-loc".'));
+    expect(exec.exec.mock.calls.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
This PR is an attempt to workaround the following gcloud run deploy issue:

> Deploying container to Cloud Run for Anthos service [xxxxxxx] in namespace [default] of cluster [k8s-cluster]
> Deploying...
> Creating Revision.................failed
> Deployment failed
> ERROR: (gcloud.run.deploy) Revision “xxxxxxx-00013-loc” failed with message: 0/3 nodes are available: 3 Insufficient cpu..

When this happens, the `cloud-run` action will use `gcloud run revisions describe` and poll the revision status until it is successful, explicitly failed or the action times out.