### PR TITLE
Revert "fix: Reapply ignoring plan.out files in cache directories"

### DIFF
--- a/terraform-plan-comment/dist/index.js
+++ b/terraform-plan-comment/dist/index.js
@@ -33166,7 +33166,7 @@ const moduleName = (plan, workingDirectory) => {
 
 const generateOutputs = async (workingDirectory, planFile, maxThreads, ignoredResourcesRegexp) => {
   const source = `${workingDirectory}/**/${planFile}`;
-  const plans = fg.sync(source, { dot: true, ignore: [`**/.terragrunt-cache/**/${planFile}`] });
+  const plans = fg.sync(source, { dot: true });
   core.info(`Found ${plans.length} plan(s) for glob ${source}`);
   const promises = [];
   const limit = pLimit(parseInt(maxThreads, 10) || 1);

--- a/terraform-plan-comment/src/generate-outputs.js
+++ b/terraform-plan-comment/src/generate-outputs.js
@@ -75,7 +75,7 @@ const moduleName = (plan, workingDirectory) => {
 
 const generateOutputs = async (workingDirectory, planFile, maxThreads, ignoredResourcesRegexp) => {
   const source = `${workingDirectory}/**/${planFile}`;
-  const plans = fg.sync(source, { dot: true, ignore: [`**/.terragrunt-cache/**/${planFile}`] });
+  const plans = fg.sync(source, { dot: true });
   core.info(`Found ${plans.length} plan(s) for glob ${source}`);
   const promises = [];
   const limit = pLimit(parseInt(maxThreads, 10) || 1);

--- a/terraform-plan-comment/test/generate-outputs.test.js
+++ b/terraform-plan-comment/test/generate-outputs.test.js
@@ -14,7 +14,6 @@ const terragruntFs = {
       },
     },
     moduleB: {
-      'plan.out': 'moduleB',
       '.terragrunt-cache': {
         UUID1: {
           UUID2: {
@@ -59,20 +58,20 @@ describe('Generate Terraform plan output', () => {
         module: 'moduleA', output: 'Module A changes', status: 0, plan: '/work/moduleA/plan.out',
       },
       {
-        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/plan.out',
+        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out',
       },
     ]);
     expect(exec.exec.mock.calls[0][1]).toEqual(['show', '-no-color', '../../../plan.out']);
     expect(exec.exec.mock.calls[0][2]).toMatchObject({
       cwd: '/work/moduleA/.terragrunt-cache/UUID1/UUID2',
     });
-    expect(exec.exec.mock.calls[1][1]).toEqual(['show', '-no-color', '../../../plan.out']);
+    expect(exec.exec.mock.calls[1][1]).toEqual(['show', '-no-color', 'plan.out']);
     expect(exec.exec.mock.calls[1][2]).toMatchObject({
       cwd: '/work/moduleB/.terragrunt-cache/UUID1/UUID2',
     });
     // expect(fs.exists('/work/moduleA/plan.out.changes'));
     expect(fs.existsSync('/work/moduleA/plan.out.changes')).toEqual(true);
-    expect(fs.existsSync('/work/moduleB/plan.out.changes')).toEqual(true);
+    expect(fs.existsSync('/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out.changes')).toEqual(true);
   });
 
   test('It can process a single plan file', async () => {
@@ -105,11 +104,11 @@ describe('Generate Terraform plan output', () => {
     expect(outputs).toHaveLength(1);
     expect(outputs).toEqual([
       {
-        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/plan.out',
+        module: 'moduleB', output: 'Module B changes', status: 0, plan: '/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out',
       },
     ]);
     expect(fs.existsSync('/work/moduleA/plan.out.changes')).toEqual(false);
-    expect(fs.existsSync('/work/moduleB/plan.out.changes')).toEqual(true);
+    expect(fs.existsSync('/work/moduleB/.terragrunt-cache/UUID1/UUID2/plan.out.changes')).toEqual(true);
   });
 
   test('It will filter changing ignored objects', async () => {


### PR DESCRIPTION
This reverts commit 837c1cf3b528cfc9e390ce5a37bae9c8ea9ea00d.