### PR TITLE
feat(cloud-deploy-plan): Show current value in plan

### DIFF
--- a/cloud-deploy-plan/src/create-comment.js
+++ b/cloud-deploy-plan/src/create-comment.js
@@ -94,11 +94,17 @@ const createComment = (filename, deployInfo) => {
         (key) => !key.endsWith('Mappings'),
       );
       if (arrayNotEmpty(changes)) {
-        comment.push('| JSON property | New value |');
-        comment.push('|---|---|');
-        changes.forEach((key) =>
-          comment.push(`${key} | ${deployInfo.updates[key]} |`),
-        );
+        comment.push('| JSON property | New value | Current value |');
+        comment.push('|---|---|---|');
+        changes.forEach((key) => {
+          const value = deployInfo.updates[key];
+          let newValue = value;
+          let currentValue = '-';
+          if (Array.isArray(value)) {
+            [newValue, currentValue] = value;
+          }
+          comment.push(`${key} | ${newValue} | ${currentValue} |`);
+        });
         comment.push('');
       }
     }

--- a/cloud-deploy-plan/test/create-comment.test.js
+++ b/cloud-deploy-plan/test/create-comment.test.js
@@ -86,3 +86,14 @@ test('It includes vulnerabilities in comment', () => {
   });
   expect(comment).toContain('[CVE-2022-37434]');
 });
+
+test('It can create a comment with new and old values in changes', () => {
+  const comment = createComment('cloud-deploy.yaml', {
+    serviceName: 'checkout-service-manager-api',
+    updates: {
+      timeout: [600, 300],
+    },
+    vulnerabilities: false,
+  });
+  expect(comment).toContain('600 | 300');
+});


### PR DESCRIPTION
Update cloud-deploy-plan to include the current value and the updated (new) value in the JSON properties table. This PR supports the old response with a single new value as well as the future response with an array containing the new and current value.