### PR TITLE
fix: Make terraform-plan-comment to work with newer terraform versions

### DIFF
--- a/terraform-plan-comment/dist/index.js
+++ b/terraform-plan-comment/dist/index.js
@@ -33242,7 +33242,8 @@ const moduleEmoji = (summary) => {
 };
 
 const outputToMarkdown = ({ module, output }) => {
-  const summary = output.trim().split('\n').pop();
+  const planSummary = output.match(/Plan: .+/);
+  const summary = planSummary ? planSummary[0] : output.trim().split('\n').pop();
   const emoji = moduleEmoji(summary);
   return [
     `#### ${emoji} \`${module}\``,

--- a/terraform-plan-comment/src/index.js
+++ b/terraform-plan-comment/src/index.js
@@ -15,7 +15,8 @@ const moduleEmoji = (summary) => {
 };
 
 const outputToMarkdown = ({ module, output }) => {
-  const summary = output.trim().split('\n').pop();
+  const planSummary = output.match(/Plan: .+/);
+  const summary = planSummary ? planSummary[0] : output.trim().split('\n').pop();
   const emoji = moduleEmoji(summary);
   return [
     `#### ${emoji} \`${module}\``,

--- a/terraform-plan-comment/test/index.test.js
+++ b/terraform-plan-comment/test/index.test.js
@@ -119,7 +119,7 @@ Plan nested output
 
   test('It can generate comment for single plan', async () => {
     generateOutputs.mockResolvedValueOnce([
-      { module: 'work', output: 'Plan output\nPlan: 1 to add, 0 to change, 0 to destroy\n\n', status: 0 },
+      { module: 'work', output: 'Plan output\nPlan: 1 to add, 0 to change, 0 to destroy\n\nOther text below\n', status: 0 },
     ]);
 
     const comment = await action();
@@ -136,6 +136,7 @@ The output only includes modules with changes.
 Plan output
 Plan: 1 to add, 0 to change, 0 to destroy
 
+Other text below
 
 \`\`\`
 


### PR DESCRIPTION
In new Terraform version there are another text after the `Plan: X to add, X to change, X to destroy` line.
So summary line extracted by regexp