### PR TITLE
build: Generate a sufficiently random token for stop-commands

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -32,9 +32,9 @@ jobs:
 
       - name: Run tests
         run: |
-          echo "::stop-commands::jest-output"
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
           npm test -- --ci
-          echo "::jest-output::"
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
         env:
           NEXUS_USERNAME: ${{secrets.NEXUS_USERNAME}}
           NEXUS_PASSWORD: ${{secrets.NEXUS_PASSWORD}}


### PR DESCRIPTION
The token for `::stop-commands::{token}` GA workflow command has to be a cryptographically secure and random string. Definitely not a string literal. See the [docs](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands) for more details. The changeset follows the proposed pattern from the docs.