### PR TITLE
feat(cloud-run): Add ability to patch specification

### DIFF
--- a/cloud-run/README.md
+++ b/cloud-run/README.md
@@ -34,19 +34,16 @@ CVE-2018-14618
 CVE-2019-1543
 ````
 
-This will be usefull when you are forced to use an image with a known vulnerability.
+This will be useful when you are forced to use an image with a known vulnerability.
 
 ## Usage
 
 See [action.yml](action.yml).
 
-
-
 ### Secrets
 
 This action requires a GCP service account key with permission to deploy the cloud run services.
 Once created, the JSON key should be `base64` encoded and added as secret in the GitHub repository.
-
 
 ### Environment variables
 

--- a/cloud-run/action.yml
+++ b/cloud-run/action.yml
@@ -12,6 +12,16 @@ inputs:
       The service YAML specification.
     required: false
     default: cloud-run.yaml
+  service-definition-patch:
+    description: |
+      Inlined YAML to patch into the included service definition.
+        * Objects are merged
+        * Properties are replaced
+        * Lists are replaced
+
+      The patch mechanism can be used to modify settings that differ between
+      staging and production.
+    required: false
   image:
     description: The Docker image to deploy to Cloud Run.
     required: true

--- a/cloud-run/dist/index.js
+++ b/cloud-run/dist/index.js
@@ -1568,6 +1568,147 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
+/***/ 61238:
+/***/ ((module) => {
+
+"use strict";
+
+
+var isMergeableObject = function isMergeableObject(value) {
+	return isNonNullObject(value)
+		&& !isSpecial(value)
+};
+
+function isNonNullObject(value) {
+	return !!value && typeof value === 'object'
+}
+
+function isSpecial(value) {
+	var stringValue = Object.prototype.toString.call(value);
+
+	return stringValue === '[object RegExp]'
+		|| stringValue === '[object Date]'
+		|| isReactElement(value)
+}
+
+// see https://github.com/facebook/react/blob/b5ac963fb791d1298e7f396236383bc955f916c1/src/isomorphic/classic/element/ReactElement.js#L21-L25
+var canUseSymbol = typeof Symbol === 'function' && Symbol.for;
+var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7;
+
+function isReactElement(value) {
+	return value.$$typeof === REACT_ELEMENT_TYPE
+}
+
+function emptyTarget(val) {
+	return Array.isArray(val) ? [] : {}
+}
+
+function cloneUnlessOtherwiseSpecified(value, options) {
+	return (options.clone !== false && options.isMergeableObject(value))
+		? deepmerge(emptyTarget(value), value, options)
+		: value
+}
+
+function defaultArrayMerge(target, source, options) {
+	return target.concat(source).map(function(element) {
+		return cloneUnlessOtherwiseSpecified(element, options)
+	})
+}
+
+function getMergeFunction(key, options) {
+	if (!options.customMerge) {
+		return deepmerge
+	}
+	var customMerge = options.customMerge(key);
+	return typeof customMerge === 'function' ? customMerge : deepmerge
+}
+
+function getEnumerableOwnPropertySymbols(target) {
+	return Object.getOwnPropertySymbols
+		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
+			return target.propertyIsEnumerable(symbol)
+		})
+		: []
+}
+
+function getKeys(target) {
+	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
+}
+
+function propertyIsOnObject(object, property) {
+	try {
+		return property in object
+	} catch(_) {
+		return false
+	}
+}
+
+// Protects from prototype poisoning and unexpected merging up the prototype chain.
+function propertyIsUnsafe(target, key) {
+	return propertyIsOnObject(target, key) // Properties are safe to merge if they don't exist in the target yet,
+		&& !(Object.hasOwnProperty.call(target, key) // unsafe if they exist up the prototype chain,
+			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
+}
+
+function mergeObject(target, source, options) {
+	var destination = {};
+	if (options.isMergeableObject(target)) {
+		getKeys(target).forEach(function(key) {
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options);
+		});
+	}
+	getKeys(source).forEach(function(key) {
+		if (propertyIsUnsafe(target, key)) {
+			return
+		}
+
+		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options);
+		} else {
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+		}
+	});
+	return destination
+}
+
+function deepmerge(target, source, options) {
+	options = options || {};
+	options.arrayMerge = options.arrayMerge || defaultArrayMerge;
+	options.isMergeableObject = options.isMergeableObject || isMergeableObject;
+	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
+	// implementations can use it. The caller may not replace it.
+	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified;
+
+	var sourceIsArray = Array.isArray(source);
+	var targetIsArray = Array.isArray(target);
+	var sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
+
+	if (!sourceAndTargetTypesMatch) {
+		return cloneUnlessOtherwiseSpecified(source, options)
+	} else if (sourceIsArray) {
+		return options.arrayMerge(target, source, options)
+	} else {
+		return mergeObject(target, source, options)
+	}
+}
+
+deepmerge.all = function deepmergeAll(array, options) {
+	if (!Array.isArray(array)) {
+		throw new Error('first argument should be an array')
+	}
+
+	return array.reduce(function(prev, next) {
+		return deepmerge(prev, next, options)
+	}, {})
+};
+
+var deepmerge_1 = deepmerge;
+
+module.exports = deepmerge_1;
+
+
+/***/ }),
+
 /***/ 38409:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -11497,6 +11638,7 @@ const jsonSchema = __webpack_require__(7783);
 const action = async () => {
   const serviceAccountKey = core.getInput('service-account-key', { required: true });
   const serviceFile = core.getInput('service-definition') || 'cloud-run.yaml';
+  const servicePatch = core.getInput('service-definition-patch');
   const image = core.getInput('image', { required: true });
   const domainBindingsEnv = core.getInput('domain-mappings-env') || '';
   const dnsProjectLabel = core.getInput('dns-project-label') || 'dns';
@@ -11504,7 +11646,7 @@ const action = async () => {
 
   failIfNotTrunkBased();
 
-  const service = loadServiceDefinition(serviceFile, jsonSchema);
+  const service = loadServiceDefinition(serviceFile, jsonSchema, servicePatch);
   await runDeploy(serviceAccountKey, service, image, verbose === 'true')
     .then(({ cluster }) => configureDomains(
       service,
@@ -11857,6 +11999,7 @@ const fs = __webpack_require__(35747);
 const yaml = __webpack_require__(75024);
 const core = __webpack_require__(6341);
 const { validate } = __webpack_require__(32039);
+const merge = __webpack_require__(61238);
 
 const loadFile = (serviceFile) => {
   if (!fs.existsSync(serviceFile)) {
@@ -11874,8 +12017,15 @@ const validateSchema = (serviceFile, spec, schema) => {
   }
 };
 
-const loadServiceDefinition = (serviceFile, schema) => {
-  const spec = loadFile(serviceFile);
+const loadServiceDefinition = (serviceFile, schema, patch) => {
+  let spec = loadFile(serviceFile);
+  if (patch) {
+    const patchSpec = yaml.parse(patch);
+    spec = merge(spec, patchSpec, {
+      arrayMerge: (specArray, patchArray) => patchArray,
+    });
+  }
+
   validateSchema(serviceFile, spec, schema);
   return spec;
 };

--- a/cloud-run/dist/licenses.txt
+++ b/cloud-run/dist/licenses.txt
@@ -355,6 +355,31 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
+deepmerge
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2012 James Halliday, Josh Duff, and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 delayed-stream
 MIT
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>

--- a/cloud-run/package-lock.json
+++ b/cloud-run/package-lock.json
@@ -103,6 +103,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",

--- a/cloud-run/package.json
+++ b/cloud-run/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
+    "deepmerge": "^4.2.2",
     "jsonschema": "^1.2.5",
     "slack-notify": "^0.1.7",
     "yaml": "^1.8.2"

--- a/cloud-run/src/index.js
+++ b/cloud-run/src/index.js
@@ -8,6 +8,7 @@ const jsonSchema = require('./cloud-run-schema');
 const action = async () => {
   const serviceAccountKey = core.getInput('service-account-key', { required: true });
   const serviceFile = core.getInput('service-definition') || 'cloud-run.yaml';
+  const servicePatch = core.getInput('service-definition-patch');
   const image = core.getInput('image', { required: true });
   const domainBindingsEnv = core.getInput('domain-mappings-env') || '';
   const dnsProjectLabel = core.getInput('dns-project-label') || 'dns';
@@ -15,7 +16,7 @@ const action = async () => {
 
   failIfNotTrunkBased();
 
-  const service = loadServiceDefinition(serviceFile, jsonSchema);
+  const service = loadServiceDefinition(serviceFile, jsonSchema, servicePatch);
   await runDeploy(serviceAccountKey, service, image, verbose === 'true')
     .then(({ cluster }) => configureDomains(
       service,

--- a/cloud-run/src/service-definition.js
+++ b/cloud-run/src/service-definition.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const yaml = require('yaml');
 const core = require('@actions/core');
 const { validate } = require('jsonschema');
+const merge = require('deepmerge');
 
 const loadFile = (serviceFile) => {
   if (!fs.existsSync(serviceFile)) {
@@ -19,8 +20,15 @@ const validateSchema = (serviceFile, spec, schema) => {
   }
 };
 
-const loadServiceDefinition = (serviceFile, schema) => {
-  const spec = loadFile(serviceFile);
+const loadServiceDefinition = (serviceFile, schema, patch) => {
+  let spec = loadFile(serviceFile);
+  if (patch) {
+    const patchSpec = yaml.parse(patch);
+    spec = merge(spec, patchSpec, {
+      arrayMerge: (specArray, patchArray) => patchArray,
+    });
+  }
+
   validateSchema(serviceFile, spec, schema);
   return spec;
 };

--- a/cloud-run/test/index.test.js
+++ b/cloud-run/test/index.test.js
@@ -25,6 +25,7 @@ describe('Cloud Run Action', () => {
     serviceDef.mockReturnValueOnce({});
     core.getInput.mockReturnValueOnce('service-account')
       .mockReturnValueOnce('cloud-run.yaml')
+      .mockReturnValueOnce('')
       .mockReturnValueOnce('gcr.io/project/image:tag')
       .mockReturnValueOnce('')
       .mockReturnValueOnce('dns')
@@ -32,7 +33,7 @@ describe('Cloud Run Action', () => {
     runDeploy.mockResolvedValueOnce({});
     await action();
 
-    expect(core.getInput).toHaveBeenCalledTimes(6);
+    expect(core.getInput).toHaveBeenCalledTimes(7);
     expect(runDeploy).toHaveBeenCalledWith(
       'service-account',
       {},
@@ -46,6 +47,7 @@ describe('Cloud Run Action', () => {
     serviceDef.mockReturnValueOnce({});
     core.getInput.mockReturnValueOnce('service-account')
       .mockReturnValueOnce('')
+      .mockReturnValueOnce('')
       .mockReturnValueOnce('gcr.io/project/image:tag')
       .mockReturnValueOnce('')
       .mockReturnValueOnce('dns')
@@ -54,7 +56,7 @@ describe('Cloud Run Action', () => {
 
     await action();
 
-    expect(core.getInput).toHaveBeenCalledTimes(6);
+    expect(core.getInput).toHaveBeenCalledTimes(7);
     expect(runDeploy).toHaveBeenCalledWith(
       'service-account',
       {},
@@ -68,6 +70,7 @@ describe('Cloud Run Action', () => {
     serviceDef.mockReturnValueOnce({});
     core.getInput.mockReturnValueOnce('service-account')
       .mockReturnValueOnce('')
+      .mockReturnValueOnce('')
       .mockReturnValueOnce('gcr.io/project/image:tag')
       .mockReturnValueOnce('')
       .mockReturnValueOnce('dns')
@@ -76,7 +79,7 @@ describe('Cloud Run Action', () => {
 
     await action();
 
-    expect(core.getInput).toHaveBeenCalledTimes(6);
+    expect(core.getInput).toHaveBeenCalledTimes(7);
     expect(runDeploy).toHaveBeenCalledWith(
       'service-account',
       {},
@@ -90,6 +93,7 @@ describe('Cloud Run Action', () => {
     serviceDef.mockReturnValueOnce({});
     core.getInput.mockReturnValueOnce('service-account')
       .mockReturnValueOnce('cloud-run.yaml')
+      .mockReturnValueOnce('')
       .mockReturnValueOnce('gcr.io/project/image:tag')
       .mockReturnValueOnce('')
       .mockReturnValueOnce('dns')

--- a/cloud-run/test/service-definition.test.js
+++ b/cloud-run/test/service-definition.test.js
@@ -359,11 +359,11 @@ platform:
   managed:
     allow-unauthenticated: true
     region: eu-west1
-canary: 
+canary:
   enabled: true
   steps: '10,50,80'
   intervall: '10'
-  thresholds: 
+  thresholds:
     latency99: '5'
     latency95: '2'
     latency50: '1'
@@ -371,5 +371,70 @@ canary:
 `,
     });
     expect(() => loadServiceDefinition('cloud-run.yaml', cloudRunSchema).not.toThrow());
+  });
+
+  test('It can patch the service definition', () => {
+    mockFs({
+      'cloud-run.yaml': `
+name: service
+memory: 256Mi
+cpu: 1
+
+environment:
+  NAME: value
+  SECRET: sm://*/secret-name
+
+platform:
+  gke:
+    connectivity: external
+    domain-mappings:
+      staging:
+        - test-service.domain.dev
+      prod:
+        - test-service.domain.com
+`,
+    });
+
+    const yamlPatch = `
+name: patch-service
+cpu: 200m
+min-instances: 2
+environment:
+  NAME: replaced
+  PATCH: added
+platform:
+  gke:
+    domain-mappings:
+      staging:
+        - patch-service.domain.dev
+      prod:
+        - patch-service.domain.com
+    `;
+
+    const service = loadServiceDefinition('cloud-run.yaml', cloudRunSchema, yamlPatch);
+    expect(service).toMatchObject({
+      name: 'patch-service',
+      memory: '256Mi',
+      cpu: '200m',
+      'min-instances': 2,
+      environment: {
+        NAME: 'replaced',
+        SECRET: 'sm://*/secret-name',
+        PATCH: 'added',
+      },
+      platform: {
+        gke: {
+          connectivity: 'external',
+          'domain-mappings': {
+            staging: [
+              'patch-service.domain.dev',
+            ],
+            prod: [
+              'patch-service.domain.com',
+            ]
+          }
+        }
+      }
+    });
   });
 });

--- a/cloud-run/test/service-definition.test.js
+++ b/cloud-run/test/service-definition.test.js
@@ -431,10 +431,10 @@ platform:
             ],
             prod: [
               'patch-service.domain.com',
-            ]
-          }
-        }
-      }
+            ],
+          },
+        },
+      },
     });
   });
 });

--- a/kubernetes/dist/index.js
+++ b/kubernetes/dist/index.js
@@ -19437,6 +19437,7 @@ const checkRequiredNumberOfPodsIsRunning = async (
     await exec.exec('kubectl', getRunningPodsNoSelectorArgs, {
       listeners: {
         stdout: (data) => {
+          // eslint-disable-next-line no-console
           console.log(parseInt(data.toString('utf8').trim(), 10));
         },
       },
@@ -19450,6 +19451,7 @@ const checkRequiredNumberOfPodsIsRunning = async (
     await exec.exec('kubectl', configViewArgs, {
       listeners: {
         stdout: (data) => {
+          // eslint-disable-next-line no-console
           console.log(data.toString('utf8'));
         },
       },

--- a/kubernetes/dist/index.js
+++ b/kubernetes/dist/index.js
@@ -1552,6 +1552,147 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
+/***/ 7794:
+/***/ ((module) => {
+
+"use strict";
+
+
+var isMergeableObject = function isMergeableObject(value) {
+	return isNonNullObject(value)
+		&& !isSpecial(value)
+};
+
+function isNonNullObject(value) {
+	return !!value && typeof value === 'object'
+}
+
+function isSpecial(value) {
+	var stringValue = Object.prototype.toString.call(value);
+
+	return stringValue === '[object RegExp]'
+		|| stringValue === '[object Date]'
+		|| isReactElement(value)
+}
+
+// see https://github.com/facebook/react/blob/b5ac963fb791d1298e7f396236383bc955f916c1/src/isomorphic/classic/element/ReactElement.js#L21-L25
+var canUseSymbol = typeof Symbol === 'function' && Symbol.for;
+var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7;
+
+function isReactElement(value) {
+	return value.$$typeof === REACT_ELEMENT_TYPE
+}
+
+function emptyTarget(val) {
+	return Array.isArray(val) ? [] : {}
+}
+
+function cloneUnlessOtherwiseSpecified(value, options) {
+	return (options.clone !== false && options.isMergeableObject(value))
+		? deepmerge(emptyTarget(value), value, options)
+		: value
+}
+
+function defaultArrayMerge(target, source, options) {
+	return target.concat(source).map(function(element) {
+		return cloneUnlessOtherwiseSpecified(element, options)
+	})
+}
+
+function getMergeFunction(key, options) {
+	if (!options.customMerge) {
+		return deepmerge
+	}
+	var customMerge = options.customMerge(key);
+	return typeof customMerge === 'function' ? customMerge : deepmerge
+}
+
+function getEnumerableOwnPropertySymbols(target) {
+	return Object.getOwnPropertySymbols
+		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
+			return target.propertyIsEnumerable(symbol)
+		})
+		: []
+}
+
+function getKeys(target) {
+	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
+}
+
+function propertyIsOnObject(object, property) {
+	try {
+		return property in object
+	} catch(_) {
+		return false
+	}
+}
+
+// Protects from prototype poisoning and unexpected merging up the prototype chain.
+function propertyIsUnsafe(target, key) {
+	return propertyIsOnObject(target, key) // Properties are safe to merge if they don't exist in the target yet,
+		&& !(Object.hasOwnProperty.call(target, key) // unsafe if they exist up the prototype chain,
+			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
+}
+
+function mergeObject(target, source, options) {
+	var destination = {};
+	if (options.isMergeableObject(target)) {
+		getKeys(target).forEach(function(key) {
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options);
+		});
+	}
+	getKeys(source).forEach(function(key) {
+		if (propertyIsUnsafe(target, key)) {
+			return
+		}
+
+		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options);
+		} else {
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+		}
+	});
+	return destination
+}
+
+function deepmerge(target, source, options) {
+	options = options || {};
+	options.arrayMerge = options.arrayMerge || defaultArrayMerge;
+	options.isMergeableObject = options.isMergeableObject || isMergeableObject;
+	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
+	// implementations can use it. The caller may not replace it.
+	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified;
+
+	var sourceIsArray = Array.isArray(source);
+	var targetIsArray = Array.isArray(target);
+	var sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
+
+	if (!sourceAndTargetTypesMatch) {
+		return cloneUnlessOtherwiseSpecified(source, options)
+	} else if (sourceIsArray) {
+		return options.arrayMerge(target, source, options)
+	} else {
+		return mergeObject(target, source, options)
+	}
+}
+
+deepmerge.all = function deepmergeAll(array, options) {
+	if (!Array.isArray(array)) {
+		throw new Error('first argument should be an array')
+	}
+
+	return array.reduce(function(prev, next) {
+		return deepmerge(prev, next, options)
+	}, {})
+};
+
+var deepmerge_1 = deepmerge;
+
+module.exports = deepmerge_1;
+
+
+/***/ }),
+
 /***/ 7887:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -10840,6 +10981,7 @@ const fs = __webpack_require__(5747);
 const yaml = __webpack_require__(6242);
 const core = __webpack_require__(7199);
 const { validate } = __webpack_require__(2145);
+const merge = __webpack_require__(7794);
 
 const loadFile = (serviceFile) => {
   if (!fs.existsSync(serviceFile)) {
@@ -10857,8 +10999,15 @@ const validateSchema = (serviceFile, spec, schema) => {
   }
 };
 
-const loadServiceDefinition = (serviceFile, schema) => {
-  const spec = loadFile(serviceFile);
+const loadServiceDefinition = (serviceFile, schema, patch) => {
+  let spec = loadFile(serviceFile);
+  if (patch) {
+    const patchSpec = yaml.parse(patch);
+    spec = merge(spec, patchSpec, {
+      arrayMerge: (specArray, patchArray) => patchArray,
+    });
+  }
+
   validateSchema(serviceFile, spec, schema);
   return spec;
 };

--- a/kubernetes/dist/licenses.txt
+++ b/kubernetes/dist/licenses.txt
@@ -215,6 +215,31 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
+deepmerge
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2012 James Halliday, Josh Duff, and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 follow-redirects
 MIT
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh

--- a/kubernetes/src/check-number-of-pods-running.js
+++ b/kubernetes/src/check-number-of-pods-running.js
@@ -105,6 +105,7 @@ const checkRequiredNumberOfPodsIsRunning = async (
     await exec.exec('kubectl', getRunningPodsNoSelectorArgs, {
       listeners: {
         stdout: (data) => {
+          // eslint-disable-next-line no-console
           console.log(parseInt(data.toString('utf8').trim(), 10));
         },
       },
@@ -118,6 +119,7 @@ const checkRequiredNumberOfPodsIsRunning = async (
     await exec.exec('kubectl', configViewArgs, {
       listeners: {
         stdout: (data) => {
+          // eslint-disable-next-line no-console
           console.log(data.toString('utf8'));
         },
       },

--- a/kubernetes/test/check-number-of-pods-running.test.js
+++ b/kubernetes/test/check-number-of-pods-running.test.js
@@ -82,6 +82,7 @@ describe('Check number of pods running', () => {
   });
 
   test('It fails on unknown error', async () => {
+    // eslint-disable-next-line no-console
     console.log = jest.fn();
     // Call before the retry.
     exec.exec
@@ -147,6 +148,7 @@ describe('Check number of pods running', () => {
     expect(exec.exec.mock.calls[2][1]).toEqual(getNonRunningPodsArgs);
     expect(exec.exec.mock.calls[7][1]).toEqual(getRunningPodsNoSelectorArgs);
     expect(exec.exec.mock.calls[8][1]).toEqual(['config', 'view']);
+    // eslint-disable-next-line no-console
     expect(console.log).toHaveBeenCalledTimes(2);
   });
 

--- a/test-pod/dist/index.js
+++ b/test-pod/dist/index.js
@@ -1552,6 +1552,147 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
+/***/ 7794:
+/***/ ((module) => {
+
+"use strict";
+
+
+var isMergeableObject = function isMergeableObject(value) {
+	return isNonNullObject(value)
+		&& !isSpecial(value)
+};
+
+function isNonNullObject(value) {
+	return !!value && typeof value === 'object'
+}
+
+function isSpecial(value) {
+	var stringValue = Object.prototype.toString.call(value);
+
+	return stringValue === '[object RegExp]'
+		|| stringValue === '[object Date]'
+		|| isReactElement(value)
+}
+
+// see https://github.com/facebook/react/blob/b5ac963fb791d1298e7f396236383bc955f916c1/src/isomorphic/classic/element/ReactElement.js#L21-L25
+var canUseSymbol = typeof Symbol === 'function' && Symbol.for;
+var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7;
+
+function isReactElement(value) {
+	return value.$$typeof === REACT_ELEMENT_TYPE
+}
+
+function emptyTarget(val) {
+	return Array.isArray(val) ? [] : {}
+}
+
+function cloneUnlessOtherwiseSpecified(value, options) {
+	return (options.clone !== false && options.isMergeableObject(value))
+		? deepmerge(emptyTarget(value), value, options)
+		: value
+}
+
+function defaultArrayMerge(target, source, options) {
+	return target.concat(source).map(function(element) {
+		return cloneUnlessOtherwiseSpecified(element, options)
+	})
+}
+
+function getMergeFunction(key, options) {
+	if (!options.customMerge) {
+		return deepmerge
+	}
+	var customMerge = options.customMerge(key);
+	return typeof customMerge === 'function' ? customMerge : deepmerge
+}
+
+function getEnumerableOwnPropertySymbols(target) {
+	return Object.getOwnPropertySymbols
+		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
+			return target.propertyIsEnumerable(symbol)
+		})
+		: []
+}
+
+function getKeys(target) {
+	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
+}
+
+function propertyIsOnObject(object, property) {
+	try {
+		return property in object
+	} catch(_) {
+		return false
+	}
+}
+
+// Protects from prototype poisoning and unexpected merging up the prototype chain.
+function propertyIsUnsafe(target, key) {
+	return propertyIsOnObject(target, key) // Properties are safe to merge if they don't exist in the target yet,
+		&& !(Object.hasOwnProperty.call(target, key) // unsafe if they exist up the prototype chain,
+			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
+}
+
+function mergeObject(target, source, options) {
+	var destination = {};
+	if (options.isMergeableObject(target)) {
+		getKeys(target).forEach(function(key) {
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options);
+		});
+	}
+	getKeys(source).forEach(function(key) {
+		if (propertyIsUnsafe(target, key)) {
+			return
+		}
+
+		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options);
+		} else {
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+		}
+	});
+	return destination
+}
+
+function deepmerge(target, source, options) {
+	options = options || {};
+	options.arrayMerge = options.arrayMerge || defaultArrayMerge;
+	options.isMergeableObject = options.isMergeableObject || isMergeableObject;
+	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
+	// implementations can use it. The caller may not replace it.
+	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified;
+
+	var sourceIsArray = Array.isArray(source);
+	var targetIsArray = Array.isArray(target);
+	var sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
+
+	if (!sourceAndTargetTypesMatch) {
+		return cloneUnlessOtherwiseSpecified(source, options)
+	} else if (sourceIsArray) {
+		return options.arrayMerge(target, source, options)
+	} else {
+		return mergeObject(target, source, options)
+	}
+}
+
+deepmerge.all = function deepmergeAll(array, options) {
+	if (!Array.isArray(array)) {
+		throw new Error('first argument should be an array')
+	}
+
+	return array.reduce(function(prev, next) {
+		return deepmerge(prev, next, options)
+	}, {})
+};
+
+var deepmerge_1 = deepmerge;
+
+module.exports = deepmerge_1;
+
+
+/***/ }),
+
 /***/ 7887:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -11039,6 +11180,7 @@ const fs = __webpack_require__(5747);
 const yaml = __webpack_require__(6242);
 const core = __webpack_require__(7199);
 const { validate } = __webpack_require__(2145);
+const merge = __webpack_require__(7794);
 
 const loadFile = (serviceFile) => {
   if (!fs.existsSync(serviceFile)) {
@@ -11056,8 +11198,15 @@ const validateSchema = (serviceFile, spec, schema) => {
   }
 };
 
-const loadServiceDefinition = (serviceFile, schema) => {
-  const spec = loadFile(serviceFile);
+const loadServiceDefinition = (serviceFile, schema, patch) => {
+  let spec = loadFile(serviceFile);
+  if (patch) {
+    const patchSpec = yaml.parse(patch);
+    spec = merge(spec, patchSpec, {
+      arrayMerge: (specArray, patchArray) => patchArray,
+    });
+  }
+
   validateSchema(serviceFile, spec, schema);
   return spec;
 };

--- a/test-pod/dist/licenses.txt
+++ b/test-pod/dist/licenses.txt
@@ -240,6 +240,31 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
+deepmerge
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2012 James Halliday, Josh Duff, and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 follow-redirects
 MIT
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh


### PR DESCRIPTION
This change makes it easy to patch a cloud-run.yaml with deployment specific properties. It can for example be used to give a deployment different concurrency, CPU and memory depending on whether it is a test or staging system vs production. Another use case is to add additional environment variables not known until the GHA workflow executes.