### PR TITLE
docs: Add single quote to maven RM.md

### DIFF
--- a/maven/README.md
+++ b/maven/README.md
@@ -171,7 +171,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == refs/heads/master
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Add single quote so that build don't fail due to missing single quotes.

`>>> Unexpected symbol: 'refs/heads/main' <<<`