### PR TITLE
feat(ELY-486): Add support for multiple IAM definitions at once

### DIFF
--- a/iam/README.md
+++ b/iam/README.md
@@ -26,7 +26,7 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }} # Used to fetch required credentials from secrets (required)
           service-account-key-staging: ${{ secrets.GCLOUD_AUTH_STAGING }} # Used to configure and create DAS-system on the correct cluster/environment (required)
           service-account-key-prod: ${{ secrets.GCLOUD_AUTH_PROD }} # Used to configure and create DAS-system on the correct cluster/environment (required)
-          iam-definition: iam.yaml # default iam.yaml
+          iam-definition: iam/ # default will match iam/*.yaml
           styra-url: https://extendaretail.styra.com # default extendaretail
 
 ```
@@ -36,7 +36,8 @@ jobs:
 The iam definition should be specified in a YAML file that is later used by this action. This allows us to handle
 permissions and roles for this service.
 
-By default, the action will load `iam.yaml` from the repository base directory.
+By default, the action will load all YAML files matching the `iam/*.yaml` glob pattern. Each found file represents a
+will be processed independent of others.
 
 ### Schema
 
@@ -55,14 +56,16 @@ properties are required and not.
 
 ### YAML Examples
 
-#### create permissions and roles
+#### Create permissions and roles
 
-This example defines a iam yaml that creates roles and permissions
-for the DAS system iam
+This example defines a YAML file that creates roles and permissions for the DAS system `iam`
 ```yaml
-system:
-  id: iam
-  description: Identity and access management api
+permission-prefix: iam
+systems:
+  - namespace: iam-api
+    repository: hiiretail-iam-api
+  - namespace: iam-ui
+    repository: hiiretail-iam-ui
 permissions:
   tenants:
     create: Create tenants
@@ -72,16 +75,16 @@ permissions:
     special: Super user access
 roles:
   - name: admin
-    description: IAM admin
+    desc: IAM admin
     permissions:
-      - 'tenants.create'
-      - 'tenants.get'
-      - 'tenants.update'
-      - 'tenants.delete'
-      - 'tenants.special'
+      - tenants.create
+      - tenants.get
+      - tenants.update
+      - tenants.delete
+      - tenants.special
   - name: readonly
-    description: IAM readonly
+    desc: IAM readonly
     permissions:
-      - 'tenants.get'
+      - tenants.get
 
 ```

--- a/iam/action.yml
+++ b/iam/action.yml
@@ -19,7 +19,12 @@ inputs:
     description: |
       The IAM YAML specification.
     required: false
-    default: iam.yaml
+    default: iam/*.yaml
+  iam-api-url:
+    description: |
+      The Hii Retail IAM API URL.
+    required: false
+    default: https://iam-api.retailsvc.com
   styra-url:
     description: |
       The styra url

--- a/iam/package-lock.json
+++ b/iam/package-lock.json
@@ -30,6 +30,29 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "ajv": {
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
@@ -75,6 +98,14 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "caseless": {
@@ -132,10 +163,39 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -158,6 +218,14 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "har-schema": {
@@ -183,6 +251,24 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -230,6 +316,20 @@
         "verror": "1.10.0"
       }
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
@@ -258,6 +358,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "psl": {
       "version": "1.8.0",
@@ -306,6 +411,16 @@
         "uuid": "^3.3.2"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -330,6 +445,14 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "tough-cookie": {

--- a/iam/package.json
+++ b/iam/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@actions/core": "^1.2.3",
     "@actions/exec": "^1.0.4",
+    "fast-glob": "^3.2.4",
     "jsonschema": "^1.2.5",
     "request": "^2.88.2",
     "yaml": "^1.8.2"

--- a/iam/src/iam-schema.js
+++ b/iam/src/iam-schema.js
@@ -14,9 +14,20 @@ module.exports = {
           type: 'string',
         },
       },
+      required: [
+        'namespace',
+        'repository',
+      ],
+      additionalProperties: false,
     },
     permissions: {
       type: 'object',
+      additionalProperties: {
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+        },
+      },
     },
     roles: {
       type: 'array',
@@ -34,6 +45,12 @@ module.exports = {
           },
         },
       },
+      required: [
+        'name',
+        'desc',
+        'permissions',
+      ],
+      additionalProperties: false,
     },
   },
   required: [

--- a/iam/test/create-system.test.js
+++ b/iam/test/create-system.test.js
@@ -14,6 +14,7 @@ describe('create system in styra-das', () => {
   });
 
   test('it can create system for staging', async () => {
+    mock({});
     exec.exec.mockResolvedValueOnce(0);
     const createSystemResult = {
       result: {
@@ -39,6 +40,7 @@ describe('create system in styra-das', () => {
   });
 
   test('it can create system for prod', async () => {
+    mock({});
     exec.exec.mockResolvedValueOnce(0);
     const createSystemResult = {
       result: {

--- a/iam/test/index.test.js
+++ b/iam/test/index.test.js
@@ -4,16 +4,24 @@ jest.mock('../src/iam-definition');
 jest.mock('../src/iam-auth');
 jest.mock('../src/load-credentials');
 jest.mock('../../setup-gcloud/src/setup-gcloud');
-
+jest.mock('fast-glob');
 
 const core = require('@actions/core');
+const fg = require('fast-glob');
 const action = require('../src/index');
 const configureIam = require('../src/configure-iam');
-const fetchToken = require('../src/iam-auth');
+const fetchIamToken = require('../src/iam-auth');
 const loadIamDefinition = require('../src/iam-definition');
 const setupGcloud = require('../../setup-gcloud/src/setup-gcloud');
 const loadCredentials = require('../src/load-credentials');
 
+const credentials = {
+  styraToken: 'styra-token',
+  iamApiEmail: 'iam-email',
+  iamApiPassword: 'iam-pass',
+  iamApiKey: 'iam-key',
+  iamApiTenant: 'iam-tenant',
+};
 
 describe('run action', () => {
   afterEach(() => {
@@ -21,27 +29,21 @@ describe('run action', () => {
   });
 
   test('It can run the action', async () => {
-    const credentials = {
-      styraToken: 'styra-token',
-      iamApiEmail: 'iam-email',
-      iamApiPassword: 'iam-pass',
-      iamApiKey: 'iam-key',
-      iamApiTenant: 'iam-tenant',
-    };
-
-    setupGcloud.mockResolvedValueOnce('test-staging-332');
-    loadCredentials.mockResolvedValueOnce(credentials);
+    setupGcloud.mockResolvedValue('test-staging-332');
+    loadCredentials.mockResolvedValue(credentials);
     core.getInput.mockReturnValueOnce('service-account')
       .mockReturnValueOnce('service-account-staging')
       .mockReturnValueOnce('service-account-prod')
       .mockReturnValueOnce('iam.yaml')
+      .mockReturnValueOnce('')
       .mockReturnValueOnce('https://extendaretail.styra.com');
     loadIamDefinition.mockReturnValueOnce({});
-    fetchToken.mockResolvedValueOnce('iam-token');
+    fg.sync.mockReturnValueOnce(['iam.yaml']);
+    fetchIamToken.mockResolvedValue('iam-token');
     await action();
 
     expect(core.getInput).toHaveBeenCalledTimes(6);
-    expect(fetchToken).toHaveBeenCalledWith(
+    expect(fetchIamToken).toHaveBeenCalledWith(
       'iam-key',
       'iam-email',
       'iam-pass',
@@ -51,9 +53,26 @@ describe('run action', () => {
       {},
       'styra-token',
       'https://extendaretail.styra.com',
-      'https://iam-api.retailsvc.dev',
+      'https://iam-api.retailsvc.com',
       'iam-token',
       'staging',
       'test-staging-332');
+  });
+
+  test('It can run for multiple files', async () => {
+    setupGcloud.mockResolvedValue('test-prod-332');
+    loadCredentials.mockResolvedValue(credentials);
+    core.getInput.mockReturnValueOnce('service-account')
+      .mockReturnValueOnce('service-account-staging')
+      .mockReturnValueOnce('service-account-prod')
+      .mockReturnValueOnce('iam/*.yaml')
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('https://extendaretail.styra.com');
+    loadIamDefinition.mockReturnValue({});
+    fg.sync.mockReturnValueOnce(['iam/iam.yaml', 'iam/two.yaml']);
+    fetchIamToken.mockResolvedValue('iam-token');
+    await action();
+
+    expect(loadIamDefinition).toHaveBeenCalledTimes(2);
   });
 });

--- a/iam/test/load-credentials.test.js
+++ b/iam/test/load-credentials.test.js
@@ -4,8 +4,11 @@ jest.mock('../../gcp-secret-manager/src/secrets');
 
 const loadCredentials = require('../src/load-credentials');
 
+const orgEnv = process.env;
+
 describe('iam Credentials', () => {
   beforeEach(() => {
+    process.env = { ...orgEnv };
     delete process.env.API_EMAIL;
     delete process.env.API_PASSWORD;
     delete process.env.API_KEY;
@@ -15,6 +18,7 @@ describe('iam Credentials', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    process.env = orgEnv;
   });
 
   test('It uses existing env vars', async () => {

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -53,7 +53,7 @@
       "integrity": "sha512-IJczPaZr02ECa3Lgws/TJEVco9tjOujiQSZbO3dHuXXjhd5vrUtfOgGwhmz3/f97L910OraPZ8SknofUk6RvOQ==",
       "requires": {
         "@actions/core": "^1.1.0",
-        "@actions/exec": "^1.0.4",
+        "@actions/exec": "^1.0.1",
         "@actions/io": "^1.0.1",
         "semver": "^6.1.0",
         "typed-rest-client": "^1.4.0",


### PR DESCRIPTION
Changes:
* Add support for multiple IAM definitions by allow a glob expression to be used as input
* Change how the action handles environments to ensure we ALWAYS publish to Hii Retail IAM production systems with a single exception: If we're deploying to staging AND we explicitly specify the staging URL, then we send permissions to the Hii Retail IAM staging system
* Minor tweaks to JSON Schema
* Fix unit tests