### PR TITLE
fix: Fix regexp for terraform plan summary

### DIFF
--- a/terraform-plan-comment/dist/index.js
+++ b/terraform-plan-comment/dist/index.js
@@ -33242,7 +33242,7 @@ const moduleEmoji = (summary) => {
 };
 
 const outputToMarkdown = ({ module, output }) => {
-  const planSummary = output.match(/Plan: .+/);
+  const planSummary = output.match(/Plan:.+/);
   const summary = planSummary ? planSummary[0] : output.trim().split('\n').pop();
   const emoji = moduleEmoji(summary);
   return [

--- a/terraform-plan-comment/src/index.js
+++ b/terraform-plan-comment/src/index.js
@@ -15,7 +15,7 @@ const moduleEmoji = (summary) => {
 };
 
 const outputToMarkdown = ({ module, output }) => {
-  const planSummary = output.match(/Plan: .+/);
+  const planSummary = output.match(/Plan:.+/);
   const summary = planSummary ? planSummary[0] : output.trim().split('\n').pop();
   const emoji = moduleEmoji(summary);
   return [


### PR DESCRIPTION
Because there are special colorizing characters in the output