### PR TITLE
fix: Ignore plan.out files in cache directories

### DIFF
--- a/terraform-plan-comment/dist/index.js
+++ b/terraform-plan-comment/dist/index.js
@@ -10990,7 +10990,7 @@ const moduleName = (plan, workingDirectory) => {
 
 const generateOutputs = async (workingDirectory, planFile, maxThreads, ignoredResourcesRegexp) => {
   const source = `${workingDirectory}/**/${planFile}`;
-  const plans = fg.sync(source, { dot: true });
+  const plans = fg.sync(source, { dot: true, ignore: [`**/.terragrunt-cache/**/${planFile}`] });
   core.info(`Found ${plans.length} plan(s) for glob ${source}`);
   const promises = [];
   const limit = pLimit(parseInt(maxThreads, 10) || 1);

--- a/terraform-plan-comment/src/generate-outputs.js
+++ b/terraform-plan-comment/src/generate-outputs.js
@@ -74,7 +74,7 @@ const moduleName = (plan, workingDirectory) => {
 
 const generateOutputs = async (workingDirectory, planFile, maxThreads, ignoredResourcesRegexp) => {
   const source = `${workingDirectory}/**/${planFile}`;
-  const plans = fg.sync(source, { dot: true });
+  const plans = fg.sync(source, { dot: true, ignore: [`**/.terragrunt-cache/**/${planFile}`] });
   core.info(`Found ${plans.length} plan(s) for glob ${source}`);
   const promises = [];
   const limit = pLimit(parseInt(maxThreads, 10) || 1);

--- a/terraform-plan-comment/test/generate-outputs.test.js
+++ b/terraform-plan-comment/test/generate-outputs.test.js
@@ -13,6 +13,7 @@ const terragruntFs = {
       },
     },
     moduleB: {
+      'plan.out': 'moduleB',
       '.terragrunt-cache': {
         UUID1: {
           UUID2: {
@@ -60,7 +61,7 @@ describe('Generate Terraform plan output', () => {
     expect(exec.exec.mock.calls[0][2]).toMatchObject({
       cwd: '/work/moduleA/.terragrunt-cache/UUID1/UUID2',
     });
-    expect(exec.exec.mock.calls[1][1]).toEqual(['show', '-no-color', 'plan.out']);
+    expect(exec.exec.mock.calls[1][1]).toEqual(['show', '-no-color', '../../../plan.out']);
     expect(exec.exec.mock.calls[1][2]).toMatchObject({
       cwd: '/work/moduleB/.terragrunt-cache/UUID1/UUID2',
     });


### PR DESCRIPTION
This PR make ignoring `plan.out` files in `.terragrunt-cache` directories, which are created by Terragrunt recursive call.
It must fix the issue with multiple items in Github report comment