### PR TITLE
feat(cloud-deploy): Add termination-grace-period setting for GKE

### DIFF
--- a/cloud-deploy/src/manifests/build-manifest.js
+++ b/cloud-deploy/src/manifests/build-manifest.js
@@ -238,7 +238,7 @@ const buildManifest = async (
   if (kubernetes) {
     envArray.push({ name: 'PORT', value: '8080' });
     envArray.push({ name: 'K_SERVICE', value: name });
-    const terminationGracePeriod = kubernetes['termination-grace-period'] || 30;
+    const terminationGracePeriod = kubernetes['termination-grace-period'] || 90;
 
     const manifests = await gkeManifestTemplate(
       name,

--- a/cloud-deploy/src/manifests/build-manifest.js
+++ b/cloud-deploy/src/manifests/build-manifest.js
@@ -238,6 +238,7 @@ const buildManifest = async (
   if (kubernetes) {
     envArray.push({ name: 'PORT', value: '8080' });
     envArray.push({ name: 'K_SERVICE', value: name });
+    const terminationGracePeriod = kubernetes['termination-grace-period'] || 30;
 
     const manifests = await gkeManifestTemplate(
       name,
@@ -260,6 +261,7 @@ const buildManifest = async (
       availability,
       baseAnnotations,
       corsEnabled,
+      terminationGracePeriod,
     );
 
     await connectToCluster(clanName, deployEnv, projectId);

--- a/cloud-deploy/src/manifests/build-manifests-gke.js
+++ b/cloud-deploy/src/manifests/build-manifests-gke.js
@@ -52,6 +52,7 @@ const gkeManifestTemplate = async (
   availability,
   baseAnnotations,
   corsEnabled,
+  terminationGracePeriod,
 ) => {
   // initialize manifest components
 
@@ -242,7 +243,7 @@ const gkeManifestTemplate = async (
               : []),
             ...(collectorContainer ? [collectorContainer] : []),
           ],
-          terminationGracePeriodSeconds: 90,
+          terminationGracePeriodSeconds: terminationGracePeriod,
           volumes: deploymentVolumes,
         },
       },

--- a/cloud-deploy/src/utils/cloud-deploy.schema.json
+++ b/cloud-deploy/src/utils/cloud-deploy.schema.json
@@ -182,6 +182,13 @@
         "availability": {
           "$ref": "#/$defs/Availability"
         },
+        "termination-grace-period": {
+          "description": "The termination grace period in seconds",
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 600,
+          "default": 30
+        },
         "scaling": {
           "title": "ScalingKubernetes",
           "description": "Scaling settings for Kubernetes",

--- a/cloud-deploy/src/utils/cloud-deploy.schema.json
+++ b/cloud-deploy/src/utils/cloud-deploy.schema.json
@@ -187,7 +187,7 @@
           "type": "integer",
           "minimum": 30,
           "maximum": 600,
-          "default": 30
+          "default": 90
         },
         "scaling": {
           "title": "ScalingKubernetes",

--- a/cloud-deploy/test/manifests/__snapshots__/build-manifest.test.js.snap
+++ b/cloud-deploy/test/manifests/__snapshots__/build-manifest.test.js.snap
@@ -469,7 +469,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -692,7 +692,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1149,7 +1149,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1276,7 +1276,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1497,7 +1497,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 5
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1618,7 +1618,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1950,7 +1950,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -2190,7 +2190,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -2333,7 +2333,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 5
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 30
       volumes: []
 ---
 apiVersion: autoscaling/v2

--- a/cloud-deploy/test/manifests/__snapshots__/build-manifest.test.js.snap
+++ b/cloud-deploy/test/manifests/__snapshots__/build-manifest.test.js.snap
@@ -469,7 +469,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -692,7 +692,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1149,7 +1149,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1276,7 +1276,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1497,7 +1497,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 5
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1618,7 +1618,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -1950,7 +1950,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -2190,7 +2190,7 @@ spec:
               value: '8080'
             - name: K_SERVICE
               value: example-service
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2
@@ -2333,7 +2333,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 5
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       volumes: []
 ---
 apiVersion: autoscaling/v2

--- a/cloud-deploy/test/manifests/build-manifest.test.js
+++ b/cloud-deploy/test/manifests/build-manifest.test.js
@@ -60,6 +60,7 @@ describe('buildManifest', () => {
         scaling: {
           cpu: 40,
         },
+        'termination-grace-period': 90,
       },
       security: 'none',
       labels: {
@@ -662,6 +663,7 @@ metadata:
           cpu: 40,
         },
         availability: 'low',
+        'termination-grace-period': 90,
       },
       security: 'none',
       labels: {


### PR DESCRIPTION
Introduce a setting for `terminationGracePeriodSeconds` in the GKE manifest. This allows teams to specify a longer grace period than the default 90s.