### PR TITLE
docs: Add deprecation notices [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ the fundamental parts of our CI/CD pipelines.
 
 The following actions are available
 
-  * [cloud-run](cloud-run#readme)
+  * ~~[cloud-run](cloud-run#readme)~~
   * [commitlint](commitlint#readme)
   * [component-tests](component-tests#readme)
   * [conventional-release](conventional-release#readme)
   * [conventional-version](conventional-version#readme)
   * [dataflow-template-build](dataflow-template-build#readme)
-  * [docker](docker#readme)
+  * ~~[docker](docker#readme)~~
   * [dataflow-deploy](dataflow-deploy#readme)
   * [customer-config](customer-config#readme)
   * [gcp-secret-manager](gcp-secret-manager#readme)
@@ -24,7 +24,7 @@ The following actions are available
   * [iam-test-token](iam-test-token#readme)
   * [jira-release](jira-release#readme)
   * [jira-releasenotes](jira-releasenotes#readme)
-  * [kubernetes](kubernetes#readme)
+  * ~~[kubernetes](kubernetes#readme)~~
   * [maven](maven#readme)
   * [nexus-auth-npm](nexus-auth-npm#readme)
   * [pact-broker](pact-broker#readme)
@@ -32,22 +32,22 @@ The following actions are available
   * [pact-publish](pact-publish#readme)
   * [pact-tag-version](pact-tag-version#readme)
   * [repository-dispatch](repository-dispatch#readme)
-  * [rs-create-installerpkg](rs-create-installerpkg#readme)
-  * [rs-permission-converter](rs-permission-converter#readme)
+  * ~~[rs-create-installerpkg](rs-create-installerpkg#readme)~~
+  * ~~[rs-permission-converter](rs-permission-converter#readme)~~
   * [setup-gcloud](setup-gcloud#readme)
   * [setup-git](setup-git#readme)
   * [setup-msbuild](setup-msbuild#readme)
   * [setup-nuget-sources](setup-nuget-sources#readme)
   * [setup-terraform](setup-terraform#readme)
-  * [slack-message](slack-message#readme)
+  * ~~[slack-message](slack-message#readme)~~
   * [slack-notify](slack-notify#readme)
   * [sonar-scanner](sonar-scanner#readme)
   * [status-check](status-check#readme)
   * [styra-das-deploy](styra-das-deploy#readme)
   * [styra-das-test](styra-das-test#readme)
   * [terraform-plan-comment](terraform-plan-comment#readme)
-  * [test-pod](test-pod#readme)
-  * [txengine-deploy](txengine-deploy#readme)
+  * ~~[test-pod](test-pod#readme)~~
+  * ~~[txengine-deploy](txengine-deploy#readme)~~
 
 ## :rocket: Workflow Examples
 

--- a/cloud-run/README.md
+++ b/cloud-run/README.md
@@ -1,5 +1,7 @@
 # cloud-run
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 This is a GitHub Action to deploy a service to Cloud Run.
 
 When deploying to Cloud Run on GKE, the action will also conditionally deploy or configure the following

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,7 @@
 # Docker Build & Push Action
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 Builds a Docker image and pushes it to the private registry of your choosing.
 
 Forked and modified to fit Extenda GitHub Actions.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,5 +1,7 @@
 # kubernetes
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 This is a GitHub Action to deploy a service to Kubernetes.
 
 ## Usage

--- a/publish-openapi/README.md
+++ b/publish-openapi/README.md
@@ -1,5 +1,7 @@
 # Deploy api documentation
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 This is a GitHub Action to deploy api documentation that will be made available on the url:
 https://api-docs.hiiretail.com
 

--- a/rs-create-installerpkg/README.md
+++ b/rs-create-installerpkg/README.md
@@ -1,5 +1,7 @@
 # rs-create-installerpkg
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 This GitHub Action generates a zipped RS installer package artifact. Installer packages will have the file extension pkg.zip
 NEXUS_USERNAME and NEXUS_PASSWORD env needs to be set to be able to download the binary from Nexus.
 
@@ -24,7 +26,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@master  
+      - uses: actions/checkout@master
 
       - uses: actions/cache@v1
         with:

--- a/rs-permission-converter/README.md
+++ b/rs-permission-converter/README.md
@@ -1,5 +1,7 @@
 # rs-permission-converter
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 This GitHub Action converts a permission.xml file into sql file or into resx files. It is the xml file that is the master when adding new access rights and translations.
 
 ## Usage
@@ -24,7 +26,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@master  
+      - uses: actions/checkout@master
 
       - name: Create sql file from permission xml
         uses: extenda/actions/rs-permission-converter@v0

--- a/slack-message/README.md
+++ b/slack-message/README.md
@@ -1,5 +1,7 @@
 # slack-message
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 This GitHub Action can be used to send messages to Slack through the GitHub Slack Integration. Messages
 posted with this action are delivered to all Slack channels that are subscribed to the repository.
 
@@ -75,12 +77,12 @@ jobs:
 
 #### Send message at release
 
-Posting a Slack message at the end of the release stage of a build can be done by adding the `@github` bot to a Slack 
+Posting a Slack message at the end of the release stage of a build can be done by adding the `@github` bot to a Slack
 channel and then configuring it so it doesn't post messages for anything else than the Slack Action.
 
 Start by subscribing the bot to a repository from a channel as described above. Configuring the bot can be done with
 `github unsubscribe extenda/actions pulls statuses commits releases`.
-This will disable the bot from sending messages when there are new pull requests, new commits to the default branch 
+This will disable the bot from sending messages when there are new pull requests, new commits to the default branch
 and published releases.
 
 Then use this Action according to the usage with Secret Manager.

--- a/test-pod/README.md
+++ b/test-pod/README.md
@@ -1,5 +1,7 @@
 # test-pod
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 GitHub Action to run acceptance tests in a Kubernetes Pod. Use this action to test internal services that are not
 reachable directly from GitHub Actions.
 
@@ -172,7 +174,7 @@ jobs:
           service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
           image: eu.gcr.io/extenda/example-test:${{ github.sha }}
         env:
-          TESTPOD_API_KEY: ${{ secrets.API_KEY }}  
+          TESTPOD_API_KEY: ${{ secrets.API_KEY }}
 ```
 
 ### Test that saves reports on the GitHub runner
@@ -184,7 +186,7 @@ write the files to standard out itself.
 The action supports a single file transfer on the following format
   1. Write `test-pod-output BEGIN` to standard out to start the transfer
   2. Create a TAR archive with the files to transfer, Base64 encode it and write it to standard out
-  3. Write `test-pod-output END` to standard out to end the transfer  
+  3. Write `test-pod-output END` to standard out to end the transfer
 
 We recommend performing the file transfer in the `entrypoint` action input script,
 or in your custom docker image's `entrypoint`.

--- a/txengine-deploy/README.md
+++ b/txengine-deploy/README.md
@@ -1,5 +1,7 @@
 # txengine-deploy
 
+**:warning: This action is deprecated and will be removed in v1.**
+
 GitHub Action to deploy a tenant-specific Transaction Engine. This action is used internally at Extenda Retail for a
 repeatable and scalable deployment of applications.
 


### PR DESCRIPTION
Deprecate actions that we no longer intend to support in the v1 tag. Deploy actions will be replaced by the general purpose cloud-deploy actions, while others are no longer in use or not possible to support due to broken APIs.