### PR TITLE
fix: Don't remove newlines in footer

### DIFF
--- a/terraform-plan-comment/dist/index.js
+++ b/terraform-plan-comment/dist/index.js
@@ -33280,8 +33280,7 @@ const createComment = (changes, workingDirectory, footer) => {
 
   if (footer) {
     comment.push(
-      // Remove line breaks, but preserve paragraphs.
-      footer.split('\n\n').map((p) => p.replace(/\n/g, ' ')).join('\n\n'),
+      footer,
       '',
     );
   }

--- a/terraform-plan-comment/src/index.js
+++ b/terraform-plan-comment/src/index.js
@@ -53,8 +53,7 @@ const createComment = (changes, workingDirectory, footer) => {
 
   if (footer) {
     comment.push(
-      // Remove line breaks, but preserve paragraphs.
-      footer.split('\n\n').map((p) => p.replace(/\n/g, ' ')).join('\n\n'),
+      footer,
       '',
     );
   }

--- a/terraform-plan-comment/test/index.test.js
+++ b/terraform-plan-comment/test/index.test.js
@@ -197,14 +197,15 @@ Plan: 1 to add, 0 to change, 0 to destroy
       .mockReturnValueOnce('')
       .mockReturnValueOnce('')
       .mockReturnValueOnce('')
-      .mockReturnValueOnce('Custom footer with\nremoved\nnew line and *markdown*\n\nNext section. Preserved.');
+      .mockReturnValueOnce('Custom footer with\nnew line and *markdown*\n\nNext section. Preserved.');
     generateOutputs.mockResolvedValueOnce([]);
     const comment = await action();
     expect(comment).toEqual(`### :white_check_mark: Terraform plan with no changes
 
 Terraform plan reported no changes.
 
-Custom footer with removed new line and *markdown*
+Custom footer with
+new line and *markdown*
 
 Next section. Preserved.
 


### PR DESCRIPTION
Remove additional processing of footer to fix the mess in comments as https://github.com/extenda/tf-infra-gcp/pull/907#issuecomment-912238660

Originally footer looked like this:
https://github.com/extenda/tf-infra-gcp/pull/854#issuecomment-884047755
But as more information were added to the footer, it was reformatted to take less space:
https://github.com/extenda/tf-infra-gcp/pull/904#issuecomment-911463382

