### PR TITLE
fix: Reapply: Ignore plan.out files in cache directories

### DIFF
--- a/terraform-plan-comment/dist/index.js
+++ b/terraform-plan-comment/dist/index.js
@@ -33166,7 +33166,7 @@ const moduleName = (plan, workingDirectory) => {
 
 const generateOutputs = async (workingDirectory, planFile, maxThreads, ignoredResourcesRegexp) => {
   const source = `${workingDirectory}/**/${planFile}`;
-  const plans = fg.sync(source, { dot: true });
+  const plans = fg.sync(source, { dot: true, ignore: [`**/.terragrunt-cache/**/${planFile}`] });
   core.info(`Found ${plans.length} plan(s) for glob ${source}`);
   const promises = [];
   const limit = pLimit(parseInt(maxThreads, 10) || 1);

--- a/terraform-plan-comment/src/generate-outputs.js
+++ b/terraform-plan-comment/src/generate-outputs.js
@@ -75,7 +75,7 @@ const moduleName = (plan, workingDirectory) => {
 
 const generateOutputs = async (workingDirectory, planFile, maxThreads, ignoredResourcesRegexp) => {
   const source = `${workingDirectory}/**/${planFile}`;
-  const plans = fg.sync(source, { dot: true });
+  const plans = fg.sync(source, { dot: true, ignore: [`**/.terragrunt-cache/**/${planFile}`] });
   core.info(`Found ${plans.length} plan(s) for glob ${source}`);
   const promises = [];
   const limit = pLimit(parseInt(maxThreads, 10) || 1);

--- a/terraform-plan-comment/test/generate-outputs.test.js
+++ b/terraform-plan-comment/test/generate-outputs.test.js
@@ -14,6 +14,7 @@ const terragruntFs = {
       },
     },
     moduleB: {
+      'plan.out': 'moduleB',
       '.terragrunt-cache': {
         UUID1: {
           UUID2: {
@@ -58,20 +59,20 @@ describe('Generate Terraform plan output', () => {
         module: 'moduleA', output: 'Module A changes', status: 0, plan: '/work/moduleA/plan.out',
       },
       {
-        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out',
+        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/plan.out',
       },
     ]);
     expect(exec.exec.mock.calls[0][1]).toEqual(['show', '-no-color', '../../../plan.out']);
     expect(exec.exec.mock.calls[0][2]).toMatchObject({
       cwd: '/work/moduleA/.terragrunt-cache/UUID1/UUID2',
     });
-    expect(exec.exec.mock.calls[1][1]).toEqual(['show', '-no-color', 'plan.out']);
+    expect(exec.exec.mock.calls[1][1]).toEqual(['show', '-no-color', '../../../plan.out']);
     expect(exec.exec.mock.calls[1][2]).toMatchObject({
       cwd: '/work/moduleB/.terragrunt-cache/UUID1/UUID2',
     });
     // expect(fs.exists('/work/moduleA/plan.out.changes'));
     expect(fs.existsSync('/work/moduleA/plan.out.changes')).toEqual(true);
-    expect(fs.existsSync('/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out.changes')).toEqual(true);
+    expect(fs.existsSync('/work/moduleB/plan.out.changes')).toEqual(true);
   });
 
   test('It can process a single plan file', async () => {
@@ -104,11 +105,11 @@ describe('Generate Terraform plan output', () => {
     expect(outputs).toHaveLength(1);
     expect(outputs).toEqual([
       {
-        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out',
+        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/plan.out',
       },
     ]);
     expect(fs.existsSync('/work/moduleA/plan.out.changes')).toEqual(false);
-    expect(fs.existsSync('/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out.changes')).toEqual(true);
+    expect(fs.existsSync('/work/moduleB/plan.out.changes')).toEqual(true);
   });
 
   test('It will filter changing ignored objects', async () => {


### PR DESCRIPTION
This reverts commit 4633ede636ac807ff6641cef68bdb6a0d00c0c0e and reapply logic to ignore plan.out files in .terragrunt-cache directory. I tested with tf-infra-gcp and after move files out from the cache directory GHA worked fine. My decision about revert this commit to fixing the issue was mistaken.