### PR TITLE
build: Use separate dependabot workflow

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -6,6 +6,7 @@ permissions: write-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -43,15 +43,13 @@ jobs:
 
   verify-dist:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/build-dist
 
       - name: Check compiled dist/* files
-        if: github.actor != 'dependabot[bot]'
         run: |
           git add '*/dist/**'
           if [ "$(git diff --staged --ignore-space-at-eol '*/dist/**' | wc -l)" -gt "0" ]; then
@@ -64,28 +62,15 @@ jobs:
             exit 1
           fi
 
-      - name: 'Dependabot: Update changed dist/* files'
-        if: github.actor == 'dependabot[bot]'
-        run: |
-          if [ "$(git diff --ignore-space-at-eol '*/dist/**' | wc -l)" -gt "0" ]; then
-            bash .github/actions/commit-changes.sh
-          fi
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   acceptance-windows:
     runs-on: windows-latest
+    if: github.actor != 'dependabot[bot]'
     needs:
       - verify-dist
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: 'Dependabot: Rebuild dist files'
-        if: github.actor == 'dependabot[bot]'
-        uses: ./.github/actions/build-dist
 
       - uses: ./setup-msbuild
 
@@ -140,14 +125,11 @@ jobs:
 
   acceptance-linux:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     needs:
       - verify-dist
     steps:
       - uses: actions/checkout@v3
-
-      - name: 'Dependabot: Rebuild dist files'
-        if: github.actor == 'dependabot[bot]'
-        uses: ./.github/actions/build-dist
 
       - name: Install Java
         uses: actions/setup-java@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,31 @@
+name: pull-request
+on: pull_request_target
+
+permissions: write-all
+
+jobs:
+  update-dist-files:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 'Dependabot: Rebuild dist files'
+        uses: ./.github/actions/build-dist
+
+      - uses: extenda/actions/gcp-secret-manager@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          secrets: |
+            COMMIT_TOKEN: github-token
+
+      - name: 'Dependabot: Update changed dist/* files'
+        run: |
+          if [ "$(git diff --ignore-space-at-eol '*/dist/**' | wc -l)" -gt "0" ]; then
+            bash .github/actions/commit-changes.sh
+          fi
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ env.COMMIT_TOKEN }}


### PR DESCRIPTION
Run a pull-request based workflow for dependabot changes. When dependabot runs, we generate the dist files and commit them with the extenda-devops-bot token. This will in turn trigger a new build that will run all the regular checks.

To optimize build time, regular commits jobs that require updated dist files are skipped for dependabot.