### PR TITLE
fix(setup-gcloud): Create 1 hour GCP access token

### DIFF
--- a/binary-auth-attestation/dist/index.cjs
+++ b/binary-auth-attestation/dist/index.cjs
@@ -68878,16 +68878,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -68996,13 +68996,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69032,7 +69032,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69058,7 +69058,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69080,7 +69080,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69091,7 +69091,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69112,7 +69112,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99890,6 +99890,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99905,7 +99914,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99919,6 +99928,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -99958,7 +99972,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/cloud-deploy-plan/dist/index.cjs
+++ b/cloud-deploy-plan/dist/index.cjs
@@ -71043,16 +71043,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -71161,13 +71161,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -71197,7 +71197,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -71223,7 +71223,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -71245,7 +71245,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -71256,7 +71256,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -71277,7 +71277,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -102058,6 +102058,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -102073,7 +102082,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -102087,6 +102096,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -102126,7 +102140,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/cloud-deploy/dist/index.cjs
+++ b/cloud-deploy/dist/index.cjs
@@ -70288,16 +70288,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70406,13 +70406,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70442,7 +70442,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70468,7 +70468,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70490,7 +70490,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70501,7 +70501,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70522,7 +70522,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101311,6 +101311,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101326,7 +101335,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101340,6 +101349,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101387,7 +101401,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -101413,11 +101427,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -101435,7 +101449,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -101655,7 +101669,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/cloud-run-traffic/dist/index.cjs
+++ b/cloud-run-traffic/dist/index.cjs
@@ -61244,16 +61244,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61362,13 +61362,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61398,7 +61398,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61424,7 +61424,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61446,7 +61446,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61457,7 +61457,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61478,7 +61478,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92256,6 +92256,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92271,7 +92280,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92285,6 +92294,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92324,7 +92338,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/customer-config/dist/index.cjs
+++ b/customer-config/dist/index.cjs
@@ -84753,16 +84753,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -84871,13 +84871,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -84907,7 +84907,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -84933,7 +84933,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -84955,7 +84955,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -84966,7 +84966,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -84987,7 +84987,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -115776,6 +115776,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -115791,7 +115800,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -115805,6 +115814,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -115852,7 +115866,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -115878,11 +115892,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -115900,7 +115914,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -116120,7 +116134,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/dataflow-deploy/dist/index.cjs
+++ b/dataflow-deploy/dist/index.cjs
@@ -61300,16 +61300,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61418,13 +61418,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61454,7 +61454,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61480,7 +61480,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61502,7 +61502,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61513,7 +61513,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61534,7 +61534,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92312,6 +92312,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92327,7 +92336,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92341,6 +92350,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92380,7 +92394,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/dataflow-template-build/dist/index.cjs
+++ b/dataflow-template-build/dist/index.cjs
@@ -61244,16 +61244,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61362,13 +61362,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61398,7 +61398,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61424,7 +61424,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61446,7 +61446,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61457,7 +61457,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61478,7 +61478,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92256,6 +92256,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92271,7 +92280,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92285,6 +92294,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92324,7 +92338,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/external-events/dist/index.cjs
+++ b/external-events/dist/index.cjs
@@ -81861,16 +81861,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -81979,13 +81979,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -82015,7 +82015,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -82041,7 +82041,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -82063,7 +82063,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -82074,7 +82074,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -82095,7 +82095,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -112884,6 +112884,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -112899,7 +112908,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -112913,6 +112922,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -112960,7 +112974,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -112986,11 +113000,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -113008,7 +113022,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -113228,7 +113242,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/gcp-secret-manager/dist/index.cjs
+++ b/gcp-secret-manager/dist/index.cjs
@@ -68802,16 +68802,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -68920,13 +68920,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -68956,7 +68956,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -68982,7 +68982,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69004,7 +69004,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69015,7 +69015,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69036,7 +69036,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99824,6 +99824,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99839,7 +99848,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99853,6 +99862,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -99900,7 +99914,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -99926,11 +99940,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -99948,7 +99962,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100168,7 +100182,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/iam-test-token/dist/index.cjs
+++ b/iam-test-token/dist/index.cjs
@@ -68802,16 +68802,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -68920,13 +68920,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -68956,7 +68956,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -68982,7 +68982,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69004,7 +69004,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69015,7 +69015,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69036,7 +69036,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99824,6 +99824,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99839,7 +99848,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99853,6 +99862,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -99900,7 +99914,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -99926,11 +99940,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -99948,7 +99962,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100168,7 +100182,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/iam/dist/index.cjs
+++ b/iam/dist/index.cjs
@@ -70180,16 +70180,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70298,13 +70298,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70334,7 +70334,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70360,7 +70360,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70382,7 +70382,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70393,7 +70393,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70414,7 +70414,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101202,6 +101202,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101217,7 +101226,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101231,6 +101240,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101278,7 +101292,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -101304,11 +101318,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -101326,7 +101340,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -101546,7 +101560,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/identity-token/dist/index.cjs
+++ b/identity-token/dist/index.cjs
@@ -61244,16 +61244,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61362,13 +61362,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61398,7 +61398,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61424,7 +61424,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61446,7 +61446,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61457,7 +61457,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61478,7 +61478,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92256,6 +92256,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92271,7 +92280,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92285,6 +92294,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92324,7 +92338,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/kubernetes/dist/index.cjs
+++ b/kubernetes/dist/index.cjs
@@ -70593,16 +70593,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70711,13 +70711,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70747,7 +70747,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70773,7 +70773,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70795,7 +70795,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70806,7 +70806,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70827,7 +70827,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101605,6 +101605,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101620,7 +101629,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101634,6 +101643,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101673,7 +101687,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/nexus-auth-npm/dist/index.cjs
+++ b/nexus-auth-npm/dist/index.cjs
@@ -68814,16 +68814,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -68932,13 +68932,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -68968,7 +68968,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -68994,7 +68994,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69016,7 +69016,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69027,7 +69027,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69048,7 +69048,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99836,6 +99836,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99851,7 +99860,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99865,6 +99874,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -99912,7 +99926,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -99938,11 +99952,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -99960,7 +99974,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100180,7 +100194,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -68803,16 +68803,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -68921,13 +68921,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -68957,7 +68957,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -68983,7 +68983,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69005,7 +69005,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69016,7 +69016,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69037,7 +69037,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99815,6 +99815,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99830,7 +99839,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99844,6 +99853,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -99883,7 +99897,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/repository-dispatch/dist/index.cjs
+++ b/repository-dispatch/dist/index.cjs
@@ -73543,16 +73543,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -73661,13 +73661,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -73697,7 +73697,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -73723,7 +73723,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -73745,7 +73745,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -73756,7 +73756,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -73777,7 +73777,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -104568,6 +104568,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -104583,7 +104592,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -104597,6 +104606,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -104644,7 +104658,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -104670,11 +104684,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -104692,7 +104706,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -104912,7 +104926,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/setup-gcloud/dist/index.cjs
+++ b/setup-gcloud/dist/index.cjs
@@ -61244,16 +61244,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61362,13 +61362,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61398,7 +61398,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61424,7 +61424,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61446,7 +61446,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61457,7 +61457,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61478,7 +61478,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92256,6 +92256,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92271,7 +92280,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92285,6 +92294,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92324,7 +92338,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -25,6 +25,911 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
+// node_modules/ms/index.js
+var require_ms = __commonJS({
+  "node_modules/ms/index.js"(exports2, module2) {
+    var s = 1e3;
+    var m = s * 60;
+    var h = m * 60;
+    var d = h * 24;
+    var w = d * 7;
+    var y = d * 365.25;
+    module2.exports = function(val, options) {
+      options = options || {};
+      var type = typeof val;
+      if (type === "string" && val.length > 0) {
+        return parse(val);
+      } else if (type === "number" && isFinite(val)) {
+        return options.long ? fmtLong(val) : fmtShort(val);
+      }
+      throw new Error(
+        "val is not a non-empty string or a valid number. val=" + JSON.stringify(val)
+      );
+    };
+    function parse(str) {
+      str = String(str);
+      if (str.length > 100) {
+        return;
+      }
+      var match = /^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.
+      exec(
+        str
+      );
+      if (!match) {
+        return;
+      }
+      var n = parseFloat(match[1]);
+      var type = (match[2] || "ms").toLowerCase();
+      switch (type) {
+        case "years":
+        case "year":
+        case "yrs":
+        case "yr":
+        case "y":
+          return n * y;
+        case "weeks":
+        case "week":
+        case "w":
+          return n * w;
+        case "days":
+        case "day":
+        case "d":
+          return n * d;
+        case "hours":
+        case "hour":
+        case "hrs":
+        case "hr":
+        case "h":
+          return n * h;
+        case "minutes":
+        case "minute":
+        case "mins":
+        case "min":
+        case "m":
+          return n * m;
+        case "seconds":
+        case "second":
+        case "secs":
+        case "sec":
+        case "s":
+          return n * s;
+        case "milliseconds":
+        case "millisecond":
+        case "msecs":
+        case "msec":
+        case "ms":
+          return n;
+        default:
+          return void 0;
+      }
+    }
+    __name(parse, "parse");
+    function fmtShort(ms) {
+      var msAbs = Math.abs(ms);
+      if (msAbs >= d) {
+        return Math.round(ms / d) + "d";
+      }
+      if (msAbs >= h) {
+        return Math.round(ms / h) + "h";
+      }
+      if (msAbs >= m) {
+        return Math.round(ms / m) + "m";
+      }
+      if (msAbs >= s) {
+        return Math.round(ms / s) + "s";
+      }
+      return ms + "ms";
+    }
+    __name(fmtShort, "fmtShort");
+    function fmtLong(ms) {
+      var msAbs = Math.abs(ms);
+      if (msAbs >= d) {
+        return plural(ms, msAbs, d, "day");
+      }
+      if (msAbs >= h) {
+        return plural(ms, msAbs, h, "hour");
+      }
+      if (msAbs >= m) {
+        return plural(ms, msAbs, m, "minute");
+      }
+      if (msAbs >= s) {
+        return plural(ms, msAbs, s, "second");
+      }
+      return ms + " ms";
+    }
+    __name(fmtLong, "fmtLong");
+    function plural(ms, msAbs, n, name) {
+      var isPlural = msAbs >= n * 1.5;
+      return Math.round(ms / n) + " " + name + (isPlural ? "s" : "");
+    }
+    __name(plural, "plural");
+  }
+});
+
+// node_modules/debug/src/common.js
+var require_common = __commonJS({
+  "node_modules/debug/src/common.js"(exports2, module2) {
+    function setup(env2) {
+      createDebug.debug = createDebug;
+      createDebug.default = createDebug;
+      createDebug.coerce = coerce;
+      createDebug.disable = disable;
+      createDebug.enable = enable;
+      createDebug.enabled = enabled;
+      createDebug.humanize = require_ms();
+      createDebug.destroy = destroy;
+      Object.keys(env2).forEach((key) => {
+        createDebug[key] = env2[key];
+      });
+      createDebug.names = [];
+      createDebug.skips = [];
+      createDebug.formatters = {};
+      function selectColor(namespace) {
+        let hash = 0;
+        for (let i = 0; i < namespace.length; i++) {
+          hash = (hash << 5) - hash + namespace.charCodeAt(i);
+          hash |= 0;
+        }
+        return createDebug.colors[Math.abs(hash) % createDebug.colors.length];
+      }
+      __name(selectColor, "selectColor");
+      createDebug.selectColor = selectColor;
+      function createDebug(namespace) {
+        let prevTime;
+        let enableOverride = null;
+        let namespacesCache;
+        let enabledCache;
+        function debug3(...args) {
+          if (!debug3.enabled) {
+            return;
+          }
+          const self = debug3;
+          const curr = Number(/* @__PURE__ */ new Date());
+          const ms = curr - (prevTime || curr);
+          self.diff = ms;
+          self.prev = prevTime;
+          self.curr = curr;
+          prevTime = curr;
+          args[0] = createDebug.coerce(args[0]);
+          if (typeof args[0] !== "string") {
+            args.unshift("%O");
+          }
+          let index = 0;
+          args[0] = args[0].replace(/%([a-zA-Z%])/g, (match, format) => {
+            if (match === "%%") {
+              return "%";
+            }
+            index++;
+            const formatter = createDebug.formatters[format];
+            if (typeof formatter === "function") {
+              const val = args[index];
+              match = formatter.call(self, val);
+              args.splice(index, 1);
+              index--;
+            }
+            return match;
+          });
+          createDebug.formatArgs.call(self, args);
+          const logFn = self.log || createDebug.log;
+          logFn.apply(self, args);
+        }
+        __name(debug3, "debug");
+        debug3.namespace = namespace;
+        debug3.useColors = createDebug.useColors();
+        debug3.color = createDebug.selectColor(namespace);
+        debug3.extend = extend;
+        debug3.destroy = createDebug.destroy;
+        Object.defineProperty(debug3, "enabled", {
+          enumerable: true,
+          configurable: false,
+          get: /* @__PURE__ */ __name(() => {
+            if (enableOverride !== null) {
+              return enableOverride;
+            }
+            if (namespacesCache !== createDebug.namespaces) {
+              namespacesCache = createDebug.namespaces;
+              enabledCache = createDebug.enabled(namespace);
+            }
+            return enabledCache;
+          }, "get"),
+          set: /* @__PURE__ */ __name((v) => {
+            enableOverride = v;
+          }, "set")
+        });
+        if (typeof createDebug.init === "function") {
+          createDebug.init(debug3);
+        }
+        return debug3;
+      }
+      __name(createDebug, "createDebug");
+      function extend(namespace, delimiter2) {
+        const newDebug = createDebug(this.namespace + (typeof delimiter2 === "undefined" ? ":" : delimiter2) + namespace);
+        newDebug.log = this.log;
+        return newDebug;
+      }
+      __name(extend, "extend");
+      function enable(namespaces) {
+        createDebug.save(namespaces);
+        createDebug.namespaces = namespaces;
+        createDebug.names = [];
+        createDebug.skips = [];
+        const split = (typeof namespaces === "string" ? namespaces : "").trim().replace(/\s+/g, ",").split(",").filter(Boolean);
+        for (const ns of split) {
+          if (ns[0] === "-") {
+            createDebug.skips.push(ns.slice(1));
+          } else {
+            createDebug.names.push(ns);
+          }
+        }
+      }
+      __name(enable, "enable");
+      function matchesTemplate(search, template) {
+        let searchIndex = 0;
+        let templateIndex = 0;
+        let starIndex = -1;
+        let matchIndex = 0;
+        while (searchIndex < search.length) {
+          if (templateIndex < template.length && (template[templateIndex] === search[searchIndex] || template[templateIndex] ===
+          "*")) {
+            if (template[templateIndex] === "*") {
+              starIndex = templateIndex;
+              matchIndex = searchIndex;
+              templateIndex++;
+            } else {
+              searchIndex++;
+              templateIndex++;
+            }
+          } else if (starIndex !== -1) {
+            templateIndex = starIndex + 1;
+            matchIndex++;
+            searchIndex = matchIndex;
+          } else {
+            return false;
+          }
+        }
+        while (templateIndex < template.length && template[templateIndex] === "*") {
+          templateIndex++;
+        }
+        return templateIndex === template.length;
+      }
+      __name(matchesTemplate, "matchesTemplate");
+      function disable() {
+        const namespaces = [
+          ...createDebug.names,
+          ...createDebug.skips.map((namespace) => "-" + namespace)
+        ].join(",");
+        createDebug.enable("");
+        return namespaces;
+      }
+      __name(disable, "disable");
+      function enabled(name) {
+        for (const skip of createDebug.skips) {
+          if (matchesTemplate(name, skip)) {
+            return false;
+          }
+        }
+        for (const ns of createDebug.names) {
+          if (matchesTemplate(name, ns)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      __name(enabled, "enabled");
+      function coerce(val) {
+        if (val instanceof Error) {
+          return val.stack || val.message;
+        }
+        return val;
+      }
+      __name(coerce, "coerce");
+      function destroy() {
+        console.warn("Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in\
+ the next major version of `debug`.");
+      }
+      __name(destroy, "destroy");
+      createDebug.enable(createDebug.load());
+      return createDebug;
+    }
+    __name(setup, "setup");
+    module2.exports = setup;
+  }
+});
+
+// node_modules/debug/src/browser.js
+var require_browser = __commonJS({
+  "node_modules/debug/src/browser.js"(exports2, module2) {
+    exports2.formatArgs = formatArgs;
+    exports2.save = save;
+    exports2.load = load;
+    exports2.useColors = useColors;
+    exports2.storage = localstorage();
+    exports2.destroy = /* @__PURE__ */ (() => {
+      let warned = false;
+      return () => {
+        if (!warned) {
+          warned = true;
+          console.warn("Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed \
+in the next major version of `debug`.");
+        }
+      };
+    })();
+    exports2.colors = [
+      "#0000CC",
+      "#0000FF",
+      "#0033CC",
+      "#0033FF",
+      "#0066CC",
+      "#0066FF",
+      "#0099CC",
+      "#0099FF",
+      "#00CC00",
+      "#00CC33",
+      "#00CC66",
+      "#00CC99",
+      "#00CCCC",
+      "#00CCFF",
+      "#3300CC",
+      "#3300FF",
+      "#3333CC",
+      "#3333FF",
+      "#3366CC",
+      "#3366FF",
+      "#3399CC",
+      "#3399FF",
+      "#33CC00",
+      "#33CC33",
+      "#33CC66",
+      "#33CC99",
+      "#33CCCC",
+      "#33CCFF",
+      "#6600CC",
+      "#6600FF",
+      "#6633CC",
+      "#6633FF",
+      "#66CC00",
+      "#66CC33",
+      "#9900CC",
+      "#9900FF",
+      "#9933CC",
+      "#9933FF",
+      "#99CC00",
+      "#99CC33",
+      "#CC0000",
+      "#CC0033",
+      "#CC0066",
+      "#CC0099",
+      "#CC00CC",
+      "#CC00FF",
+      "#CC3300",
+      "#CC3333",
+      "#CC3366",
+      "#CC3399",
+      "#CC33CC",
+      "#CC33FF",
+      "#CC6600",
+      "#CC6633",
+      "#CC9900",
+      "#CC9933",
+      "#CCCC00",
+      "#CCCC33",
+      "#FF0000",
+      "#FF0033",
+      "#FF0066",
+      "#FF0099",
+      "#FF00CC",
+      "#FF00FF",
+      "#FF3300",
+      "#FF3333",
+      "#FF3366",
+      "#FF3399",
+      "#FF33CC",
+      "#FF33FF",
+      "#FF6600",
+      "#FF6633",
+      "#FF9900",
+      "#FF9933",
+      "#FFCC00",
+      "#FFCC33"
+    ];
+    function useColors() {
+      if (typeof window !== "undefined" && window.process && (window.process.type === "renderer" || window.process.__nwjs)) {
+        return true;
+      }
+      if (typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/(edge|trident)\/(\d+)/)) {
+        return false;
+      }
+      let m;
+      return typeof document !== "undefined" && document.documentElement && document.documentElement.style && document.documentElement.
+      style.WebkitAppearance || // Is firebug? http://stackoverflow.com/a/398120/376773
+      typeof window !== "undefined" && window.console && (window.console.firebug || window.console.exception && window.console.
+      table) || // Is firefox >= v31?
+      // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
+      typeof navigator !== "undefined" && navigator.userAgent && (m = navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/)) &&
+      parseInt(m[1], 10) >= 31 || // Double check webkit in userAgent just in case we are in a worker
+      typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/);
+    }
+    __name(useColors, "useColors");
+    function formatArgs(args) {
+      args[0] = (this.useColors ? "%c" : "") + this.namespace + (this.useColors ? " %c" : " ") + args[0] + (this.useColors ?
+      "%c " : " ") + "+" + module2.exports.humanize(this.diff);
+      if (!this.useColors) {
+        return;
+      }
+      const c = "color: " + this.color;
+      args.splice(1, 0, c, "color: inherit");
+      let index = 0;
+      let lastC = 0;
+      args[0].replace(/%[a-zA-Z%]/g, (match) => {
+        if (match === "%%") {
+          return;
+        }
+        index++;
+        if (match === "%c") {
+          lastC = index;
+        }
+      });
+      args.splice(lastC, 0, c);
+    }
+    __name(formatArgs, "formatArgs");
+    exports2.log = console.debug || console.log || (() => {
+    });
+    function save(namespaces) {
+      try {
+        if (namespaces) {
+          exports2.storage.setItem("debug", namespaces);
+        } else {
+          exports2.storage.removeItem("debug");
+        }
+      } catch (error2) {
+      }
+    }
+    __name(save, "save");
+    function load() {
+      let r;
+      try {
+        r = exports2.storage.getItem("debug") || exports2.storage.getItem("DEBUG");
+      } catch (error2) {
+      }
+      if (!r && typeof process !== "undefined" && "env" in process) {
+        r = process.env.DEBUG;
+      }
+      return r;
+    }
+    __name(load, "load");
+    function localstorage() {
+      try {
+        return localStorage;
+      } catch (error2) {
+      }
+    }
+    __name(localstorage, "localstorage");
+    module2.exports = require_common()(exports2);
+    var { formatters } = module2.exports;
+    formatters.j = function(v) {
+      try {
+        return JSON.stringify(v);
+      } catch (error2) {
+        return "[UnexpectedJSONParseError]: " + error2.message;
+      }
+    };
+  }
+});
+
+// node_modules/has-flag/index.js
+var require_has_flag = __commonJS({
+  "node_modules/has-flag/index.js"(exports2, module2) {
+    "use strict";
+    module2.exports = (flag, argv = process.argv) => {
+      const prefix = flag.startsWith("-") ? "" : flag.length === 1 ? "-" : "--";
+      const position = argv.indexOf(prefix + flag);
+      const terminatorPosition = argv.indexOf("--");
+      return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
+    };
+  }
+});
+
+// node_modules/supports-color/index.js
+var require_supports_color = __commonJS({
+  "node_modules/supports-color/index.js"(exports2, module2) {
+    "use strict";
+    var os7 = require("os");
+    var tty = require("tty");
+    var hasFlag = require_has_flag();
+    var { env: env2 } = process;
+    var forceColor;
+    if (hasFlag("no-color") || hasFlag("no-colors") || hasFlag("color=false") || hasFlag("color=never")) {
+      forceColor = 0;
+    } else if (hasFlag("color") || hasFlag("colors") || hasFlag("color=true") || hasFlag("color=always")) {
+      forceColor = 1;
+    }
+    if ("FORCE_COLOR" in env2) {
+      if (env2.FORCE_COLOR === "true") {
+        forceColor = 1;
+      } else if (env2.FORCE_COLOR === "false") {
+        forceColor = 0;
+      } else {
+        forceColor = env2.FORCE_COLOR.length === 0 ? 1 : Math.min(parseInt(env2.FORCE_COLOR, 10), 3);
+      }
+    }
+    function translateLevel(level) {
+      if (level === 0) {
+        return false;
+      }
+      return {
+        level,
+        hasBasic: true,
+        has256: level >= 2,
+        has16m: level >= 3
+      };
+    }
+    __name(translateLevel, "translateLevel");
+    function supportsColor(haveStream, streamIsTTY) {
+      if (forceColor === 0) {
+        return 0;
+      }
+      if (hasFlag("color=16m") || hasFlag("color=full") || hasFlag("color=truecolor")) {
+        return 3;
+      }
+      if (hasFlag("color=256")) {
+        return 2;
+      }
+      if (haveStream && !streamIsTTY && forceColor === void 0) {
+        return 0;
+      }
+      const min = forceColor || 0;
+      if (env2.TERM === "dumb") {
+        return min;
+      }
+      if (process.platform === "win32") {
+        const osRelease = os7.release().split(".");
+        if (Number(osRelease[0]) >= 10 && Number(osRelease[2]) >= 10586) {
+          return Number(osRelease[2]) >= 14931 ? 3 : 2;
+        }
+        return 1;
+      }
+      if ("CI" in env2) {
+        if (["TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "BUILDKITE"].some((sign) => sign in env2) ||
+        env2.CI_NAME === "codeship") {
+          return 1;
+        }
+        return min;
+      }
+      if ("TEAMCITY_VERSION" in env2) {
+        return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env2.TEAMCITY_VERSION) ? 1 : 0;
+      }
+      if (env2.COLORTERM === "truecolor") {
+        return 3;
+      }
+      if ("TERM_PROGRAM" in env2) {
+        const version = parseInt((env2.TERM_PROGRAM_VERSION || "").split(".")[0], 10);
+        switch (env2.TERM_PROGRAM) {
+          case "iTerm.app":
+            return version >= 3 ? 3 : 2;
+          case "Apple_Terminal":
+            return 2;
+        }
+      }
+      if (/-256(color)?$/i.test(env2.TERM)) {
+        return 2;
+      }
+      if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env2.TERM)) {
+        return 1;
+      }
+      if ("COLORTERM" in env2) {
+        return 1;
+      }
+      return min;
+    }
+    __name(supportsColor, "supportsColor");
+    function getSupportLevel(stream) {
+      const level = supportsColor(stream, stream && stream.isTTY);
+      return translateLevel(level);
+    }
+    __name(getSupportLevel, "getSupportLevel");
+    module2.exports = {
+      supportsColor: getSupportLevel,
+      stdout: translateLevel(supportsColor(true, tty.isatty(1))),
+      stderr: translateLevel(supportsColor(true, tty.isatty(2)))
+    };
+  }
+});
+
+// node_modules/debug/src/node.js
+var require_node = __commonJS({
+  "node_modules/debug/src/node.js"(exports2, module2) {
+    var tty = require("tty");
+    var util = require("util");
+    exports2.init = init;
+    exports2.log = log;
+    exports2.formatArgs = formatArgs;
+    exports2.save = save;
+    exports2.load = load;
+    exports2.useColors = useColors;
+    exports2.destroy = util.deprecate(
+      () => {
+      },
+      "Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major\
+ version of `debug`."
+    );
+    exports2.colors = [6, 2, 3, 4, 5, 1];
+    try {
+      const supportsColor = require_supports_color();
+      if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
+        exports2.colors = [
+          20,
+          21,
+          26,
+          27,
+          32,
+          33,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          56,
+          57,
+          62,
+          63,
+          68,
+          69,
+          74,
+          75,
+          76,
+          77,
+          78,
+          79,
+          80,
+          81,
+          92,
+          93,
+          98,
+          99,
+          112,
+          113,
+          128,
+          129,
+          134,
+          135,
+          148,
+          149,
+          160,
+          161,
+          162,
+          163,
+          164,
+          165,
+          166,
+          167,
+          168,
+          169,
+          170,
+          171,
+          172,
+          173,
+          178,
+          179,
+          184,
+          185,
+          196,
+          197,
+          198,
+          199,
+          200,
+          201,
+          202,
+          203,
+          204,
+          205,
+          206,
+          207,
+          208,
+          209,
+          214,
+          215,
+          220,
+          221
+        ];
+      }
+    } catch (error2) {
+    }
+    exports2.inspectOpts = Object.keys(process.env).filter((key) => {
+      return /^debug_/i.test(key);
+    }).reduce((obj, key) => {
+      const prop = key.substring(6).toLowerCase().replace(/_([a-z])/g, (_, k) => {
+        return k.toUpperCase();
+      });
+      let val = process.env[key];
+      if (/^(yes|on|true|enabled)$/i.test(val)) {
+        val = true;
+      } else if (/^(no|off|false|disabled)$/i.test(val)) {
+        val = false;
+      } else if (val === "null") {
+        val = null;
+      } else {
+        val = Number(val);
+      }
+      obj[prop] = val;
+      return obj;
+    }, {});
+    function useColors() {
+      return "colors" in exports2.inspectOpts ? Boolean(exports2.inspectOpts.colors) : tty.isatty(process.stderr.fd);
+    }
+    __name(useColors, "useColors");
+    function formatArgs(args) {
+      const { namespace: name, useColors: useColors2 } = this;
+      if (useColors2) {
+        const c = this.color;
+        const colorCode = "\x1B[3" + (c < 8 ? c : "8;5;" + c);
+        const prefix = `  ${colorCode};1m${name} \x1B[0m`;
+        args[0] = prefix + args[0].split("\n").join("\n" + prefix);
+        args.push(colorCode + "m+" + module2.exports.humanize(this.diff) + "\x1B[0m");
+      } else {
+        args[0] = getDate() + name + " " + args[0];
+      }
+    }
+    __name(formatArgs, "formatArgs");
+    function getDate() {
+      if (exports2.inspectOpts.hideDate) {
+        return "";
+      }
+      return (/* @__PURE__ */ new Date()).toISOString() + " ";
+    }
+    __name(getDate, "getDate");
+    function log(...args) {
+      return process.stderr.write(util.formatWithOptions(exports2.inspectOpts, ...args) + "\n");
+    }
+    __name(log, "log");
+    function save(namespaces) {
+      if (namespaces) {
+        process.env.DEBUG = namespaces;
+      } else {
+        delete process.env.DEBUG;
+      }
+    }
+    __name(save, "save");
+    function load() {
+      return process.env.DEBUG;
+    }
+    __name(load, "load");
+    function init(debug3) {
+      debug3.inspectOpts = {};
+      const keys = Object.keys(exports2.inspectOpts);
+      for (let i = 0; i < keys.length; i++) {
+        debug3.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
+      }
+    }
+    __name(init, "init");
+    module2.exports = require_common()(exports2);
+    var { formatters } = module2.exports;
+    formatters.o = function(v) {
+      this.inspectOpts.colors = this.useColors;
+      return util.inspect(v, this.inspectOpts).split("\n").map((str) => str.trim()).join(" ");
+    };
+    formatters.O = function(v) {
+      this.inspectOpts.colors = this.useColors;
+      return util.inspect(v, this.inspectOpts);
+    };
+  }
+});
+
+// node_modules/debug/src/index.js
+var require_src = __commonJS({
+  "node_modules/debug/src/index.js"(exports2, module2) {
+    if (typeof process === "undefined" || process.type === "renderer" || process.browser === true || process.__nwjs) {
+      module2.exports = require_browser();
+    } else {
+      module2.exports = require_node();
+    }
+  }
+});
+
+// node_modules/@kwsites/file-exists/dist/src/index.js
+var require_src2 = __commonJS({
+  "node_modules/@kwsites/file-exists/dist/src/index.js"(exports2) {
+    "use strict";
+    var __importDefault = exports2 && exports2.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var fs_1 = require("fs");
+    var debug_1 = __importDefault(require_src());
+    var log = debug_1.default("@kwsites/file-exists");
+    function check(path5, isFile, isDirectory2) {
+      log(`checking %s`, path5);
+      try {
+        const stat2 = fs_1.statSync(path5);
+        if (stat2.isFile() && isFile) {
+          log(`[OK] path represents a file`);
+          return true;
+        }
+        if (stat2.isDirectory() && isDirectory2) {
+          log(`[OK] path represents a directory`);
+          return true;
+        }
+        log(`[FAIL] path represents something other than a file or directory`);
+        return false;
+      } catch (e) {
+        if (e.code === "ENOENT") {
+          log(`[FAIL] path is not accessible: %o`, e);
+          return false;
+        }
+        log(`[FATAL] %o`, e);
+        throw e;
+      }
+    }
+    __name(check, "check");
+    function exists3(path5, type = exports2.READABLE) {
+      return check(path5, (type & exports2.FILE) > 0, (type & exports2.FOLDER) > 0);
+    }
+    __name(exists3, "exists");
+    exports2.exists = exists3;
+    exports2.FILE = 1;
+    exports2.FOLDER = 2;
+    exports2.READABLE = exports2.FILE + exports2.FOLDER;
+  }
+});
+
+// node_modules/@kwsites/file-exists/dist/index.js
+var require_dist = __commonJS({
+  "node_modules/@kwsites/file-exists/dist/index.js"(exports2) {
+    "use strict";
+    function __export2(m) {
+      for (var p in m) if (!exports2.hasOwnProperty(p)) exports2[p] = m[p];
+    }
+    __name(__export2, "__export");
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    __export2(require_src2());
+  }
+});
+
+// node_modules/@kwsites/promise-deferred/dist/index.js
+var require_dist2 = __commonJS({
+  "node_modules/@kwsites/promise-deferred/dist/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.createDeferred = exports2.deferred = void 0;
+    function deferred2() {
+      let done;
+      let fail;
+      let status = "pending";
+      const promise = new Promise((_done, _fail) => {
+        done = _done;
+        fail = _fail;
+      });
+      return {
+        promise,
+        done(result) {
+          if (status === "pending") {
+            status = "resolved";
+            done(result);
+          }
+        },
+        fail(error2) {
+          if (status === "pending") {
+            status = "rejected";
+            fail(error2);
+          }
+        },
+        get fulfilled() {
+          return status !== "pending";
+        },
+        get status() {
+          return status;
+        }
+      };
+    }
+    __name(deferred2, "deferred");
+    exports2.deferred = deferred2;
+    exports2.createDeferred = deferred2;
+    exports2.default = deferred2;
+  }
+});
+
 // node_modules/tunnel/lib/tunnel.js
 var require_tunnel = __commonJS({
   "node_modules/tunnel/lib/tunnel.js"(exports2) {
@@ -135,13 +1040,13 @@ var require_tunnel = __commonJS({
         connectOptions.headers = connectOptions.headers || {};
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
-      debug2("making CONNECT request");
+      debug3("making CONNECT request");
       var connectReq = self.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
       connectReq.once("upgrade", onUpgrade);
       connectReq.once("connect", onConnect);
-      connectReq.once("error", onError);
+      connectReq.once("error", onError2);
       connectReq.end();
       function onResponse(res) {
         res.upgrade = true;
@@ -157,44 +1062,44 @@ var require_tunnel = __commonJS({
         connectReq.removeAllListeners();
         socket.removeAllListeners();
         if (res.statusCode !== 200) {
-          debug2(
+          debug3(
             "tunneling socket could not be established, statusCode=%d",
             res.statusCode
           );
           socket.destroy();
-          var error = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
-          debug2("got illegal response body from proxy");
+          debug3("got illegal response body from proxy");
           socket.destroy();
-          var error = new Error("got illegal response body from proxy");
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("got illegal response body from proxy");
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
-        debug2("tunneling connection has established");
+        debug3("tunneling connection has established");
         self.sockets[self.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       __name(onConnect, "onConnect");
-      function onError(cause) {
+      function onError2(cause) {
         connectReq.removeAllListeners();
-        debug2(
+        debug3(
           "tunneling socket could not be established, cause=%s\n",
           cause.message,
           cause.stack
         );
-        var error = new Error("tunneling socket could not be established, cause=" + cause.message);
-        error.code = "ECONNRESET";
-        options.request.emit("error", error);
+        var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
+        error2.code = "ECONNRESET";
+        options.request.emit("error", error2);
         self.removeSocket(placeholder);
       }
-      __name(onError, "onError");
+      __name(onError2, "onError");
     }, "createSocket");
     TunnelingAgent.prototype.removeSocket = /* @__PURE__ */ __name(function removeSocket(socket) {
       var pos = this.sockets.indexOf(socket);
@@ -250,9 +1155,9 @@ var require_tunnel = __commonJS({
       return target;
     }
     __name(mergeOptions, "mergeOptions");
-    var debug2;
+    var debug3;
     if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-      debug2 = /* @__PURE__ */ __name(function() {
+      debug3 = /* @__PURE__ */ __name(function() {
         var args = Array.prototype.slice.call(arguments);
         if (typeof args[0] === "string") {
           args[0] = "TUNNEL: " + args[0];
@@ -262,10 +1167,10 @@ var require_tunnel = __commonJS({
         console.error.apply(console, args);
       }, "debug");
     } else {
-      debug2 = /* @__PURE__ */ __name(function() {
+      debug3 = /* @__PURE__ */ __name(function() {
       }, "debug");
     }
-    exports2.debug = debug2;
+    exports2.debug = debug3;
   }
 });
 
@@ -1657,14 +2562,14 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
         const {
           connectParams: { version, protocol, port, host },
-          error
+          error: error2
         } = evt;
         debuglog(
           "connection to %s using %s%s errored - %s",
           `${host}${port ? `:${port}` : ""}`,
           protocol,
           version,
-          error.message
+          error2.message
         );
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
@@ -1695,14 +2600,14 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
           request: { method, path: path5, origin },
-          error
+          error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
           path5,
-          error.message
+          error2.message
         );
       });
       isClientSet = true;
@@ -1737,7 +2642,7 @@ var require_diagnostics = __commonJS({
         diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
           const {
             connectParams: { version, protocol, port, host },
-            error
+            error: error2
           } = evt;
           debuglog(
             "connection to %s%s using %s%s errored - %s",
@@ -1745,7 +2650,7 @@ var require_diagnostics = __commonJS({
             port ? `:${port}` : "",
             protocol,
             version,
-            error.message
+            error2.message
           );
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
@@ -2020,16 +2925,16 @@ terable");
           this.onError(err);
         }
       }
-      onError(error) {
+      onError(error2) {
         this.onFinally();
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       onFinally() {
         if (this.errorHandler) {
@@ -2458,9 +3363,9 @@ var require_timers = __commonJS({
        * before the specified function or code is executed.
        * @param {*} arg
        */
-      constructor(callback, delay, arg) {
+      constructor(callback, delay2, arg) {
         this._onTimeout = callback;
-        this._idleTimeout = delay;
+        this._idleTimeout = delay2;
         this._timerArg = arg;
         this.refresh();
       }
@@ -2505,8 +3410,8 @@ var require_timers = __commonJS({
        * when the timer expires.
        * @returns {NodeJS.Timeout|FastTimer}
        */
-      setTimeout(callback, delay, arg) {
-        return delay <= RESOLUTION_MS ? setTimeout(callback, delay, arg) : new FastTimer(callback, delay, arg);
+      setTimeout(callback, delay2, arg) {
+        return delay2 <= RESOLUTION_MS ? setTimeout(callback, delay2, arg) : new FastTimer(callback, delay2, arg);
       },
       /**
        * The clearTimeout method cancels an instantiated Timer previously created
@@ -2532,8 +3437,8 @@ var require_timers = __commonJS({
        * when the timer expires.
        * @returns {FastTimer}
        */
-      setFastTimeout(callback, delay, arg) {
-        return new FastTimer(callback, delay, arg);
+      setFastTimeout(callback, delay2, arg) {
+        return new FastTimer(callback, delay2, arg);
       },
       /**
        * The clearTimeout method cancels an instantiated FastTimer previously
@@ -2559,8 +3464,8 @@ var require_timers = __commonJS({
        * @deprecated
        * @param {number} [delay=0] The delay in milliseconds to add to the now value.
        */
-      tick(delay = 0) {
-        fastNow += delay - RESOLUTION_MS + 1;
+      tick(delay2 = 0) {
+        fastNow += delay2 - RESOLUTION_MS + 1;
         onTick();
         onTick();
       },
@@ -3126,8 +4031,8 @@ var require_constants2 = __commonJS({
 var require_llhttp_wasm = __commonJS({
   "node_modules/undici/lib/llhttp/llhttp-wasm.js"(exports2, module2) {
     "use strict";
-    var { Buffer: Buffer2 } = require("node:buffer");
-    module2.exports = Buffer2.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
+    var { Buffer: Buffer3 } = require("node:buffer");
+    module2.exports = Buffer3.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
 b25faGVhZGVyc19jb21wbGV0ZQAEA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNl\
 bnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2Fn\
 ZV9jb21wbGV0ZQAAAy0sBQYAAAIAAAAAAAACAQIAAgICAAADAAAAAAMDAwMBAQEBAQEBAQEAAAIAAAAEBQFwARISBQMBAAIGCAF/AUGA1AQLB9EFIgZtZW1v\
@@ -3675,8 +4580,8 @@ RUJTQ1JJQkVBUkRPV05BQ0VJTkROS0NLVUJTQ1JJQkVIVFRQL0FEVFAv", "base64");
 var require_llhttp_simd_wasm = __commonJS({
   "node_modules/undici/lib/llhttp/llhttp_simd-wasm.js"(exports2, module2) {
     "use strict";
-    var { Buffer: Buffer2 } = require("node:buffer");
-    module2.exports = Buffer2.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
+    var { Buffer: Buffer3 } = require("node:buffer");
+    module2.exports = Buffer3.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
 b25faGVhZGVyc19jb21wbGV0ZQAEA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNl\
 bnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2Fn\
 ZV9jb21wbGV0ZQAAAy0sBQYAAAIAAAAAAAACAQIAAgICAAADAAAAAAMDAwMBAQEBAQEBAQEAAAIAAAAEBQFwARISBQMBAAIGCAF/AUGA1AQLB9EFIgZtZW1v\
@@ -5840,7 +6745,7 @@ ption");
           writable: true,
           enumerable: true,
           configurable: true,
-          value: /* @__PURE__ */ __name(function forEach(callbackfn, thisArg = globalThis) {
+          value: /* @__PURE__ */ __name(function forEach2(callbackfn, thisArg = globalThis) {
             webidl.brandCheck(this, object);
             webidl.argumentLengthCheck(arguments, 1, `${name}.forEach`);
             if (typeof callbackfn !== "function") {
@@ -6479,8 +7384,9 @@ var require_formdata_parser = __commonJS({
         return false;
       }
       for (let i = 0; i < length; ++i) {
-        const cp = boundary.charCodeAt(i);
-        if (!(cp >= 48 && cp <= 57 || cp >= 65 && cp <= 90 || cp >= 97 && cp <= 122 || cp === 39 || cp === 45 || cp === 95)) {
+        const cp2 = boundary.charCodeAt(i);
+        if (!(cp2 >= 48 && cp2 <= 57 || cp2 >= 65 && cp2 <= 90 || cp2 >= 97 && cp2 <= 122 || cp2 === 39 || cp2 === 45 ||
+        cp2 === 95)) {
           return false;
         }
       }
@@ -6990,7 +7896,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
       }
       throwIfAborted(object[kState]);
       const promise = createDeferredPromise();
-      const errorSteps = /* @__PURE__ */ __name((error) => promise.reject(error), "errorSteps");
+      const errorSteps = /* @__PURE__ */ __name((error2) => promise.reject(error2), "errorSteps");
       const successSteps = /* @__PURE__ */ __name((data) => {
         try {
           promise.resolve(convertBytesToJSValue(data));
@@ -7186,21 +8092,21 @@ var require_client_h1 = __commonJS({
         this.connection = "";
         this.maxResponseSize = client[kMaxResponseSize];
       }
-      setTimeout(delay, type) {
-        if (delay !== this.timeoutValue || type & USE_FAST_TIMER ^ this.timeoutType & USE_FAST_TIMER) {
+      setTimeout(delay2, type) {
+        if (delay2 !== this.timeoutValue || type & USE_FAST_TIMER ^ this.timeoutType & USE_FAST_TIMER) {
           if (this.timeout) {
             timers.clearTimeout(this.timeout);
             this.timeout = null;
           }
-          if (delay) {
+          if (delay2) {
             if (type & USE_FAST_TIMER) {
-              this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this));
+              this.timeout = timers.setFastTimeout(onParserTimeout, delay2, new WeakRef(this));
             } else {
-              this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this));
+              this.timeout = setTimeout(onParserTimeout, delay2, new WeakRef(this));
               this.timeout.unref();
             }
           }
-          this.timeoutValue = delay;
+          this.timeoutValue = delay2;
         } else if (this.timeout) {
           if (this.timeout.refresh) {
             this.timeout.refresh();
@@ -7519,8 +8425,8 @@ var require_client_h1 = __commonJS({
         }
       }
     };
-    function onParserTimeout(parser) {
-      const { socket, timeoutType, client, paused } = parser.deref();
+    function onParserTimeout(parser4) {
+      const { socket, timeoutType, client, paused } = parser4.deref();
       if (timeoutType === TIMEOUT_HEADERS) {
         if (!socket[kWriting] || socket.writableNeedDrain || client[kRunning] > 1) {
           assert(!paused, "cannot be paused while waiting for headers");
@@ -7549,34 +8455,34 @@ var require_client_h1 = __commonJS({
       socket[kParser] = new Parser(client, socket, llhttpInstance);
       addListener(socket, "error", function(err) {
         assert(err.code !== "ERR_TLS_CERT_ALTNAME_INVALID");
-        const parser = this[kParser];
-        if (err.code === "ECONNRESET" && parser.statusCode && !parser.shouldKeepAlive) {
-          parser.onMessageComplete();
+        const parser4 = this[kParser];
+        if (err.code === "ECONNRESET" && parser4.statusCode && !parser4.shouldKeepAlive) {
+          parser4.onMessageComplete();
           return;
         }
         this[kError] = err;
         this[kClient][kOnError](err);
       });
       addListener(socket, "readable", function() {
-        const parser = this[kParser];
-        if (parser) {
-          parser.readMore();
+        const parser4 = this[kParser];
+        if (parser4) {
+          parser4.readMore();
         }
       });
       addListener(socket, "end", function() {
-        const parser = this[kParser];
-        if (parser.statusCode && !parser.shouldKeepAlive) {
-          parser.onMessageComplete();
+        const parser4 = this[kParser];
+        if (parser4.statusCode && !parser4.shouldKeepAlive) {
+          parser4.onMessageComplete();
           return;
         }
         util.destroy(this, new SocketError("other side closed", util.getSocketInfo(this)));
       });
       addListener(socket, "close", function() {
         const client2 = this[kClient];
-        const parser = this[kParser];
-        if (parser) {
-          if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-            parser.onMessageComplete();
+        const parser4 = this[kParser];
+        if (parser4) {
+          if (!this[kError] && parser4.statusCode && !parser4.shouldKeepAlive) {
+            parser4.onMessageComplete();
           }
           this[kParser].destroy();
           this[kParser] = null;
@@ -8535,8 +9441,8 @@ var require_client_h2 = __commonJS({
         }
         request.onRequestSent();
         client[kResume]();
-      } catch (error) {
-        abort(error);
+      } catch (error2) {
+        abort(error2);
       }
     }
     __name(writeBuffer, "writeBuffer");
@@ -8704,8 +9610,8 @@ var require_redirect_handler = __commonJS({
       onUpgrade(statusCode, headers, socket) {
         this.handler.onUpgrade(statusCode, headers, socket);
       }
-      onError(error) {
-        this.handler.onError(error);
+      onError(error2) {
+        this.handler.onError(error2);
       }
       onHeaders(statusCode, headers, resume, statusText) {
         this.location = this.history.length >= this.maxRedirections || util.isDisturbed(this.opts.body) ? null : parseLocation(
@@ -9052,7 +9958,7 @@ var require_client = __commonJS({
         this[kRunningIdx] = 0;
         this[kPendingIdx] = 0;
         this[kResume] = (sync) => resume(this, sync);
-        this[kOnError] = (err) => onError(this, err);
+        this[kOnError] = (err) => onError2(this, err);
       }
       get pipelining() {
         return this[kPipelining];
@@ -9133,7 +10039,7 @@ var require_client = __commonJS({
       }
     };
     var createRedirectInterceptor = require_redirect_interceptor();
-    function onError(client, err) {
+    function onError2(client, err) {
       if (client[kRunning] === 0 && err.code !== "UND_ERR_INFO" && err.code !== "UND_ERR_SOCKET") {
         assert(client[kPendingIdx] === client[kRunningIdx]);
         const requests = client[kQueue].splice(client[kRunningIdx]);
@@ -9144,7 +10050,7 @@ var require_client = __commonJS({
         assert(client[kSize] === 0);
       }
     }
-    __name(onError, "onError");
+    __name(onError2, "onError");
     async function connect(client) {
       assert(!client[kConnecting]);
       assert(!client[kHTTPContext]);
@@ -9248,7 +10154,7 @@ var require_client = __commonJS({
             util.errorRequest(client, request, err);
           }
         } else {
-          onError(client, err);
+          onError2(client, err);
         }
         client.emit("connectionError", client[kUrl], [client], err);
       }
@@ -9669,7 +10575,7 @@ var require_pool = __commonJS({
         this[kOptions] = { ...util.deepClone(options), connect, allowH2 };
         this[kOptions].interceptors = options.interceptors ? { ...options.interceptors } : void 0;
         this[kFactory] = factory;
-        this.on("connectionError", (origin2, targets, error) => {
+        this.on("connectionError", (origin2, targets, error2) => {
           for (const target of targets) {
             const idx = this[kClients].indexOf(target);
             if (idx !== -1) {
@@ -12145,19 +13051,19 @@ var require_mock_utils = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay: delay2, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler.onError(error);
+        handler.onError(error2);
         return true;
       }
-      if (typeof delay === "number" && delay > 0) {
+      if (typeof delay2 === "number" && delay2 > 0) {
         setTimeout(() => {
           handleReply(this[kDispatches]);
-        }, delay);
+        }, delay2);
       } else {
         handleReply(this[kDispatches]);
       }
@@ -12192,21 +13098,21 @@ var require_mock_utils = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler);
-          } catch (error) {
-            if (error instanceof MockNotMatchedError) {
+          } catch (error2) {
+            if (error2 instanceof MockNotMatchedError) {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed \
-(net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed\
+ (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed \
-(net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed\
+ (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -12380,11 +13286,11 @@ var require_mock_interceptor = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -13387,12 +14293,12 @@ var require_headers = __commonJS({
       append(name, value, isLowerCase) {
         this[kHeadersSortedMap] = null;
         const lowercaseName = isLowerCase ? name : name.toLowerCase();
-        const exists2 = this[kHeadersMap].get(lowercaseName);
-        if (exists2) {
+        const exists3 = this[kHeadersMap].get(lowercaseName);
+        if (exists3) {
           const delimiter2 = lowercaseName === "cookie" ? "; " : ", ";
           this[kHeadersMap].set(lowercaseName, {
-            name: exists2.name,
-            value: `${exists2.value}${delimiter2}${value}`
+            name: exists3.name,
+            value: `${exists3.value}${delimiter2}${value}`
           });
         } else {
           this[kHeadersMap].set(lowercaseName, { name, value });
@@ -14288,15 +15194,15 @@ var require_request2 = __commonJS({
           signal = input[kSignal];
         }
         const origin = environmentSettingsObject.settingsObject.origin;
-        let window = "client";
+        let window2 = "client";
         if (request.window?.constructor?.name === "EnvironmentSettingsObject" && sameOrigin(request.window, origin)) {
-          window = request.window;
+          window2 = request.window;
         }
         if (init.window != null) {
-          throw new TypeError(`'window' option '${window}' must be null`);
+          throw new TypeError(`'window' option '${window2}' must be null`);
         }
         if ("window" in init) {
-          window = "no-window";
+          window2 = "no-window";
         }
         request = makeRequest({
           // URL request’s URL.
@@ -14311,7 +15217,7 @@ var require_request2 = __commonJS({
           // client This’s relevant settings object.
           client: environmentSettingsObject.settingsObject,
           // window window.
-          window,
+          window: window2,
           // priority request’s priority.
           priority: request.priority,
           // origin request’s origin. The propagation of the origin is only significant for navigation requests
@@ -14980,17 +15886,17 @@ var require_fetch = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     function handleFetchDone(response) {
@@ -15089,12 +15995,12 @@ var require_fetch = __commonJS({
     }
     __name(finalizeAndReportTiming, "finalizeAndReportTiming");
     var markResourceTiming = performance.markResourceTiming;
-    function abortFetch(p, request, responseObject, error) {
+    function abortFetch(p, request, responseObject, error2) {
       if (p) {
-        p.reject(error);
+        p.reject(error2);
       }
       if (request.body != null && isReadable(request.body?.stream)) {
-        request.body.stream.cancel(error).catch((err) => {
+        request.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -15106,7 +16012,7 @@ var require_fetch = __commonJS({
       }
       const response = responseObject[kState];
       if (response.body != null && isReadable(response.body?.stream)) {
-        response.body.stream.cancel(error).catch((err) => {
+        response.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -15916,7 +16822,7 @@ processBodyError");
                   }
                 }
               }
-              const onError = this.onError.bind(this);
+              const onError2 = this.onError.bind(this);
               resolve2({
                 status,
                 statusText,
@@ -15925,7 +16831,7 @@ processBodyError");
                   if (err) {
                     this.onError(err);
                   }
-                }).on("error", onError) : this.body.on("error", onError)
+                }).on("error", onError2) : this.body.on("error", onError2)
               });
               return true;
             },
@@ -15947,13 +16853,13 @@ processBodyError");
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onUpgrade(status, rawHeaders, socket) {
               if (status !== 101) {
@@ -16422,8 +17328,8 @@ var require_util4 = __commonJS({
                   }
                   fr[kResult] = result;
                   fireAProgressEvent("load", fr);
-                } catch (error) {
-                  fr[kError] = error;
+                } catch (error2) {
+                  fr[kError] = error2;
                   fireAProgressEvent("error", fr);
                 }
                 if (fr[kState] !== "loading") {
@@ -16432,13 +17338,13 @@ var require_util4 = __commonJS({
               });
               break;
             }
-          } catch (error) {
+          } catch (error2) {
             if (fr[kAborted]) {
               return;
             }
             queueMicrotask(() => {
               fr[kState] = "done";
-              fr[kError] = error;
+              fr[kError] = error2;
               fireAProgressEvent("error", fr);
               if (fr[kState] !== "loading") {
                 fireAProgressEvent("loadend", fr);
@@ -17192,8 +18098,8 @@ var require_cache = __commonJS({
        * @returns {requestResponseList}
        */
       #batchCacheOperations(operations) {
-        const cache = this.#relevantRequestResponseList;
-        const backupCache = [...cache];
+        const cache2 = this.#relevantRequestResponseList;
+        const backupCache = [...cache2];
         const addedItems = [];
         const resultList = [];
         try {
@@ -17220,9 +18126,9 @@ var require_cache = __commonJS({
                 return [];
               }
               for (const requestResponse of requestResponses) {
-                const idx = cache.indexOf(requestResponse);
+                const idx = cache2.indexOf(requestResponse);
                 assert(idx !== -1);
-                cache.splice(idx, 1);
+                cache2.splice(idx, 1);
               }
             } else if (operation.type === "put") {
               if (operation.response == null) {
@@ -17252,11 +18158,11 @@ var require_cache = __commonJS({
               }
               requestResponses = this.#queryCache(operation.request);
               for (const requestResponse of requestResponses) {
-                const idx = cache.indexOf(requestResponse);
+                const idx = cache2.indexOf(requestResponse);
                 assert(idx !== -1);
-                cache.splice(idx, 1);
+                cache2.splice(idx, 1);
               }
-              cache.push([operation.request, operation.response]);
+              cache2.push([operation.request, operation.response]);
               addedItems.push([operation.request, operation.response]);
             }
             resultList.push([operation.request, operation.response]);
@@ -17433,13 +18339,13 @@ var require_cachestorage = __commonJS({
         if (options.cacheName != null) {
           if (this.#caches.has(options.cacheName)) {
             const cacheList = this.#caches.get(options.cacheName);
-            const cache = new Cache(kConstruct, cacheList);
-            return await cache.match(request, options);
+            const cache2 = new Cache(kConstruct, cacheList);
+            return await cache2.match(request, options);
           }
         } else {
           for (const cacheList of this.#caches.values()) {
-            const cache = new Cache(kConstruct, cacheList);
-            const response = await cache.match(request, options);
+            const cache2 = new Cache(kConstruct, cacheList);
+            const response = await cache2.match(request, options);
             if (response !== void 0) {
               return response;
             }
@@ -17469,12 +18375,12 @@ var require_cachestorage = __commonJS({
         webidl.argumentLengthCheck(arguments, 1, prefix);
         cacheName = webidl.converters.DOMString(cacheName, prefix, "cacheName");
         if (this.#caches.has(cacheName)) {
-          const cache2 = this.#caches.get(cacheName);
-          return new Cache(kConstruct, cache2);
+          const cache3 = this.#caches.get(cacheName);
+          return new Cache(kConstruct, cache3);
         }
-        const cache = [];
-        this.#caches.set(cacheName, cache);
-        return new Cache(kConstruct, cache);
+        const cache2 = [];
+        this.#caches.set(cacheName, cache2);
+        return new Cache(kConstruct, cache2);
       }
       /**
        * @see https://w3c.github.io/ServiceWorker/#cache-storage-delete
@@ -18776,11 +19682,11 @@ var require_connection = __commonJS({
       }
     }
     __name(onSocketClose, "onSocketClose");
-    function onSocketError(error) {
+    function onSocketError(error2) {
       const { ws } = this;
       ws[kReadyState] = states.CLOSING;
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(error);
+        channels.socketError.publish(error2);
       }
       this.destroy();
     }
@@ -19054,9 +19960,9 @@ var require_receiver = __commonJS({
                 }
                 this.#state = parserStates.INFO;
               } else {
-                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error, data) => {
-                  if (error) {
-                    failWebsocketConnection(this.ws, error.message);
+                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error2, data) => {
+                  if (error2) {
+                    failWebsocketConnection(this.ws, error2.message);
                     return;
                   }
                   this.#fragments.push(data);
@@ -19561,11 +20467,11 @@ ns");
        */
       #onConnectionEstablished(response, parsedExtensions) {
         this[kResponse] = response;
-        const parser = new ByteParser(this, parsedExtensions);
-        parser.on("drain", onParserDrain);
-        parser.on("error", onParserError.bind(this));
+        const parser4 = new ByteParser(this, parsedExtensions);
+        parser4.on("drain", onParserDrain);
+        parser4.on("error", onParserError.bind(this));
         response.socket.ws = this;
-        this[kByteParser] = parser;
+        this[kByteParser] = parser4;
         this.#sendQueue = new SendQueue(response.socket);
         this[kReadyState] = states.OPEN;
         const extensions = response.headersList.get("sec-websocket-extensions");
@@ -19694,16 +20600,16 @@ var require_util8 = __commonJS({
       return true;
     }
     __name(isASCIINumber, "isASCIINumber");
-    function delay(ms) {
+    function delay2(ms) {
       return new Promise((resolve2) => {
         setTimeout(resolve2, ms).unref();
       });
     }
-    __name(delay, "delay");
+    __name(delay2, "delay");
     module2.exports = {
       isValidLastEventId,
       isASCIINumber,
-      delay
+      delay: delay2
     };
   }
 });
@@ -19953,7 +20859,7 @@ var require_eventsource = __commonJS({
     var { parseMIMEType } = require_data_url();
     var { createFastMessageEvent } = require_events();
     var { isNetworkError } = require_response();
-    var { delay } = require_util8();
+    var { delay: delay2 } = require_util8();
     var { kEnumerableProperty } = require_util();
     var { environmentSettingsObject } = require_util2();
     var experimentalWarned = false;
@@ -20109,8 +21015,8 @@ var require_eventsource = __commonJS({
           pipeline(
             response.body.stream,
             eventSourceStream,
-            (error) => {
-              if (error?.aborted === false) {
+            (error2) => {
+              if (error2?.aborted === false) {
                 this.close();
                 this.dispatchEvent(new Event("error"));
               }
@@ -20127,7 +21033,7 @@ var require_eventsource = __commonJS({
         if (this.#readyState === CLOSED) return;
         this.#readyState = CONNECTING;
         this.dispatchEvent(new Event("error"));
-        await delay(this.#state.reconnectionTime);
+        await delay2(this.#state.reconnectionTime);
         if (this.#readyState !== CONNECTING) return;
         if (this.#state.lastEventId.length) {
           this.#request.headersList.set("last-event-id", this.#state.lastEventId, true);
@@ -20384,6 +21290,6402 @@ var require_undici = __commonJS({
   }
 });
 
+// node_modules/semver/internal/constants.js
+var require_constants6 = __commonJS({
+  "node_modules/semver/internal/constants.js"(exports2, module2) {
+    "use strict";
+    var SEMVER_SPEC_VERSION = "2.0.0";
+    var MAX_LENGTH = 256;
+    var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || /* istanbul ignore next */
+    9007199254740991;
+    var MAX_SAFE_COMPONENT_LENGTH = 16;
+    var MAX_SAFE_BUILD_LENGTH = MAX_LENGTH - 6;
+    var RELEASE_TYPES = [
+      "major",
+      "premajor",
+      "minor",
+      "preminor",
+      "patch",
+      "prepatch",
+      "prerelease"
+    ];
+    module2.exports = {
+      MAX_LENGTH,
+      MAX_SAFE_COMPONENT_LENGTH,
+      MAX_SAFE_BUILD_LENGTH,
+      MAX_SAFE_INTEGER,
+      RELEASE_TYPES,
+      SEMVER_SPEC_VERSION,
+      FLAG_INCLUDE_PRERELEASE: 1,
+      FLAG_LOOSE: 2
+    };
+  }
+});
+
+// node_modules/semver/internal/debug.js
+var require_debug = __commonJS({
+  "node_modules/semver/internal/debug.js"(exports2, module2) {
+    "use strict";
+    var debug3 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.
+    NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
+    };
+    module2.exports = debug3;
+  }
+});
+
+// node_modules/semver/internal/re.js
+var require_re = __commonJS({
+  "node_modules/semver/internal/re.js"(exports2, module2) {
+    "use strict";
+    var {
+      MAX_SAFE_COMPONENT_LENGTH,
+      MAX_SAFE_BUILD_LENGTH,
+      MAX_LENGTH
+    } = require_constants6();
+    var debug3 = require_debug();
+    exports2 = module2.exports = {};
+    var re = exports2.re = [];
+    var safeRe = exports2.safeRe = [];
+    var src = exports2.src = [];
+    var safeSrc = exports2.safeSrc = [];
+    var t = exports2.t = {};
+    var R = 0;
+    var LETTERDASHNUMBER = "[a-zA-Z0-9-]";
+    var safeRegexReplacements = [
+      ["\\s", 1],
+      ["\\d", MAX_LENGTH],
+      [LETTERDASHNUMBER, MAX_SAFE_BUILD_LENGTH]
+    ];
+    var makeSafeRegex = /* @__PURE__ */ __name((value) => {
+      for (const [token, max] of safeRegexReplacements) {
+        value = value.split(`${token}*`).join(`${token}{0,${max}}`).split(`${token}+`).join(`${token}{1,${max}}`);
+      }
+      return value;
+    }, "makeSafeRegex");
+    var createToken = /* @__PURE__ */ __name((name, value, isGlobal) => {
+      const safe = makeSafeRegex(value);
+      const index = R++;
+      debug3(name, index, value);
+      t[name] = index;
+      src[index] = value;
+      safeSrc[index] = safe;
+      re[index] = new RegExp(value, isGlobal ? "g" : void 0);
+      safeRe[index] = new RegExp(safe, isGlobal ? "g" : void 0);
+    }, "createToken");
+    createToken("NUMERICIDENTIFIER", "0|[1-9]\\d*");
+    createToken("NUMERICIDENTIFIERLOOSE", "\\d+");
+    createToken("NONNUMERICIDENTIFIER", `\\d*[a-zA-Z-]${LETTERDASHNUMBER}*`);
+    createToken("MAINVERSION", `(${src[t.NUMERICIDENTIFIER]})\\.(${src[t.NUMERICIDENTIFIER]})\\.(${src[t.NUMERICIDENTIFIER]}\
+)`);
+    createToken("MAINVERSIONLOOSE", `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.(${src[t.NUMERICIDENTIFIERLOOSE]})\\.(${src[t.
+    NUMERICIDENTIFIERLOOSE]})`);
+    createToken("PRERELEASEIDENTIFIER", `(?:${src[t.NONNUMERICIDENTIFIER]}|${src[t.NUMERICIDENTIFIER]})`);
+    createToken("PRERELEASEIDENTIFIERLOOSE", `(?:${src[t.NONNUMERICIDENTIFIER]}|${src[t.NUMERICIDENTIFIERLOOSE]})`);
+    createToken("PRERELEASE", `(?:-(${src[t.PRERELEASEIDENTIFIER]}(?:\\.${src[t.PRERELEASEIDENTIFIER]})*))`);
+    createToken("PRERELEASELOOSE", `(?:-?(${src[t.PRERELEASEIDENTIFIERLOOSE]}(?:\\.${src[t.PRERELEASEIDENTIFIERLOOSE]})*\
+))`);
+    createToken("BUILDIDENTIFIER", `${LETTERDASHNUMBER}+`);
+    createToken("BUILD", `(?:\\+(${src[t.BUILDIDENTIFIER]}(?:\\.${src[t.BUILDIDENTIFIER]})*))`);
+    createToken("FULLPLAIN", `v?${src[t.MAINVERSION]}${src[t.PRERELEASE]}?${src[t.BUILD]}?`);
+    createToken("FULL", `^${src[t.FULLPLAIN]}$`);
+    createToken("LOOSEPLAIN", `[v=\\s]*${src[t.MAINVERSIONLOOSE]}${src[t.PRERELEASELOOSE]}?${src[t.BUILD]}?`);
+    createToken("LOOSE", `^${src[t.LOOSEPLAIN]}$`);
+    createToken("GTLT", "((?:<|>)?=?)");
+    createToken("XRANGEIDENTIFIERLOOSE", `${src[t.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`);
+    createToken("XRANGEIDENTIFIER", `${src[t.NUMERICIDENTIFIER]}|x|X|\\*`);
+    createToken("XRANGEPLAIN", `[v=\\s]*(${src[t.XRANGEIDENTIFIER]})(?:\\.(${src[t.XRANGEIDENTIFIER]})(?:\\.(${src[t.XRANGEIDENTIFIER]}\
+)(?:${src[t.PRERELEASE]})?${src[t.BUILD]}?)?)?`);
+    createToken("XRANGEPLAINLOOSE", `[v=\\s]*(${src[t.XRANGEIDENTIFIERLOOSE]})(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})(?:\
+\\.(${src[t.XRANGEIDENTIFIERLOOSE]})(?:${src[t.PRERELEASELOOSE]})?${src[t.BUILD]}?)?)?`);
+    createToken("XRANGE", `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAIN]}$`);
+    createToken("XRANGELOOSE", `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("COERCEPLAIN", `${"(^|[^\\d])(\\d{1,"}${MAX_SAFE_COMPONENT_LENGTH}})(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}\
+}))?(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?`);
+    createToken("COERCE", `${src[t.COERCEPLAIN]}(?:$|[^\\d])`);
+    createToken("COERCEFULL", src[t.COERCEPLAIN] + `(?:${src[t.PRERELEASE]})?(?:${src[t.BUILD]})?(?:$|[^\\d])`);
+    createToken("COERCERTL", src[t.COERCE], true);
+    createToken("COERCERTLFULL", src[t.COERCEFULL], true);
+    createToken("LONETILDE", "(?:~>?)");
+    createToken("TILDETRIM", `(\\s*)${src[t.LONETILDE]}\\s+`, true);
+    exports2.tildeTrimReplace = "$1~";
+    createToken("TILDE", `^${src[t.LONETILDE]}${src[t.XRANGEPLAIN]}$`);
+    createToken("TILDELOOSE", `^${src[t.LONETILDE]}${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("LONECARET", "(?:\\^)");
+    createToken("CARETTRIM", `(\\s*)${src[t.LONECARET]}\\s+`, true);
+    exports2.caretTrimReplace = "$1^";
+    createToken("CARET", `^${src[t.LONECARET]}${src[t.XRANGEPLAIN]}$`);
+    createToken("CARETLOOSE", `^${src[t.LONECARET]}${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("COMPARATORLOOSE", `^${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]})$|^$`);
+    createToken("COMPARATOR", `^${src[t.GTLT]}\\s*(${src[t.FULLPLAIN]})$|^$`);
+    createToken("COMPARATORTRIM", `(\\s*)${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]}|${src[t.XRANGEPLAIN]})`, true);
+    exports2.comparatorTrimReplace = "$1$2$3";
+    createToken("HYPHENRANGE", `^\\s*(${src[t.XRANGEPLAIN]})\\s+-\\s+(${src[t.XRANGEPLAIN]})\\s*$`);
+    createToken("HYPHENRANGELOOSE", `^\\s*(${src[t.XRANGEPLAINLOOSE]})\\s+-\\s+(${src[t.XRANGEPLAINLOOSE]})\\s*$`);
+    createToken("STAR", "(<|>)?=?\\s*\\*");
+    createToken("GTE0", "^\\s*>=\\s*0\\.0\\.0\\s*$");
+    createToken("GTE0PRE", "^\\s*>=\\s*0\\.0\\.0-0\\s*$");
+  }
+});
+
+// node_modules/semver/internal/parse-options.js
+var require_parse_options = __commonJS({
+  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+    "use strict";
+    var looseOption = Object.freeze({ loose: true });
+    var emptyOpts = Object.freeze({});
+    var parseOptions = /* @__PURE__ */ __name((options) => {
+      if (!options) {
+        return emptyOpts;
+      }
+      if (typeof options !== "object") {
+        return looseOption;
+      }
+      return options;
+    }, "parseOptions");
+    module2.exports = parseOptions;
+  }
+});
+
+// node_modules/semver/internal/identifiers.js
+var require_identifiers = __commonJS({
+  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+    "use strict";
+    var numeric = /^[0-9]+$/;
+    var compareIdentifiers = /* @__PURE__ */ __name((a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
+      const anum = numeric.test(a);
+      const bnum = numeric.test(b);
+      if (anum && bnum) {
+        a = +a;
+        b = +b;
+      }
+      return a === b ? 0 : anum && !bnum ? -1 : bnum && !anum ? 1 : a < b ? -1 : 1;
+    }, "compareIdentifiers");
+    var rcompareIdentifiers = /* @__PURE__ */ __name((a, b) => compareIdentifiers(b, a), "rcompareIdentifiers");
+    module2.exports = {
+      compareIdentifiers,
+      rcompareIdentifiers
+    };
+  }
+});
+
+// node_modules/semver/classes/semver.js
+var require_semver = __commonJS({
+  "node_modules/semver/classes/semver.js"(exports2, module2) {
+    "use strict";
+    var debug3 = require_debug();
+    var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants6();
+    var { safeRe: re, t } = require_re();
+    var parseOptions = require_parse_options();
+    var { compareIdentifiers } = require_identifiers();
+    var SemVer = class _SemVer {
+      static {
+        __name(this, "SemVer");
+      }
+      constructor(version, options) {
+        options = parseOptions(options);
+        if (version instanceof _SemVer) {
+          if (version.loose === !!options.loose && version.includePrerelease === !!options.includePrerelease) {
+            return version;
+          } else {
+            version = version.version;
+          }
+        } else if (typeof version !== "string") {
+          throw new TypeError(`Invalid version. Must be a string. Got type "${typeof version}".`);
+        }
+        if (version.length > MAX_LENGTH) {
+          throw new TypeError(
+            `version is longer than ${MAX_LENGTH} characters`
+          );
+        }
+        debug3("SemVer", version, options);
+        this.options = options;
+        this.loose = !!options.loose;
+        this.includePrerelease = !!options.includePrerelease;
+        const m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL]);
+        if (!m) {
+          throw new TypeError(`Invalid Version: ${version}`);
+        }
+        this.raw = version;
+        this.major = +m[1];
+        this.minor = +m[2];
+        this.patch = +m[3];
+        if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
+          throw new TypeError("Invalid major version");
+        }
+        if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
+          throw new TypeError("Invalid minor version");
+        }
+        if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
+          throw new TypeError("Invalid patch version");
+        }
+        if (!m[4]) {
+          this.prerelease = [];
+        } else {
+          this.prerelease = m[4].split(".").map((id) => {
+            if (/^[0-9]+$/.test(id)) {
+              const num = +id;
+              if (num >= 0 && num < MAX_SAFE_INTEGER) {
+                return num;
+              }
+            }
+            return id;
+          });
+        }
+        this.build = m[5] ? m[5].split(".") : [];
+        this.format();
+      }
+      format() {
+        this.version = `${this.major}.${this.minor}.${this.patch}`;
+        if (this.prerelease.length) {
+          this.version += `-${this.prerelease.join(".")}`;
+        }
+        return this.version;
+      }
+      toString() {
+        return this.version;
+      }
+      compare(other) {
+        debug3("SemVer.compare", this.version, this.options, other);
+        if (!(other instanceof _SemVer)) {
+          if (typeof other === "string" && other === this.version) {
+            return 0;
+          }
+          other = new _SemVer(other, this.options);
+        }
+        if (other.version === this.version) {
+          return 0;
+        }
+        return this.compareMain(other) || this.comparePre(other);
+      }
+      compareMain(other) {
+        if (!(other instanceof _SemVer)) {
+          other = new _SemVer(other, this.options);
+        }
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
+      }
+      comparePre(other) {
+        if (!(other instanceof _SemVer)) {
+          other = new _SemVer(other, this.options);
+        }
+        if (this.prerelease.length && !other.prerelease.length) {
+          return -1;
+        } else if (!this.prerelease.length && other.prerelease.length) {
+          return 1;
+        } else if (!this.prerelease.length && !other.prerelease.length) {
+          return 0;
+        }
+        let i = 0;
+        do {
+          const a = this.prerelease[i];
+          const b = other.prerelease[i];
+          debug3("prerelease compare", i, a, b);
+          if (a === void 0 && b === void 0) {
+            return 0;
+          } else if (b === void 0) {
+            return 1;
+          } else if (a === void 0) {
+            return -1;
+          } else if (a === b) {
+            continue;
+          } else {
+            return compareIdentifiers(a, b);
+          }
+        } while (++i);
+      }
+      compareBuild(other) {
+        if (!(other instanceof _SemVer)) {
+          other = new _SemVer(other, this.options);
+        }
+        let i = 0;
+        do {
+          const a = this.build[i];
+          const b = other.build[i];
+          debug3("build compare", i, a, b);
+          if (a === void 0 && b === void 0) {
+            return 0;
+          } else if (b === void 0) {
+            return 1;
+          } else if (a === void 0) {
+            return -1;
+          } else if (a === b) {
+            continue;
+          } else {
+            return compareIdentifiers(a, b);
+          }
+        } while (++i);
+      }
+      // preminor will bump the version up to the next minor release, and immediately
+      // down to pre-release. premajor and prepatch work the same way.
+      inc(release, identifier, identifierBase) {
+        if (release.startsWith("pre")) {
+          if (!identifier && identifierBase === false) {
+            throw new Error("invalid increment argument: identifier is empty");
+          }
+          if (identifier) {
+            const match = `-${identifier}`.match(this.options.loose ? re[t.PRERELEASELOOSE] : re[t.PRERELEASE]);
+            if (!match || match[1] !== identifier) {
+              throw new Error(`invalid identifier: ${identifier}`);
+            }
+          }
+        }
+        switch (release) {
+          case "premajor":
+            this.prerelease.length = 0;
+            this.patch = 0;
+            this.minor = 0;
+            this.major++;
+            this.inc("pre", identifier, identifierBase);
+            break;
+          case "preminor":
+            this.prerelease.length = 0;
+            this.patch = 0;
+            this.minor++;
+            this.inc("pre", identifier, identifierBase);
+            break;
+          case "prepatch":
+            this.prerelease.length = 0;
+            this.inc("patch", identifier, identifierBase);
+            this.inc("pre", identifier, identifierBase);
+            break;
+          // If the input is a non-prerelease version, this acts the same as
+          // prepatch.
+          case "prerelease":
+            if (this.prerelease.length === 0) {
+              this.inc("patch", identifier, identifierBase);
+            }
+            this.inc("pre", identifier, identifierBase);
+            break;
+          case "release":
+            if (this.prerelease.length === 0) {
+              throw new Error(`version ${this.raw} is not a prerelease`);
+            }
+            this.prerelease.length = 0;
+            break;
+          case "major":
+            if (this.minor !== 0 || this.patch !== 0 || this.prerelease.length === 0) {
+              this.major++;
+            }
+            this.minor = 0;
+            this.patch = 0;
+            this.prerelease = [];
+            break;
+          case "minor":
+            if (this.patch !== 0 || this.prerelease.length === 0) {
+              this.minor++;
+            }
+            this.patch = 0;
+            this.prerelease = [];
+            break;
+          case "patch":
+            if (this.prerelease.length === 0) {
+              this.patch++;
+            }
+            this.prerelease = [];
+            break;
+          // This probably shouldn't be used publicly.
+          // 1.0.0 'pre' would become 1.0.0-0 which is the wrong direction.
+          case "pre": {
+            const base = Number(identifierBase) ? 1 : 0;
+            if (this.prerelease.length === 0) {
+              this.prerelease = [base];
+            } else {
+              let i = this.prerelease.length;
+              while (--i >= 0) {
+                if (typeof this.prerelease[i] === "number") {
+                  this.prerelease[i]++;
+                  i = -2;
+                }
+              }
+              if (i === -1) {
+                if (identifier === this.prerelease.join(".") && identifierBase === false) {
+                  throw new Error("invalid increment argument: identifier already exists");
+                }
+                this.prerelease.push(base);
+              }
+            }
+            if (identifier) {
+              let prerelease = [identifier, base];
+              if (identifierBase === false) {
+                prerelease = [identifier];
+              }
+              if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+                if (isNaN(this.prerelease[1])) {
+                  this.prerelease = prerelease;
+                }
+              } else {
+                this.prerelease = prerelease;
+              }
+            }
+            break;
+          }
+          default:
+            throw new Error(`invalid increment argument: ${release}`);
+        }
+        this.raw = this.format();
+        if (this.build.length) {
+          this.raw += `+${this.build.join(".")}`;
+        }
+        return this;
+      }
+    };
+    module2.exports = SemVer;
+  }
+});
+
+// node_modules/semver/functions/parse.js
+var require_parse2 = __commonJS({
+  "node_modules/semver/functions/parse.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var parse = /* @__PURE__ */ __name((version, options, throwErrors = false) => {
+      if (version instanceof SemVer) {
+        return version;
+      }
+      try {
+        return new SemVer(version, options);
+      } catch (er) {
+        if (!throwErrors) {
+          return null;
+        }
+        throw er;
+      }
+    }, "parse");
+    module2.exports = parse;
+  }
+});
+
+// node_modules/semver/functions/valid.js
+var require_valid = __commonJS({
+  "node_modules/semver/functions/valid.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var valid2 = /* @__PURE__ */ __name((version, options) => {
+      const v = parse(version, options);
+      return v ? v.version : null;
+    }, "valid");
+    module2.exports = valid2;
+  }
+});
+
+// node_modules/semver/functions/clean.js
+var require_clean = __commonJS({
+  "node_modules/semver/functions/clean.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var clean2 = /* @__PURE__ */ __name((version, options) => {
+      const s = parse(version.trim().replace(/^[=v]+/, ""), options);
+      return s ? s.version : null;
+    }, "clean");
+    module2.exports = clean2;
+  }
+});
+
+// node_modules/semver/functions/inc.js
+var require_inc = __commonJS({
+  "node_modules/semver/functions/inc.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var inc = /* @__PURE__ */ __name((version, release, options, identifier, identifierBase) => {
+      if (typeof options === "string") {
+        identifierBase = identifier;
+        identifier = options;
+        options = void 0;
+      }
+      try {
+        return new SemVer(
+          version instanceof SemVer ? version.version : version,
+          options
+        ).inc(release, identifier, identifierBase).version;
+      } catch (er) {
+        return null;
+      }
+    }, "inc");
+    module2.exports = inc;
+  }
+});
+
+// node_modules/semver/functions/diff.js
+var require_diff = __commonJS({
+  "node_modules/semver/functions/diff.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var diff = /* @__PURE__ */ __name((version1, version2) => {
+      const v1 = parse(version1, null, true);
+      const v2 = parse(version2, null, true);
+      const comparison = v1.compare(v2);
+      if (comparison === 0) {
+        return null;
+      }
+      const v1Higher = comparison > 0;
+      const highVersion = v1Higher ? v1 : v2;
+      const lowVersion = v1Higher ? v2 : v1;
+      const highHasPre = !!highVersion.prerelease.length;
+      const lowHasPre = !!lowVersion.prerelease.length;
+      if (lowHasPre && !highHasPre) {
+        if (!lowVersion.patch && !lowVersion.minor) {
+          return "major";
+        }
+        if (lowVersion.compareMain(highVersion) === 0) {
+          if (lowVersion.minor && !lowVersion.patch) {
+            return "minor";
+          }
+          return "patch";
+        }
+      }
+      const prefix = highHasPre ? "pre" : "";
+      if (v1.major !== v2.major) {
+        return prefix + "major";
+      }
+      if (v1.minor !== v2.minor) {
+        return prefix + "minor";
+      }
+      if (v1.patch !== v2.patch) {
+        return prefix + "patch";
+      }
+      return "prerelease";
+    }, "diff");
+    module2.exports = diff;
+  }
+});
+
+// node_modules/semver/functions/major.js
+var require_major = __commonJS({
+  "node_modules/semver/functions/major.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var major = /* @__PURE__ */ __name((a, loose) => new SemVer(a, loose).major, "major");
+    module2.exports = major;
+  }
+});
+
+// node_modules/semver/functions/minor.js
+var require_minor = __commonJS({
+  "node_modules/semver/functions/minor.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var minor = /* @__PURE__ */ __name((a, loose) => new SemVer(a, loose).minor, "minor");
+    module2.exports = minor;
+  }
+});
+
+// node_modules/semver/functions/patch.js
+var require_patch = __commonJS({
+  "node_modules/semver/functions/patch.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var patch = /* @__PURE__ */ __name((a, loose) => new SemVer(a, loose).patch, "patch");
+    module2.exports = patch;
+  }
+});
+
+// node_modules/semver/functions/prerelease.js
+var require_prerelease = __commonJS({
+  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var prerelease = /* @__PURE__ */ __name((version, options) => {
+      const parsed = parse(version, options);
+      return parsed && parsed.prerelease.length ? parsed.prerelease : null;
+    }, "prerelease");
+    module2.exports = prerelease;
+  }
+});
+
+// node_modules/semver/functions/compare.js
+var require_compare = __commonJS({
+  "node_modules/semver/functions/compare.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var compare = /* @__PURE__ */ __name((a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose)), "compare");
+    module2.exports = compare;
+  }
+});
+
+// node_modules/semver/functions/rcompare.js
+var require_rcompare = __commonJS({
+  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var rcompare = /* @__PURE__ */ __name((a, b, loose) => compare(b, a, loose), "rcompare");
+    module2.exports = rcompare;
+  }
+});
+
+// node_modules/semver/functions/compare-loose.js
+var require_compare_loose = __commonJS({
+  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var compareLoose = /* @__PURE__ */ __name((a, b) => compare(a, b, true), "compareLoose");
+    module2.exports = compareLoose;
+  }
+});
+
+// node_modules/semver/functions/compare-build.js
+var require_compare_build = __commonJS({
+  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var compareBuild = /* @__PURE__ */ __name((a, b, loose) => {
+      const versionA = new SemVer(a, loose);
+      const versionB = new SemVer(b, loose);
+      return versionA.compare(versionB) || versionA.compareBuild(versionB);
+    }, "compareBuild");
+    module2.exports = compareBuild;
+  }
+});
+
+// node_modules/semver/functions/sort.js
+var require_sort = __commonJS({
+  "node_modules/semver/functions/sort.js"(exports2, module2) {
+    "use strict";
+    var compareBuild = require_compare_build();
+    var sort = /* @__PURE__ */ __name((list, loose) => list.sort((a, b) => compareBuild(a, b, loose)), "sort");
+    module2.exports = sort;
+  }
+});
+
+// node_modules/semver/functions/rsort.js
+var require_rsort = __commonJS({
+  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+    "use strict";
+    var compareBuild = require_compare_build();
+    var rsort = /* @__PURE__ */ __name((list, loose) => list.sort((a, b) => compareBuild(b, a, loose)), "rsort");
+    module2.exports = rsort;
+  }
+});
+
+// node_modules/semver/functions/gt.js
+var require_gt = __commonJS({
+  "node_modules/semver/functions/gt.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var gt2 = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) > 0, "gt");
+    module2.exports = gt2;
+  }
+});
+
+// node_modules/semver/functions/lt.js
+var require_lt = __commonJS({
+  "node_modules/semver/functions/lt.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var lt = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) < 0, "lt");
+    module2.exports = lt;
+  }
+});
+
+// node_modules/semver/functions/eq.js
+var require_eq = __commonJS({
+  "node_modules/semver/functions/eq.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var eq = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) === 0, "eq");
+    module2.exports = eq;
+  }
+});
+
+// node_modules/semver/functions/neq.js
+var require_neq = __commonJS({
+  "node_modules/semver/functions/neq.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var neq = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) !== 0, "neq");
+    module2.exports = neq;
+  }
+});
+
+// node_modules/semver/functions/gte.js
+var require_gte = __commonJS({
+  "node_modules/semver/functions/gte.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var gte = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) >= 0, "gte");
+    module2.exports = gte;
+  }
+});
+
+// node_modules/semver/functions/lte.js
+var require_lte = __commonJS({
+  "node_modules/semver/functions/lte.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var lte = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) <= 0, "lte");
+    module2.exports = lte;
+  }
+});
+
+// node_modules/semver/functions/cmp.js
+var require_cmp = __commonJS({
+  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+    "use strict";
+    var eq = require_eq();
+    var neq = require_neq();
+    var gt2 = require_gt();
+    var gte = require_gte();
+    var lt = require_lt();
+    var lte = require_lte();
+    var cmp = /* @__PURE__ */ __name((a, op, b, loose) => {
+      switch (op) {
+        case "===":
+          if (typeof a === "object") {
+            a = a.version;
+          }
+          if (typeof b === "object") {
+            b = b.version;
+          }
+          return a === b;
+        case "!==":
+          if (typeof a === "object") {
+            a = a.version;
+          }
+          if (typeof b === "object") {
+            b = b.version;
+          }
+          return a !== b;
+        case "":
+        case "=":
+        case "==":
+          return eq(a, b, loose);
+        case "!=":
+          return neq(a, b, loose);
+        case ">":
+          return gt2(a, b, loose);
+        case ">=":
+          return gte(a, b, loose);
+        case "<":
+          return lt(a, b, loose);
+        case "<=":
+          return lte(a, b, loose);
+        default:
+          throw new TypeError(`Invalid operator: ${op}`);
+      }
+    }, "cmp");
+    module2.exports = cmp;
+  }
+});
+
+// node_modules/semver/functions/coerce.js
+var require_coerce = __commonJS({
+  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var parse = require_parse2();
+    var { safeRe: re, t } = require_re();
+    var coerce = /* @__PURE__ */ __name((version, options) => {
+      if (version instanceof SemVer) {
+        return version;
+      }
+      if (typeof version === "number") {
+        version = String(version);
+      }
+      if (typeof version !== "string") {
+        return null;
+      }
+      options = options || {};
+      let match = null;
+      if (!options.rtl) {
+        match = version.match(options.includePrerelease ? re[t.COERCEFULL] : re[t.COERCE]);
+      } else {
+        const coerceRtlRegex = options.includePrerelease ? re[t.COERCERTLFULL] : re[t.COERCERTL];
+        let next;
+        while ((next = coerceRtlRegex.exec(version)) && (!match || match.index + match[0].length !== version.length)) {
+          if (!match || next.index + next[0].length !== match.index + match[0].length) {
+            match = next;
+          }
+          coerceRtlRegex.lastIndex = next.index + next[1].length + next[2].length;
+        }
+        coerceRtlRegex.lastIndex = -1;
+      }
+      if (match === null) {
+        return null;
+      }
+      const major = match[2];
+      const minor = match[3] || "0";
+      const patch = match[4] || "0";
+      const prerelease = options.includePrerelease && match[5] ? `-${match[5]}` : "";
+      const build = options.includePrerelease && match[6] ? `+${match[6]}` : "";
+      return parse(`${major}.${minor}.${patch}${prerelease}${build}`, options);
+    }, "coerce");
+    module2.exports = coerce;
+  }
+});
+
+// node_modules/semver/internal/lrucache.js
+var require_lrucache = __commonJS({
+  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+    "use strict";
+    var LRUCache = class {
+      static {
+        __name(this, "LRUCache");
+      }
+      constructor() {
+        this.max = 1e3;
+        this.map = /* @__PURE__ */ new Map();
+      }
+      get(key) {
+        const value = this.map.get(key);
+        if (value === void 0) {
+          return void 0;
+        } else {
+          this.map.delete(key);
+          this.map.set(key, value);
+          return value;
+        }
+      }
+      delete(key) {
+        return this.map.delete(key);
+      }
+      set(key, value) {
+        const deleted = this.delete(key);
+        if (!deleted && value !== void 0) {
+          if (this.map.size >= this.max) {
+            const firstKey = this.map.keys().next().value;
+            this.delete(firstKey);
+          }
+          this.map.set(key, value);
+        }
+        return this;
+      }
+    };
+    module2.exports = LRUCache;
+  }
+});
+
+// node_modules/semver/classes/range.js
+var require_range = __commonJS({
+  "node_modules/semver/classes/range.js"(exports2, module2) {
+    "use strict";
+    var SPACE_CHARACTERS = /\s+/g;
+    var Range = class _Range {
+      static {
+        __name(this, "Range");
+      }
+      constructor(range, options) {
+        options = parseOptions(options);
+        if (range instanceof _Range) {
+          if (range.loose === !!options.loose && range.includePrerelease === !!options.includePrerelease) {
+            return range;
+          } else {
+            return new _Range(range.raw, options);
+          }
+        }
+        if (range instanceof Comparator) {
+          this.raw = range.value;
+          this.set = [[range]];
+          this.formatted = void 0;
+          return this;
+        }
+        this.options = options;
+        this.loose = !!options.loose;
+        this.includePrerelease = !!options.includePrerelease;
+        this.raw = range.trim().replace(SPACE_CHARACTERS, " ");
+        this.set = this.raw.split("||").map((r) => this.parseRange(r.trim())).filter((c) => c.length);
+        if (!this.set.length) {
+          throw new TypeError(`Invalid SemVer Range: ${this.raw}`);
+        }
+        if (this.set.length > 1) {
+          const first2 = this.set[0];
+          this.set = this.set.filter((c) => !isNullSet(c[0]));
+          if (this.set.length === 0) {
+            this.set = [first2];
+          } else if (this.set.length > 1) {
+            for (const c of this.set) {
+              if (c.length === 1 && isAny(c[0])) {
+                this.set = [c];
+                break;
+              }
+            }
+          }
+        }
+        this.formatted = void 0;
+      }
+      get range() {
+        if (this.formatted === void 0) {
+          this.formatted = "";
+          for (let i = 0; i < this.set.length; i++) {
+            if (i > 0) {
+              this.formatted += "||";
+            }
+            const comps = this.set[i];
+            for (let k = 0; k < comps.length; k++) {
+              if (k > 0) {
+                this.formatted += " ";
+              }
+              this.formatted += comps[k].toString().trim();
+            }
+          }
+        }
+        return this.formatted;
+      }
+      format() {
+        return this.range;
+      }
+      toString() {
+        return this.range;
+      }
+      parseRange(range) {
+        const memoOpts = (this.options.includePrerelease && FLAG_INCLUDE_PRERELEASE) | (this.options.loose && FLAG_LOOSE);
+        const memoKey = memoOpts + ":" + range;
+        const cached = cache2.get(memoKey);
+        if (cached) {
+          return cached;
+        }
+        const loose = this.options.loose;
+        const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
+        range = range.replace(hr, hyphenReplace(this.options.includePrerelease));
+        debug3("hyphen replace", range);
+        range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
+        debug3("comparator trim", range);
+        range = range.replace(re[t.TILDETRIM], tildeTrimReplace);
+        debug3("tilde trim", range);
+        range = range.replace(re[t.CARETTRIM], caretTrimReplace);
+        debug3("caret trim", range);
+        let rangeList = range.split(" ").map((comp) => parseComparator(comp, this.options)).join(" ").split(/\s+/).map((comp) => replaceGTE0(
+        comp, this.options));
+        if (loose) {
+          rangeList = rangeList.filter((comp) => {
+            debug3("loose invalid filter", comp, this.options);
+            return !!comp.match(re[t.COMPARATORLOOSE]);
+          });
+        }
+        debug3("range list", rangeList);
+        const rangeMap = /* @__PURE__ */ new Map();
+        const comparators = rangeList.map((comp) => new Comparator(comp, this.options));
+        for (const comp of comparators) {
+          if (isNullSet(comp)) {
+            return [comp];
+          }
+          rangeMap.set(comp.value, comp);
+        }
+        if (rangeMap.size > 1 && rangeMap.has("")) {
+          rangeMap.delete("");
+        }
+        const result = [...rangeMap.values()];
+        cache2.set(memoKey, result);
+        return result;
+      }
+      intersects(range, options) {
+        if (!(range instanceof _Range)) {
+          throw new TypeError("a Range is required");
+        }
+        return this.set.some((thisComparators) => {
+          return isSatisfiable(thisComparators, options) && range.set.some((rangeComparators) => {
+            return isSatisfiable(rangeComparators, options) && thisComparators.every((thisComparator) => {
+              return rangeComparators.every((rangeComparator) => {
+                return thisComparator.intersects(rangeComparator, options);
+              });
+            });
+          });
+        });
+      }
+      // if ANY of the sets match ALL of its comparators, then pass
+      test(version) {
+        if (!version) {
+          return false;
+        }
+        if (typeof version === "string") {
+          try {
+            version = new SemVer(version, this.options);
+          } catch (er) {
+            return false;
+          }
+        }
+        for (let i = 0; i < this.set.length; i++) {
+          if (testSet(this.set[i], version, this.options)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+    module2.exports = Range;
+    var LRU = require_lrucache();
+    var cache2 = new LRU();
+    var parseOptions = require_parse_options();
+    var Comparator = require_comparator();
+    var debug3 = require_debug();
+    var SemVer = require_semver();
+    var {
+      safeRe: re,
+      t,
+      comparatorTrimReplace,
+      tildeTrimReplace,
+      caretTrimReplace
+    } = require_re();
+    var { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = require_constants6();
+    var isNullSet = /* @__PURE__ */ __name((c) => c.value === "<0.0.0-0", "isNullSet");
+    var isAny = /* @__PURE__ */ __name((c) => c.value === "", "isAny");
+    var isSatisfiable = /* @__PURE__ */ __name((comparators, options) => {
+      let result = true;
+      const remainingComparators = comparators.slice();
+      let testComparator = remainingComparators.pop();
+      while (result && remainingComparators.length) {
+        result = remainingComparators.every((otherComparator) => {
+          return testComparator.intersects(otherComparator, options);
+        });
+        testComparator = remainingComparators.pop();
+      }
+      return result;
+    }, "isSatisfiable");
+    var parseComparator = /* @__PURE__ */ __name((comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
+      debug3("comp", comp, options);
+      comp = replaceCarets(comp, options);
+      debug3("caret", comp);
+      comp = replaceTildes(comp, options);
+      debug3("tildes", comp);
+      comp = replaceXRanges(comp, options);
+      debug3("xrange", comp);
+      comp = replaceStars(comp, options);
+      debug3("stars", comp);
+      return comp;
+    }, "parseComparator");
+    var isX = /* @__PURE__ */ __name((id) => !id || id.toLowerCase() === "x" || id === "*", "isX");
+    var replaceTildes = /* @__PURE__ */ __name((comp, options) => {
+      return comp.trim().split(/\s+/).map((c) => replaceTilde(c, options)).join(" ");
+    }, "replaceTildes");
+    var replaceTilde = /* @__PURE__ */ __name((comp, options) => {
+      const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
+      return comp.replace(r, (_, M, m, p, pr) => {
+        debug3("tilde", comp, _, M, m, p, pr);
+        let ret;
+        if (isX(M)) {
+          ret = "";
+        } else if (isX(m)) {
+          ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
+        } else if (isX(p)) {
+          ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
+        } else if (pr) {
+          debug3("replaceTilde pr", pr);
+          ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
+        } else {
+          ret = `>=${M}.${m}.${p} <${M}.${+m + 1}.0-0`;
+        }
+        debug3("tilde return", ret);
+        return ret;
+      });
+    }, "replaceTilde");
+    var replaceCarets = /* @__PURE__ */ __name((comp, options) => {
+      return comp.trim().split(/\s+/).map((c) => replaceCaret(c, options)).join(" ");
+    }, "replaceCarets");
+    var replaceCaret = /* @__PURE__ */ __name((comp, options) => {
+      debug3("caret", comp, options);
+      const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET];
+      const z = options.includePrerelease ? "-0" : "";
+      return comp.replace(r, (_, M, m, p, pr) => {
+        debug3("caret", comp, _, M, m, p, pr);
+        let ret;
+        if (isX(M)) {
+          ret = "";
+        } else if (isX(m)) {
+          ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
+        } else if (isX(p)) {
+          if (M === "0") {
+            ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
+          } else {
+            ret = `>=${M}.${m}.0${z} <${+M + 1}.0.0-0`;
+          }
+        } else if (pr) {
+          debug3("replaceCaret pr", pr);
+          if (M === "0") {
+            if (m === "0") {
+              ret = `>=${M}.${m}.${p}-${pr} <${M}.${m}.${+p + 1}-0`;
+            } else {
+              ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
+            }
+          } else {
+            ret = `>=${M}.${m}.${p}-${pr} <${+M + 1}.0.0-0`;
+          }
+        } else {
+          debug3("no pr");
+          if (M === "0") {
+            if (m === "0") {
+              ret = `>=${M}.${m}.${p}${z} <${M}.${m}.${+p + 1}-0`;
+            } else {
+              ret = `>=${M}.${m}.${p}${z} <${M}.${+m + 1}.0-0`;
+            }
+          } else {
+            ret = `>=${M}.${m}.${p} <${+M + 1}.0.0-0`;
+          }
+        }
+        debug3("caret return", ret);
+        return ret;
+      });
+    }, "replaceCaret");
+    var replaceXRanges = /* @__PURE__ */ __name((comp, options) => {
+      debug3("replaceXRanges", comp, options);
+      return comp.split(/\s+/).map((c) => replaceXRange(c, options)).join(" ");
+    }, "replaceXRanges");
+    var replaceXRange = /* @__PURE__ */ __name((comp, options) => {
+      comp = comp.trim();
+      const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
+      return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
+        debug3("xRange", comp, ret, gtlt, M, m, p, pr);
+        const xM = isX(M);
+        const xm = xM || isX(m);
+        const xp = xm || isX(p);
+        const anyX = xp;
+        if (gtlt === "=" && anyX) {
+          gtlt = "";
+        }
+        pr = options.includePrerelease ? "-0" : "";
+        if (xM) {
+          if (gtlt === ">" || gtlt === "<") {
+            ret = "<0.0.0-0";
+          } else {
+            ret = "*";
+          }
+        } else if (gtlt && anyX) {
+          if (xm) {
+            m = 0;
+          }
+          p = 0;
+          if (gtlt === ">") {
+            gtlt = ">=";
+            if (xm) {
+              M = +M + 1;
+              m = 0;
+              p = 0;
+            } else {
+              m = +m + 1;
+              p = 0;
+            }
+          } else if (gtlt === "<=") {
+            gtlt = "<";
+            if (xm) {
+              M = +M + 1;
+            } else {
+              m = +m + 1;
+            }
+          }
+          if (gtlt === "<") {
+            pr = "-0";
+          }
+          ret = `${gtlt + M}.${m}.${p}${pr}`;
+        } else if (xm) {
+          ret = `>=${M}.0.0${pr} <${+M + 1}.0.0-0`;
+        } else if (xp) {
+          ret = `>=${M}.${m}.0${pr} <${M}.${+m + 1}.0-0`;
+        }
+        debug3("xRange return", ret);
+        return ret;
+      });
+    }, "replaceXRange");
+    var replaceStars = /* @__PURE__ */ __name((comp, options) => {
+      debug3("replaceStars", comp, options);
+      return comp.trim().replace(re[t.STAR], "");
+    }, "replaceStars");
+    var replaceGTE0 = /* @__PURE__ */ __name((comp, options) => {
+      debug3("replaceGTE0", comp, options);
+      return comp.trim().replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], "");
+    }, "replaceGTE0");
+    var hyphenReplace = /* @__PURE__ */ __name((incPr) => ($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr) => {
+      if (isX(fM)) {
+        from = "";
+      } else if (isX(fm)) {
+        from = `>=${fM}.0.0${incPr ? "-0" : ""}`;
+      } else if (isX(fp)) {
+        from = `>=${fM}.${fm}.0${incPr ? "-0" : ""}`;
+      } else if (fpr) {
+        from = `>=${from}`;
+      } else {
+        from = `>=${from}${incPr ? "-0" : ""}`;
+      }
+      if (isX(tM)) {
+        to = "";
+      } else if (isX(tm)) {
+        to = `<${+tM + 1}.0.0-0`;
+      } else if (isX(tp)) {
+        to = `<${tM}.${+tm + 1}.0-0`;
+      } else if (tpr) {
+        to = `<=${tM}.${tm}.${tp}-${tpr}`;
+      } else if (incPr) {
+        to = `<${tM}.${tm}.${+tp + 1}-0`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }, "hyphenReplace");
+    var testSet = /* @__PURE__ */ __name((set, version, options) => {
+      for (let i = 0; i < set.length; i++) {
+        if (!set[i].test(version)) {
+          return false;
+        }
+      }
+      if (version.prerelease.length && !options.includePrerelease) {
+        for (let i = 0; i < set.length; i++) {
+          debug3(set[i].semver);
+          if (set[i].semver === Comparator.ANY) {
+            continue;
+          }
+          if (set[i].semver.prerelease.length > 0) {
+            const allowed = set[i].semver;
+            if (allowed.major === version.major && allowed.minor === version.minor && allowed.patch === version.patch) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      return true;
+    }, "testSet");
+  }
+});
+
+// node_modules/semver/classes/comparator.js
+var require_comparator = __commonJS({
+  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+    "use strict";
+    var ANY = /* @__PURE__ */ Symbol("SemVer ANY");
+    var Comparator = class _Comparator {
+      static {
+        __name(this, "Comparator");
+      }
+      static get ANY() {
+        return ANY;
+      }
+      constructor(comp, options) {
+        options = parseOptions(options);
+        if (comp instanceof _Comparator) {
+          if (comp.loose === !!options.loose) {
+            return comp;
+          } else {
+            comp = comp.value;
+          }
+        }
+        comp = comp.trim().split(/\s+/).join(" ");
+        debug3("comparator", comp, options);
+        this.options = options;
+        this.loose = !!options.loose;
+        this.parse(comp);
+        if (this.semver === ANY) {
+          this.value = "";
+        } else {
+          this.value = this.operator + this.semver.version;
+        }
+        debug3("comp", this);
+      }
+      parse(comp) {
+        const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
+        const m = comp.match(r);
+        if (!m) {
+          throw new TypeError(`Invalid comparator: ${comp}`);
+        }
+        this.operator = m[1] !== void 0 ? m[1] : "";
+        if (this.operator === "=") {
+          this.operator = "";
+        }
+        if (!m[2]) {
+          this.semver = ANY;
+        } else {
+          this.semver = new SemVer(m[2], this.options.loose);
+        }
+      }
+      toString() {
+        return this.value;
+      }
+      test(version) {
+        debug3("Comparator.test", version, this.options.loose);
+        if (this.semver === ANY || version === ANY) {
+          return true;
+        }
+        if (typeof version === "string") {
+          try {
+            version = new SemVer(version, this.options);
+          } catch (er) {
+            return false;
+          }
+        }
+        return cmp(version, this.operator, this.semver, this.options);
+      }
+      intersects(comp, options) {
+        if (!(comp instanceof _Comparator)) {
+          throw new TypeError("a Comparator is required");
+        }
+        if (this.operator === "") {
+          if (this.value === "") {
+            return true;
+          }
+          return new Range(comp.value, options).test(this.value);
+        } else if (comp.operator === "") {
+          if (comp.value === "") {
+            return true;
+          }
+          return new Range(this.value, options).test(comp.semver);
+        }
+        options = parseOptions(options);
+        if (options.includePrerelease && (this.value === "<0.0.0-0" || comp.value === "<0.0.0-0")) {
+          return false;
+        }
+        if (!options.includePrerelease && (this.value.startsWith("<0.0.0") || comp.value.startsWith("<0.0.0"))) {
+          return false;
+        }
+        if (this.operator.startsWith(">") && comp.operator.startsWith(">")) {
+          return true;
+        }
+        if (this.operator.startsWith("<") && comp.operator.startsWith("<")) {
+          return true;
+        }
+        if (this.semver.version === comp.semver.version && this.operator.includes("=") && comp.operator.includes("=")) {
+          return true;
+        }
+        if (cmp(this.semver, "<", comp.semver, options) && this.operator.startsWith(">") && comp.operator.startsWith("<")) {
+          return true;
+        }
+        if (cmp(this.semver, ">", comp.semver, options) && this.operator.startsWith("<") && comp.operator.startsWith(">")) {
+          return true;
+        }
+        return false;
+      }
+    };
+    module2.exports = Comparator;
+    var parseOptions = require_parse_options();
+    var { safeRe: re, t } = require_re();
+    var cmp = require_cmp();
+    var debug3 = require_debug();
+    var SemVer = require_semver();
+    var Range = require_range();
+  }
+});
+
+// node_modules/semver/functions/satisfies.js
+var require_satisfies = __commonJS({
+  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var satisfies3 = /* @__PURE__ */ __name((version, range, options) => {
+      try {
+        range = new Range(range, options);
+      } catch (er) {
+        return false;
+      }
+      return range.test(version);
+    }, "satisfies");
+    module2.exports = satisfies3;
+  }
+});
+
+// node_modules/semver/ranges/to-comparators.js
+var require_to_comparators = __commonJS({
+  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var toComparators = /* @__PURE__ */ __name((range, options) => new Range(range, options).set.map((comp) => comp.map(
+    (c) => c.value).join(" ").trim().split(" ")), "toComparators");
+    module2.exports = toComparators;
+  }
+});
+
+// node_modules/semver/ranges/max-satisfying.js
+var require_max_satisfying = __commonJS({
+  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Range = require_range();
+    var maxSatisfying = /* @__PURE__ */ __name((versions, range, options) => {
+      let max = null;
+      let maxSV = null;
+      let rangeObj = null;
+      try {
+        rangeObj = new Range(range, options);
+      } catch (er) {
+        return null;
+      }
+      versions.forEach((v) => {
+        if (rangeObj.test(v)) {
+          if (!max || maxSV.compare(v) === -1) {
+            max = v;
+            maxSV = new SemVer(max, options);
+          }
+        }
+      });
+      return max;
+    }, "maxSatisfying");
+    module2.exports = maxSatisfying;
+  }
+});
+
+// node_modules/semver/ranges/min-satisfying.js
+var require_min_satisfying = __commonJS({
+  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Range = require_range();
+    var minSatisfying = /* @__PURE__ */ __name((versions, range, options) => {
+      let min = null;
+      let minSV = null;
+      let rangeObj = null;
+      try {
+        rangeObj = new Range(range, options);
+      } catch (er) {
+        return null;
+      }
+      versions.forEach((v) => {
+        if (rangeObj.test(v)) {
+          if (!min || minSV.compare(v) === 1) {
+            min = v;
+            minSV = new SemVer(min, options);
+          }
+        }
+      });
+      return min;
+    }, "minSatisfying");
+    module2.exports = minSatisfying;
+  }
+});
+
+// node_modules/semver/ranges/min-version.js
+var require_min_version = __commonJS({
+  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Range = require_range();
+    var gt2 = require_gt();
+    var minVersion = /* @__PURE__ */ __name((range, loose) => {
+      range = new Range(range, loose);
+      let minver = new SemVer("0.0.0");
+      if (range.test(minver)) {
+        return minver;
+      }
+      minver = new SemVer("0.0.0-0");
+      if (range.test(minver)) {
+        return minver;
+      }
+      minver = null;
+      for (let i = 0; i < range.set.length; ++i) {
+        const comparators = range.set[i];
+        let setMin = null;
+        comparators.forEach((comparator) => {
+          const compver = new SemVer(comparator.semver.version);
+          switch (comparator.operator) {
+            case ">":
+              if (compver.prerelease.length === 0) {
+                compver.patch++;
+              } else {
+                compver.prerelease.push(0);
+              }
+              compver.raw = compver.format();
+            /* fallthrough */
+            case "":
+            case ">=":
+              if (!setMin || gt2(compver, setMin)) {
+                setMin = compver;
+              }
+              break;
+            case "<":
+            case "<=":
+              break;
+            /* istanbul ignore next */
+            default:
+              throw new Error(`Unexpected operation: ${comparator.operator}`);
+          }
+        });
+        if (setMin && (!minver || gt2(minver, setMin))) {
+          minver = setMin;
+        }
+      }
+      if (minver && range.test(minver)) {
+        return minver;
+      }
+      return null;
+    }, "minVersion");
+    module2.exports = minVersion;
+  }
+});
+
+// node_modules/semver/ranges/valid.js
+var require_valid2 = __commonJS({
+  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var validRange = /* @__PURE__ */ __name((range, options) => {
+      try {
+        return new Range(range, options).range || "*";
+      } catch (er) {
+        return null;
+      }
+    }, "validRange");
+    module2.exports = validRange;
+  }
+});
+
+// node_modules/semver/ranges/outside.js
+var require_outside = __commonJS({
+  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Comparator = require_comparator();
+    var { ANY } = Comparator;
+    var Range = require_range();
+    var satisfies3 = require_satisfies();
+    var gt2 = require_gt();
+    var lt = require_lt();
+    var lte = require_lte();
+    var gte = require_gte();
+    var outside = /* @__PURE__ */ __name((version, range, hilo, options) => {
+      version = new SemVer(version, options);
+      range = new Range(range, options);
+      let gtfn, ltefn, ltfn, comp, ecomp;
+      switch (hilo) {
+        case ">":
+          gtfn = gt2;
+          ltefn = lte;
+          ltfn = lt;
+          comp = ">";
+          ecomp = ">=";
+          break;
+        case "<":
+          gtfn = lt;
+          ltefn = gte;
+          ltfn = gt2;
+          comp = "<";
+          ecomp = "<=";
+          break;
+        default:
+          throw new TypeError('Must provide a hilo val of "<" or ">"');
+      }
+      if (satisfies3(version, range, options)) {
+        return false;
+      }
+      for (let i = 0; i < range.set.length; ++i) {
+        const comparators = range.set[i];
+        let high = null;
+        let low = null;
+        comparators.forEach((comparator) => {
+          if (comparator.semver === ANY) {
+            comparator = new Comparator(">=0.0.0");
+          }
+          high = high || comparator;
+          low = low || comparator;
+          if (gtfn(comparator.semver, high.semver, options)) {
+            high = comparator;
+          } else if (ltfn(comparator.semver, low.semver, options)) {
+            low = comparator;
+          }
+        });
+        if (high.operator === comp || high.operator === ecomp) {
+          return false;
+        }
+        if ((!low.operator || low.operator === comp) && ltefn(version, low.semver)) {
+          return false;
+        } else if (low.operator === ecomp && ltfn(version, low.semver)) {
+          return false;
+        }
+      }
+      return true;
+    }, "outside");
+    module2.exports = outside;
+  }
+});
+
+// node_modules/semver/ranges/gtr.js
+var require_gtr = __commonJS({
+  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+    "use strict";
+    var outside = require_outside();
+    var gtr = /* @__PURE__ */ __name((version, range, options) => outside(version, range, ">", options), "gtr");
+    module2.exports = gtr;
+  }
+});
+
+// node_modules/semver/ranges/ltr.js
+var require_ltr = __commonJS({
+  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+    "use strict";
+    var outside = require_outside();
+    var ltr = /* @__PURE__ */ __name((version, range, options) => outside(version, range, "<", options), "ltr");
+    module2.exports = ltr;
+  }
+});
+
+// node_modules/semver/ranges/intersects.js
+var require_intersects = __commonJS({
+  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var intersects = /* @__PURE__ */ __name((r1, r2, options) => {
+      r1 = new Range(r1, options);
+      r2 = new Range(r2, options);
+      return r1.intersects(r2, options);
+    }, "intersects");
+    module2.exports = intersects;
+  }
+});
+
+// node_modules/semver/ranges/simplify.js
+var require_simplify = __commonJS({
+  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+    "use strict";
+    var satisfies3 = require_satisfies();
+    var compare = require_compare();
+    module2.exports = (versions, range, options) => {
+      const set = [];
+      let first2 = null;
+      let prev = null;
+      const v = versions.sort((a, b) => compare(a, b, options));
+      for (const version of v) {
+        const included = satisfies3(version, range, options);
+        if (included) {
+          prev = version;
+          if (!first2) {
+            first2 = version;
+          }
+        } else {
+          if (prev) {
+            set.push([first2, prev]);
+          }
+          prev = null;
+          first2 = null;
+        }
+      }
+      if (first2) {
+        set.push([first2, null]);
+      }
+      const ranges = [];
+      for (const [min, max] of set) {
+        if (min === max) {
+          ranges.push(min);
+        } else if (!max && min === v[0]) {
+          ranges.push("*");
+        } else if (!max) {
+          ranges.push(`>=${min}`);
+        } else if (min === v[0]) {
+          ranges.push(`<=${max}`);
+        } else {
+          ranges.push(`${min} - ${max}`);
+        }
+      }
+      const simplified = ranges.join(" || ");
+      const original = typeof range.raw === "string" ? range.raw : String(range);
+      return simplified.length < original.length ? simplified : range;
+    };
+  }
+});
+
+// node_modules/semver/ranges/subset.js
+var require_subset = __commonJS({
+  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var Comparator = require_comparator();
+    var { ANY } = Comparator;
+    var satisfies3 = require_satisfies();
+    var compare = require_compare();
+    var subset = /* @__PURE__ */ __name((sub, dom, options = {}) => {
+      if (sub === dom) {
+        return true;
+      }
+      sub = new Range(sub, options);
+      dom = new Range(dom, options);
+      let sawNonNull = false;
+      OUTER: for (const simpleSub of sub.set) {
+        for (const simpleDom of dom.set) {
+          const isSub = simpleSubset(simpleSub, simpleDom, options);
+          sawNonNull = sawNonNull || isSub !== null;
+          if (isSub) {
+            continue OUTER;
+          }
+        }
+        if (sawNonNull) {
+          return false;
+        }
+      }
+      return true;
+    }, "subset");
+    var minimumVersionWithPreRelease = [new Comparator(">=0.0.0-0")];
+    var minimumVersion = [new Comparator(">=0.0.0")];
+    var simpleSubset = /* @__PURE__ */ __name((sub, dom, options) => {
+      if (sub === dom) {
+        return true;
+      }
+      if (sub.length === 1 && sub[0].semver === ANY) {
+        if (dom.length === 1 && dom[0].semver === ANY) {
+          return true;
+        } else if (options.includePrerelease) {
+          sub = minimumVersionWithPreRelease;
+        } else {
+          sub = minimumVersion;
+        }
+      }
+      if (dom.length === 1 && dom[0].semver === ANY) {
+        if (options.includePrerelease) {
+          return true;
+        } else {
+          dom = minimumVersion;
+        }
+      }
+      const eqSet = /* @__PURE__ */ new Set();
+      let gt2, lt;
+      for (const c of sub) {
+        if (c.operator === ">" || c.operator === ">=") {
+          gt2 = higherGT(gt2, c, options);
+        } else if (c.operator === "<" || c.operator === "<=") {
+          lt = lowerLT(lt, c, options);
+        } else {
+          eqSet.add(c.semver);
+        }
+      }
+      if (eqSet.size > 1) {
+        return null;
+      }
+      let gtltComp;
+      if (gt2 && lt) {
+        gtltComp = compare(gt2.semver, lt.semver, options);
+        if (gtltComp > 0) {
+          return null;
+        } else if (gtltComp === 0 && (gt2.operator !== ">=" || lt.operator !== "<=")) {
+          return null;
+        }
+      }
+      for (const eq of eqSet) {
+        if (gt2 && !satisfies3(eq, String(gt2), options)) {
+          return null;
+        }
+        if (lt && !satisfies3(eq, String(lt), options)) {
+          return null;
+        }
+        for (const c of dom) {
+          if (!satisfies3(eq, String(c), options)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      let higher, lower;
+      let hasDomLT, hasDomGT;
+      let needDomLTPre = lt && !options.includePrerelease && lt.semver.prerelease.length ? lt.semver : false;
+      let needDomGTPre = gt2 && !options.includePrerelease && gt2.semver.prerelease.length ? gt2.semver : false;
+      if (needDomLTPre && needDomLTPre.prerelease.length === 1 && lt.operator === "<" && needDomLTPre.prerelease[0] === 0) {
+        needDomLTPre = false;
+      }
+      for (const c of dom) {
+        hasDomGT = hasDomGT || c.operator === ">" || c.operator === ">=";
+        hasDomLT = hasDomLT || c.operator === "<" || c.operator === "<=";
+        if (gt2) {
+          if (needDomGTPre) {
+            if (c.semver.prerelease && c.semver.prerelease.length && c.semver.major === needDomGTPre.major && c.semver.minor ===
+            needDomGTPre.minor && c.semver.patch === needDomGTPre.patch) {
+              needDomGTPre = false;
+            }
+          }
+          if (c.operator === ">" || c.operator === ">=") {
+            higher = higherGT(gt2, c, options);
+            if (higher === c && higher !== gt2) {
+              return false;
+            }
+          } else if (gt2.operator === ">=" && !satisfies3(gt2.semver, String(c), options)) {
+            return false;
+          }
+        }
+        if (lt) {
+          if (needDomLTPre) {
+            if (c.semver.prerelease && c.semver.prerelease.length && c.semver.major === needDomLTPre.major && c.semver.minor ===
+            needDomLTPre.minor && c.semver.patch === needDomLTPre.patch) {
+              needDomLTPre = false;
+            }
+          }
+          if (c.operator === "<" || c.operator === "<=") {
+            lower = lowerLT(lt, c, options);
+            if (lower === c && lower !== lt) {
+              return false;
+            }
+          } else if (lt.operator === "<=" && !satisfies3(lt.semver, String(c), options)) {
+            return false;
+          }
+        }
+        if (!c.operator && (lt || gt2) && gtltComp !== 0) {
+          return false;
+        }
+      }
+      if (gt2 && hasDomLT && !lt && gtltComp !== 0) {
+        return false;
+      }
+      if (lt && hasDomGT && !gt2 && gtltComp !== 0) {
+        return false;
+      }
+      if (needDomGTPre || needDomLTPre) {
+        return false;
+      }
+      return true;
+    }, "simpleSubset");
+    var higherGT = /* @__PURE__ */ __name((a, b, options) => {
+      if (!a) {
+        return b;
+      }
+      const comp = compare(a.semver, b.semver, options);
+      return comp > 0 ? a : comp < 0 ? b : b.operator === ">" && a.operator === ">=" ? b : a;
+    }, "higherGT");
+    var lowerLT = /* @__PURE__ */ __name((a, b, options) => {
+      if (!a) {
+        return b;
+      }
+      const comp = compare(a.semver, b.semver, options);
+      return comp < 0 ? a : comp > 0 ? b : b.operator === "<" && a.operator === "<=" ? b : a;
+    }, "lowerLT");
+    module2.exports = subset;
+  }
+});
+
+// node_modules/semver/index.js
+var require_semver2 = __commonJS({
+  "node_modules/semver/index.js"(exports2, module2) {
+    "use strict";
+    var internalRe = require_re();
+    var constants3 = require_constants6();
+    var SemVer = require_semver();
+    var identifiers = require_identifiers();
+    var parse = require_parse2();
+    var valid2 = require_valid();
+    var clean2 = require_clean();
+    var inc = require_inc();
+    var diff = require_diff();
+    var major = require_major();
+    var minor = require_minor();
+    var patch = require_patch();
+    var prerelease = require_prerelease();
+    var compare = require_compare();
+    var rcompare = require_rcompare();
+    var compareLoose = require_compare_loose();
+    var compareBuild = require_compare_build();
+    var sort = require_sort();
+    var rsort = require_rsort();
+    var gt2 = require_gt();
+    var lt = require_lt();
+    var eq = require_eq();
+    var neq = require_neq();
+    var gte = require_gte();
+    var lte = require_lte();
+    var cmp = require_cmp();
+    var coerce = require_coerce();
+    var Comparator = require_comparator();
+    var Range = require_range();
+    var satisfies3 = require_satisfies();
+    var toComparators = require_to_comparators();
+    var maxSatisfying = require_max_satisfying();
+    var minSatisfying = require_min_satisfying();
+    var minVersion = require_min_version();
+    var validRange = require_valid2();
+    var outside = require_outside();
+    var gtr = require_gtr();
+    var ltr = require_ltr();
+    var intersects = require_intersects();
+    var simplifyRange = require_simplify();
+    var subset = require_subset();
+    module2.exports = {
+      parse,
+      valid: valid2,
+      clean: clean2,
+      inc,
+      diff,
+      major,
+      minor,
+      patch,
+      prerelease,
+      compare,
+      rcompare,
+      compareLoose,
+      compareBuild,
+      sort,
+      rsort,
+      gt: gt2,
+      lt,
+      eq,
+      neq,
+      gte,
+      lte,
+      cmp,
+      coerce,
+      Comparator,
+      Range,
+      satisfies: satisfies3,
+      toComparators,
+      maxSatisfying,
+      minSatisfying,
+      minVersion,
+      validRange,
+      outside,
+      gtr,
+      ltr,
+      intersects,
+      simplifyRange,
+      subset,
+      SemVer,
+      re: internalRe.re,
+      src: internalRe.src,
+      tokens: internalRe.t,
+      SEMVER_SPEC_VERSION: constants3.SEMVER_SPEC_VERSION,
+      RELEASE_TYPES: constants3.RELEASE_TYPES,
+      compareIdentifiers: identifiers.compareIdentifiers,
+      rcompareIdentifiers: identifiers.rcompareIdentifiers
+    };
+  }
+});
+
+// node_modules/simple-git/dist/esm/index.js
+var import_node_buffer = require("node:buffer");
+var import_file_exists = __toESM(require_dist(), 1);
+var import_debug = __toESM(require_src(), 1);
+var import_child_process = require("child_process");
+var import_promise_deferred = __toESM(require_dist2(), 1);
+var import_node_path = require("node:path");
+var import_promise_deferred2 = __toESM(require_dist2(), 1);
+var __defProp2 = Object.defineProperty;
+var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames2 = Object.getOwnPropertyNames;
+var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+var __esm = /* @__PURE__ */ __name((fn, res) => /* @__PURE__ */ __name(function __init() {
+  return fn && (res = (0, fn[__getOwnPropNames2(fn)[0]])(fn = 0)), res;
+}, "__init"), "__esm");
+var __commonJS2 = /* @__PURE__ */ __name((cb, mod) => /* @__PURE__ */ __name(function __require() {
+  return mod || (0, cb[__getOwnPropNames2(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+}, "__require"), "__commonJS");
+var __export = /* @__PURE__ */ __name((target, all) => {
+  for (var name in all)
+    __defProp2(target, name, { get: all[name], enumerable: true });
+}, "__export");
+var __copyProps2 = /* @__PURE__ */ __name((to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames2(from))
+      if (!__hasOwnProp2.call(to, key) && key !== except)
+        __defProp2(to, key, { get: /* @__PURE__ */ __name(() => from[key], "get"), enumerable: !(desc = __getOwnPropDesc2(
+        from, key)) || desc.enumerable });
+  }
+  return to;
+}, "__copyProps");
+var __toCommonJS = /* @__PURE__ */ __name((mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod), "__\
+toCommonJS");
+function pathspec(...paths) {
+  const key = new String(paths);
+  cache.set(key, paths);
+  return key;
+}
+__name(pathspec, "pathspec");
+function isPathSpec(path5) {
+  return path5 instanceof String && cache.has(path5);
+}
+__name(isPathSpec, "isPathSpec");
+var cache;
+var init_pathspec = __esm({
+  "src/lib/args/pathspec.ts"() {
+    "use strict";
+    cache = /* @__PURE__ */ new WeakMap();
+  }
+});
+var GitError;
+var init_git_error = __esm({
+  "src/lib/errors/git-error.ts"() {
+    "use strict";
+    GitError = class extends Error {
+      static {
+        __name(this, "GitError");
+      }
+      constructor(task, message) {
+        super(message);
+        this.task = task;
+        Object.setPrototypeOf(this, new.target.prototype);
+      }
+    };
+  }
+});
+var GitResponseError;
+var init_git_response_error = __esm({
+  "src/lib/errors/git-response-error.ts"() {
+    "use strict";
+    init_git_error();
+    GitResponseError = class extends GitError {
+      static {
+        __name(this, "GitResponseError");
+      }
+      constructor(git, message) {
+        super(void 0, message || String(git));
+        this.git = git;
+      }
+    };
+  }
+});
+var TaskConfigurationError;
+var init_task_configuration_error = __esm({
+  "src/lib/errors/task-configuration-error.ts"() {
+    "use strict";
+    init_git_error();
+    TaskConfigurationError = class extends GitError {
+      static {
+        __name(this, "TaskConfigurationError");
+      }
+      constructor(message) {
+        super(void 0, message);
+      }
+    };
+  }
+});
+function asFunction(source) {
+  if (typeof source !== "function") {
+    return NOOP;
+  }
+  return source;
+}
+__name(asFunction, "asFunction");
+function isUserFunction(source) {
+  return typeof source === "function" && source !== NOOP;
+}
+__name(isUserFunction, "isUserFunction");
+function splitOn(input, char) {
+  const index = input.indexOf(char);
+  if (index <= 0) {
+    return [input, ""];
+  }
+  return [input.substr(0, index), input.substr(index + 1)];
+}
+__name(splitOn, "splitOn");
+function first(input, offset = 0) {
+  return isArrayLike(input) && input.length > offset ? input[offset] : void 0;
+}
+__name(first, "first");
+function last(input, offset = 0) {
+  if (isArrayLike(input) && input.length > offset) {
+    return input[input.length - 1 - offset];
+  }
+}
+__name(last, "last");
+function isArrayLike(input) {
+  return filterHasLength(input);
+}
+__name(isArrayLike, "isArrayLike");
+function toLinesWithContent(input = "", trimmed2 = true, separator = "\n") {
+  return input.split(separator).reduce((output, line) => {
+    const lineContent = trimmed2 ? line.trim() : line;
+    if (lineContent) {
+      output.push(lineContent);
+    }
+    return output;
+  }, []);
+}
+__name(toLinesWithContent, "toLinesWithContent");
+function forEachLineWithContent(input, callback) {
+  return toLinesWithContent(input, true).map((line) => callback(line));
+}
+__name(forEachLineWithContent, "forEachLineWithContent");
+function folderExists(path5) {
+  return (0, import_file_exists.exists)(path5, import_file_exists.FOLDER);
+}
+__name(folderExists, "folderExists");
+function append(target, item) {
+  if (Array.isArray(target)) {
+    if (!target.includes(item)) {
+      target.push(item);
+    }
+  } else {
+    target.add(item);
+  }
+  return item;
+}
+__name(append, "append");
+function including(target, item) {
+  if (Array.isArray(target) && !target.includes(item)) {
+    target.push(item);
+  }
+  return target;
+}
+__name(including, "including");
+function remove(target, item) {
+  if (Array.isArray(target)) {
+    const index = target.indexOf(item);
+    if (index >= 0) {
+      target.splice(index, 1);
+    }
+  } else {
+    target.delete(item);
+  }
+  return item;
+}
+__name(remove, "remove");
+function asArray(source) {
+  return Array.isArray(source) ? source : [source];
+}
+__name(asArray, "asArray");
+function asCamelCase(str) {
+  return str.replace(/[\s-]+(.)/g, (_all, chr) => {
+    return chr.toUpperCase();
+  });
+}
+__name(asCamelCase, "asCamelCase");
+function asStringArray(source) {
+  return asArray(source).map((item) => {
+    return item instanceof String ? item : String(item);
+  });
+}
+__name(asStringArray, "asStringArray");
+function asNumber(source, onNaN = 0) {
+  if (source == null) {
+    return onNaN;
+  }
+  const num = parseInt(source, 10);
+  return Number.isNaN(num) ? onNaN : num;
+}
+__name(asNumber, "asNumber");
+function prefixedArray(input, prefix) {
+  const output = [];
+  for (let i = 0, max = input.length; i < max; i++) {
+    output.push(prefix, input[i]);
+  }
+  return output;
+}
+__name(prefixedArray, "prefixedArray");
+function bufferToString(input) {
+  return (Array.isArray(input) ? import_node_buffer.Buffer.concat(input) : input).toString("utf-8");
+}
+__name(bufferToString, "bufferToString");
+function pick(source, properties) {
+  const out = {};
+  properties.forEach((key) => {
+    if (source[key] !== void 0) {
+      out[key] = source[key];
+    }
+  });
+  return out;
+}
+__name(pick, "pick");
+function delay(duration = 0) {
+  return new Promise((done) => setTimeout(done, duration));
+}
+__name(delay, "delay");
+function orVoid(input) {
+  if (input === false) {
+    return void 0;
+  }
+  return input;
+}
+__name(orVoid, "orVoid");
+var NULL;
+var NOOP;
+var objectToString;
+var init_util = __esm({
+  "src/lib/utils/util.ts"() {
+    "use strict";
+    init_argument_filters();
+    NULL = "\0";
+    NOOP = /* @__PURE__ */ __name(() => {
+    }, "NOOP");
+    objectToString = Object.prototype.toString.call.bind(Object.prototype.toString);
+  }
+});
+function filterType(input, filter, def) {
+  if (filter(input)) {
+    return input;
+  }
+  return arguments.length > 2 ? def : void 0;
+}
+__name(filterType, "filterType");
+function filterPrimitives(input, omit) {
+  const type = isPathSpec(input) ? "string" : typeof input;
+  return /number|string|boolean/.test(type) && (!omit || !omit.includes(type));
+}
+__name(filterPrimitives, "filterPrimitives");
+function filterPlainObject(input) {
+  return !!input && objectToString(input) === "[object Object]";
+}
+__name(filterPlainObject, "filterPlainObject");
+function filterFunction(input) {
+  return typeof input === "function";
+}
+__name(filterFunction, "filterFunction");
+var filterArray;
+var filterNumber;
+var filterString;
+var filterStringOrStringArray;
+var filterHasLength;
+var init_argument_filters = __esm({
+  "src/lib/utils/argument-filters.ts"() {
+    "use strict";
+    init_pathspec();
+    init_util();
+    filterArray = /* @__PURE__ */ __name((input) => {
+      return Array.isArray(input);
+    }, "filterArray");
+    filterNumber = /* @__PURE__ */ __name((input) => {
+      return typeof input === "number";
+    }, "filterNumber");
+    filterString = /* @__PURE__ */ __name((input) => {
+      return typeof input === "string" || isPathSpec(input);
+    }, "filterString");
+    filterStringOrStringArray = /* @__PURE__ */ __name((input) => {
+      return filterString(input) || Array.isArray(input) && input.every(filterString);
+    }, "filterStringOrStringArray");
+    filterHasLength = /* @__PURE__ */ __name((input) => {
+      if (input == null || "number|boolean|function".includes(typeof input)) {
+        return false;
+      }
+      return typeof input.length === "number";
+    }, "filterHasLength");
+  }
+});
+var ExitCodes;
+var init_exit_codes = __esm({
+  "src/lib/utils/exit-codes.ts"() {
+    "use strict";
+    ExitCodes = /* @__PURE__ */ ((ExitCodes2) => {
+      ExitCodes2[ExitCodes2["SUCCESS"] = 0] = "SUCCESS";
+      ExitCodes2[ExitCodes2["ERROR"] = 1] = "ERROR";
+      ExitCodes2[ExitCodes2["NOT_FOUND"] = -2] = "NOT_FOUND";
+      ExitCodes2[ExitCodes2["UNCLEAN"] = 128] = "UNCLEAN";
+      return ExitCodes2;
+    })(ExitCodes || {});
+  }
+});
+var GitOutputStreams;
+var init_git_output_streams = __esm({
+  "src/lib/utils/git-output-streams.ts"() {
+    "use strict";
+    GitOutputStreams = class _GitOutputStreams {
+      static {
+        __name(this, "_GitOutputStreams");
+      }
+      constructor(stdOut, stdErr) {
+        this.stdOut = stdOut;
+        this.stdErr = stdErr;
+      }
+      asStrings() {
+        return new _GitOutputStreams(this.stdOut.toString("utf8"), this.stdErr.toString("utf8"));
+      }
+    };
+  }
+});
+function useMatchesDefault() {
+  throw new Error(`LineParser:useMatches not implemented`);
+}
+__name(useMatchesDefault, "useMatchesDefault");
+var LineParser;
+var RemoteLineParser;
+var init_line_parser = __esm({
+  "src/lib/utils/line-parser.ts"() {
+    "use strict";
+    LineParser = class {
+      static {
+        __name(this, "LineParser");
+      }
+      constructor(regExp, useMatches) {
+        this.matches = [];
+        this.useMatches = useMatchesDefault;
+        this.parse = (line, target) => {
+          this.resetMatches();
+          if (!this._regExp.every((reg, index) => this.addMatch(reg, index, line(index)))) {
+            return false;
+          }
+          return this.useMatches(target, this.prepareMatches()) !== false;
+        };
+        this._regExp = Array.isArray(regExp) ? regExp : [regExp];
+        if (useMatches) {
+          this.useMatches = useMatches;
+        }
+      }
+      resetMatches() {
+        this.matches.length = 0;
+      }
+      prepareMatches() {
+        return this.matches;
+      }
+      addMatch(reg, index, line) {
+        const matched = line && reg.exec(line);
+        if (matched) {
+          this.pushMatch(index, matched);
+        }
+        return !!matched;
+      }
+      pushMatch(_index, matched) {
+        this.matches.push(...matched.slice(1));
+      }
+    };
+    RemoteLineParser = class extends LineParser {
+      static {
+        __name(this, "RemoteLineParser");
+      }
+      addMatch(reg, index, line) {
+        return /^remote:\s/.test(String(line)) && super.addMatch(reg, index, line);
+      }
+      pushMatch(index, matched) {
+        if (index > 0 || matched.length > 1) {
+          super.pushMatch(index, matched);
+        }
+      }
+    };
+  }
+});
+function createInstanceConfig(...options) {
+  const baseDir = process.cwd();
+  const config = Object.assign(
+    { baseDir, ...defaultOptions },
+    ...options.filter((o) => typeof o === "object" && o)
+  );
+  config.baseDir = config.baseDir || baseDir;
+  config.trimmed = config.trimmed === true;
+  return config;
+}
+__name(createInstanceConfig, "createInstanceConfig");
+var defaultOptions;
+var init_simple_git_options = __esm({
+  "src/lib/utils/simple-git-options.ts"() {
+    "use strict";
+    defaultOptions = {
+      binary: "git",
+      maxConcurrentProcesses: 5,
+      config: [],
+      trimmed: false
+    };
+  }
+});
+function appendTaskOptions(options, commands = []) {
+  if (!filterPlainObject(options)) {
+    return commands;
+  }
+  return Object.keys(options).reduce((commands2, key) => {
+    const value = options[key];
+    if (isPathSpec(value)) {
+      commands2.push(value);
+    } else if (filterPrimitives(value, ["boolean"])) {
+      commands2.push(key + "=" + value);
+    } else if (Array.isArray(value)) {
+      for (const v of value) {
+        if (!filterPrimitives(v, ["string", "number"])) {
+          commands2.push(key + "=" + v);
+        }
+      }
+    } else {
+      commands2.push(key);
+    }
+    return commands2;
+  }, commands);
+}
+__name(appendTaskOptions, "appendTaskOptions");
+function getTrailingOptions(args, initialPrimitive = 0, objectOnly = false) {
+  const command = [];
+  for (let i = 0, max = initialPrimitive < 0 ? args.length : initialPrimitive; i < max; i++) {
+    if ("string|number".includes(typeof args[i])) {
+      command.push(String(args[i]));
+    }
+  }
+  appendTaskOptions(trailingOptionsArgument(args), command);
+  if (!objectOnly) {
+    command.push(...trailingArrayArgument(args));
+  }
+  return command;
+}
+__name(getTrailingOptions, "getTrailingOptions");
+function trailingArrayArgument(args) {
+  const hasTrailingCallback = typeof last(args) === "function";
+  return asStringArray(filterType(last(args, hasTrailingCallback ? 1 : 0), filterArray, []));
+}
+__name(trailingArrayArgument, "trailingArrayArgument");
+function trailingOptionsArgument(args) {
+  const hasTrailingCallback = filterFunction(last(args));
+  return filterType(last(args, hasTrailingCallback ? 1 : 0), filterPlainObject);
+}
+__name(trailingOptionsArgument, "trailingOptionsArgument");
+function trailingFunctionArgument(args, includeNoop = true) {
+  const callback = asFunction(last(args));
+  return includeNoop || isUserFunction(callback) ? callback : void 0;
+}
+__name(trailingFunctionArgument, "trailingFunctionArgument");
+var init_task_options = __esm({
+  "src/lib/utils/task-options.ts"() {
+    "use strict";
+    init_argument_filters();
+    init_util();
+    init_pathspec();
+  }
+});
+function callTaskParser(parser4, streams) {
+  return parser4(streams.stdOut, streams.stdErr);
+}
+__name(callTaskParser, "callTaskParser");
+function parseStringResponse(result, parsers12, texts, trim = true) {
+  asArray(texts).forEach((text) => {
+    for (let lines = toLinesWithContent(text, trim), i = 0, max = lines.length; i < max; i++) {
+      const line = /* @__PURE__ */ __name((offset = 0) => {
+        if (i + offset >= max) {
+          return;
+        }
+        return lines[i + offset];
+      }, "line");
+      parsers12.some(({ parse }) => parse(line, result));
+    }
+  });
+  return result;
+}
+__name(parseStringResponse, "parseStringResponse");
+var init_task_parser = __esm({
+  "src/lib/utils/task-parser.ts"() {
+    "use strict";
+    init_util();
+  }
+});
+var utils_exports = {};
+__export(utils_exports, {
+  ExitCodes: /* @__PURE__ */ __name(() => ExitCodes, "ExitCodes"),
+  GitOutputStreams: /* @__PURE__ */ __name(() => GitOutputStreams, "GitOutputStreams"),
+  LineParser: /* @__PURE__ */ __name(() => LineParser, "LineParser"),
+  NOOP: /* @__PURE__ */ __name(() => NOOP, "NOOP"),
+  NULL: /* @__PURE__ */ __name(() => NULL, "NULL"),
+  RemoteLineParser: /* @__PURE__ */ __name(() => RemoteLineParser, "RemoteLineParser"),
+  append: /* @__PURE__ */ __name(() => append, "append"),
+  appendTaskOptions: /* @__PURE__ */ __name(() => appendTaskOptions, "appendTaskOptions"),
+  asArray: /* @__PURE__ */ __name(() => asArray, "asArray"),
+  asCamelCase: /* @__PURE__ */ __name(() => asCamelCase, "asCamelCase"),
+  asFunction: /* @__PURE__ */ __name(() => asFunction, "asFunction"),
+  asNumber: /* @__PURE__ */ __name(() => asNumber, "asNumber"),
+  asStringArray: /* @__PURE__ */ __name(() => asStringArray, "asStringArray"),
+  bufferToString: /* @__PURE__ */ __name(() => bufferToString, "bufferToString"),
+  callTaskParser: /* @__PURE__ */ __name(() => callTaskParser, "callTaskParser"),
+  createInstanceConfig: /* @__PURE__ */ __name(() => createInstanceConfig, "createInstanceConfig"),
+  delay: /* @__PURE__ */ __name(() => delay, "delay"),
+  filterArray: /* @__PURE__ */ __name(() => filterArray, "filterArray"),
+  filterFunction: /* @__PURE__ */ __name(() => filterFunction, "filterFunction"),
+  filterHasLength: /* @__PURE__ */ __name(() => filterHasLength, "filterHasLength"),
+  filterNumber: /* @__PURE__ */ __name(() => filterNumber, "filterNumber"),
+  filterPlainObject: /* @__PURE__ */ __name(() => filterPlainObject, "filterPlainObject"),
+  filterPrimitives: /* @__PURE__ */ __name(() => filterPrimitives, "filterPrimitives"),
+  filterString: /* @__PURE__ */ __name(() => filterString, "filterString"),
+  filterStringOrStringArray: /* @__PURE__ */ __name(() => filterStringOrStringArray, "filterStringOrStringArray"),
+  filterType: /* @__PURE__ */ __name(() => filterType, "filterType"),
+  first: /* @__PURE__ */ __name(() => first, "first"),
+  folderExists: /* @__PURE__ */ __name(() => folderExists, "folderExists"),
+  forEachLineWithContent: /* @__PURE__ */ __name(() => forEachLineWithContent, "forEachLineWithContent"),
+  getTrailingOptions: /* @__PURE__ */ __name(() => getTrailingOptions, "getTrailingOptions"),
+  including: /* @__PURE__ */ __name(() => including, "including"),
+  isUserFunction: /* @__PURE__ */ __name(() => isUserFunction, "isUserFunction"),
+  last: /* @__PURE__ */ __name(() => last, "last"),
+  objectToString: /* @__PURE__ */ __name(() => objectToString, "objectToString"),
+  orVoid: /* @__PURE__ */ __name(() => orVoid, "orVoid"),
+  parseStringResponse: /* @__PURE__ */ __name(() => parseStringResponse, "parseStringResponse"),
+  pick: /* @__PURE__ */ __name(() => pick, "pick"),
+  prefixedArray: /* @__PURE__ */ __name(() => prefixedArray, "prefixedArray"),
+  remove: /* @__PURE__ */ __name(() => remove, "remove"),
+  splitOn: /* @__PURE__ */ __name(() => splitOn, "splitOn"),
+  toLinesWithContent: /* @__PURE__ */ __name(() => toLinesWithContent, "toLinesWithContent"),
+  trailingFunctionArgument: /* @__PURE__ */ __name(() => trailingFunctionArgument, "trailingFunctionArgument"),
+  trailingOptionsArgument: /* @__PURE__ */ __name(() => trailingOptionsArgument, "trailingOptionsArgument")
+});
+var init_utils = __esm({
+  "src/lib/utils/index.ts"() {
+    "use strict";
+    init_argument_filters();
+    init_exit_codes();
+    init_git_output_streams();
+    init_line_parser();
+    init_simple_git_options();
+    init_task_options();
+    init_task_parser();
+    init_util();
+  }
+});
+var check_is_repo_exports = {};
+__export(check_is_repo_exports, {
+  CheckRepoActions: /* @__PURE__ */ __name(() => CheckRepoActions, "CheckRepoActions"),
+  checkIsBareRepoTask: /* @__PURE__ */ __name(() => checkIsBareRepoTask, "checkIsBareRepoTask"),
+  checkIsRepoRootTask: /* @__PURE__ */ __name(() => checkIsRepoRootTask, "checkIsRepoRootTask"),
+  checkIsRepoTask: /* @__PURE__ */ __name(() => checkIsRepoTask, "checkIsRepoTask")
+});
+function checkIsRepoTask(action) {
+  switch (action) {
+    case "bare":
+      return checkIsBareRepoTask();
+    case "root":
+      return checkIsRepoRootTask();
+  }
+  const commands = ["rev-parse", "--is-inside-work-tree"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser
+  };
+}
+__name(checkIsRepoTask, "checkIsRepoTask");
+function checkIsRepoRootTask() {
+  const commands = ["rev-parse", "--git-dir"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser(path5) {
+      return /^\.(git)?$/.test(path5.trim());
+    }
+  };
+}
+__name(checkIsRepoRootTask, "checkIsRepoRootTask");
+function checkIsBareRepoTask() {
+  const commands = ["rev-parse", "--is-bare-repository"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser
+  };
+}
+__name(checkIsBareRepoTask, "checkIsBareRepoTask");
+function isNotRepoMessage(error2) {
+  return /(Not a git repository|Kein Git-Repository)/i.test(String(error2));
+}
+__name(isNotRepoMessage, "isNotRepoMessage");
+var CheckRepoActions;
+var onError;
+var parser;
+var init_check_is_repo = __esm({
+  "src/lib/tasks/check-is-repo.ts"() {
+    "use strict";
+    init_utils();
+    CheckRepoActions = /* @__PURE__ */ ((CheckRepoActions2) => {
+      CheckRepoActions2["BARE"] = "bare";
+      CheckRepoActions2["IN_TREE"] = "tree";
+      CheckRepoActions2["IS_REPO_ROOT"] = "root";
+      return CheckRepoActions2;
+    })(CheckRepoActions || {});
+    onError = /* @__PURE__ */ __name(({ exitCode }, error2, done, fail) => {
+      if (exitCode === 128 && isNotRepoMessage(error2)) {
+        return done(Buffer.from("false"));
+      }
+      fail(error2);
+    }, "onError");
+    parser = /* @__PURE__ */ __name((text) => {
+      return text.trim() === "true";
+    }, "parser");
+  }
+});
+function cleanSummaryParser(dryRun, text) {
+  const summary2 = new CleanResponse(dryRun);
+  const regexp = dryRun ? dryRunRemovalRegexp : removalRegexp;
+  toLinesWithContent(text).forEach((line) => {
+    const removed = line.replace(regexp, "");
+    summary2.paths.push(removed);
+    (isFolderRegexp.test(removed) ? summary2.folders : summary2.files).push(removed);
+  });
+  return summary2;
+}
+__name(cleanSummaryParser, "cleanSummaryParser");
+var CleanResponse;
+var removalRegexp;
+var dryRunRemovalRegexp;
+var isFolderRegexp;
+var init_CleanSummary = __esm({
+  "src/lib/responses/CleanSummary.ts"() {
+    "use strict";
+    init_utils();
+    CleanResponse = class {
+      static {
+        __name(this, "CleanResponse");
+      }
+      constructor(dryRun) {
+        this.dryRun = dryRun;
+        this.paths = [];
+        this.files = [];
+        this.folders = [];
+      }
+    };
+    removalRegexp = /^[a-z]+\s*/i;
+    dryRunRemovalRegexp = /^[a-z]+\s+[a-z]+\s*/i;
+    isFolderRegexp = /\/$/;
+  }
+});
+var task_exports = {};
+__export(task_exports, {
+  EMPTY_COMMANDS: /* @__PURE__ */ __name(() => EMPTY_COMMANDS, "EMPTY_COMMANDS"),
+  adhocExecTask: /* @__PURE__ */ __name(() => adhocExecTask, "adhocExecTask"),
+  configurationErrorTask: /* @__PURE__ */ __name(() => configurationErrorTask, "configurationErrorTask"),
+  isBufferTask: /* @__PURE__ */ __name(() => isBufferTask, "isBufferTask"),
+  isEmptyTask: /* @__PURE__ */ __name(() => isEmptyTask, "isEmptyTask"),
+  straightThroughBufferTask: /* @__PURE__ */ __name(() => straightThroughBufferTask, "straightThroughBufferTask"),
+  straightThroughStringTask: /* @__PURE__ */ __name(() => straightThroughStringTask, "straightThroughStringTask")
+});
+function adhocExecTask(parser4) {
+  return {
+    commands: EMPTY_COMMANDS,
+    format: "empty",
+    parser: parser4
+  };
+}
+__name(adhocExecTask, "adhocExecTask");
+function configurationErrorTask(error2) {
+  return {
+    commands: EMPTY_COMMANDS,
+    format: "empty",
+    parser() {
+      throw typeof error2 === "string" ? new TaskConfigurationError(error2) : error2;
+    }
+  };
+}
+__name(configurationErrorTask, "configurationErrorTask");
+function straightThroughStringTask(commands, trimmed2 = false) {
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return trimmed2 ? String(text).trim() : text;
+    }
+  };
+}
+__name(straightThroughStringTask, "straightThroughStringTask");
+function straightThroughBufferTask(commands) {
+  return {
+    commands,
+    format: "buffer",
+    parser(buffer) {
+      return buffer;
+    }
+  };
+}
+__name(straightThroughBufferTask, "straightThroughBufferTask");
+function isBufferTask(task) {
+  return task.format === "buffer";
+}
+__name(isBufferTask, "isBufferTask");
+function isEmptyTask(task) {
+  return task.format === "empty" || !task.commands.length;
+}
+__name(isEmptyTask, "isEmptyTask");
+var EMPTY_COMMANDS;
+var init_task = __esm({
+  "src/lib/tasks/task.ts"() {
+    "use strict";
+    init_task_configuration_error();
+    EMPTY_COMMANDS = [];
+  }
+});
+var clean_exports = {};
+__export(clean_exports, {
+  CONFIG_ERROR_INTERACTIVE_MODE: /* @__PURE__ */ __name(() => CONFIG_ERROR_INTERACTIVE_MODE, "CONFIG_ERROR_INTERACTIVE_M\
+ODE"),
+  CONFIG_ERROR_MODE_REQUIRED: /* @__PURE__ */ __name(() => CONFIG_ERROR_MODE_REQUIRED, "CONFIG_ERROR_MODE_REQUIRED"),
+  CONFIG_ERROR_UNKNOWN_OPTION: /* @__PURE__ */ __name(() => CONFIG_ERROR_UNKNOWN_OPTION, "CONFIG_ERROR_UNKNOWN_OPTION"),
+  CleanOptions: /* @__PURE__ */ __name(() => CleanOptions, "CleanOptions"),
+  cleanTask: /* @__PURE__ */ __name(() => cleanTask, "cleanTask"),
+  cleanWithOptionsTask: /* @__PURE__ */ __name(() => cleanWithOptionsTask, "cleanWithOptionsTask"),
+  isCleanOptionsArray: /* @__PURE__ */ __name(() => isCleanOptionsArray, "isCleanOptionsArray")
+});
+function cleanWithOptionsTask(mode, customArgs) {
+  const { cleanMode, options, valid: valid2 } = getCleanOptions(mode);
+  if (!cleanMode) {
+    return configurationErrorTask(CONFIG_ERROR_MODE_REQUIRED);
+  }
+  if (!valid2.options) {
+    return configurationErrorTask(CONFIG_ERROR_UNKNOWN_OPTION + JSON.stringify(mode));
+  }
+  options.push(...customArgs);
+  if (options.some(isInteractiveMode)) {
+    return configurationErrorTask(CONFIG_ERROR_INTERACTIVE_MODE);
+  }
+  return cleanTask(cleanMode, options);
+}
+__name(cleanWithOptionsTask, "cleanWithOptionsTask");
+function cleanTask(mode, customArgs) {
+  const commands = ["clean", `-${mode}`, ...customArgs];
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return cleanSummaryParser(mode === "n", text);
+    }
+  };
+}
+__name(cleanTask, "cleanTask");
+function isCleanOptionsArray(input) {
+  return Array.isArray(input) && input.every((test) => CleanOptionValues.has(test));
+}
+__name(isCleanOptionsArray, "isCleanOptionsArray");
+function getCleanOptions(input) {
+  let cleanMode;
+  let options = [];
+  let valid2 = { cleanMode: false, options: true };
+  input.replace(/[^a-z]i/g, "").split("").forEach((char) => {
+    if (isCleanMode(char)) {
+      cleanMode = char;
+      valid2.cleanMode = true;
+    } else {
+      valid2.options = valid2.options && isKnownOption(options[options.length] = `-${char}`);
+    }
+  });
+  return {
+    cleanMode,
+    options,
+    valid: valid2
+  };
+}
+__name(getCleanOptions, "getCleanOptions");
+function isCleanMode(cleanMode) {
+  return cleanMode === "f" || cleanMode === "n";
+}
+__name(isCleanMode, "isCleanMode");
+function isKnownOption(option) {
+  return /^-[a-z]$/i.test(option) && CleanOptionValues.has(option.charAt(1));
+}
+__name(isKnownOption, "isKnownOption");
+function isInteractiveMode(option) {
+  if (/^-[^\-]/.test(option)) {
+    return option.indexOf("i") > 0;
+  }
+  return option === "--interactive";
+}
+__name(isInteractiveMode, "isInteractiveMode");
+var CONFIG_ERROR_INTERACTIVE_MODE;
+var CONFIG_ERROR_MODE_REQUIRED;
+var CONFIG_ERROR_UNKNOWN_OPTION;
+var CleanOptions;
+var CleanOptionValues;
+var init_clean = __esm({
+  "src/lib/tasks/clean.ts"() {
+    "use strict";
+    init_CleanSummary();
+    init_utils();
+    init_task();
+    CONFIG_ERROR_INTERACTIVE_MODE = "Git clean interactive mode is not supported";
+    CONFIG_ERROR_MODE_REQUIRED = 'Git clean mode parameter ("n" or "f") is required';
+    CONFIG_ERROR_UNKNOWN_OPTION = "Git clean unknown option found in: ";
+    CleanOptions = /* @__PURE__ */ ((CleanOptions2) => {
+      CleanOptions2["DRY_RUN"] = "n";
+      CleanOptions2["FORCE"] = "f";
+      CleanOptions2["IGNORED_INCLUDED"] = "x";
+      CleanOptions2["IGNORED_ONLY"] = "X";
+      CleanOptions2["EXCLUDING"] = "e";
+      CleanOptions2["QUIET"] = "q";
+      CleanOptions2["RECURSIVE"] = "d";
+      return CleanOptions2;
+    })(CleanOptions || {});
+    CleanOptionValues = /* @__PURE__ */ new Set([
+      "i",
+      ...asStringArray(Object.values(CleanOptions))
+    ]);
+  }
+});
+function configListParser(text) {
+  const config = new ConfigList();
+  for (const item of configParser(text)) {
+    config.addValue(item.file, String(item.key), item.value);
+  }
+  return config;
+}
+__name(configListParser, "configListParser");
+function configGetParser(text, key) {
+  let value = null;
+  const values = [];
+  const scopes = /* @__PURE__ */ new Map();
+  for (const item of configParser(text, key)) {
+    if (item.key !== key) {
+      continue;
+    }
+    values.push(value = item.value);
+    if (!scopes.has(item.file)) {
+      scopes.set(item.file, []);
+    }
+    scopes.get(item.file).push(value);
+  }
+  return {
+    key,
+    paths: Array.from(scopes.keys()),
+    scopes,
+    value,
+    values
+  };
+}
+__name(configGetParser, "configGetParser");
+function configFilePath(filePath) {
+  return filePath.replace(/^(file):/, "");
+}
+__name(configFilePath, "configFilePath");
+function* configParser(text, requestedKey = null) {
+  const lines = text.split("\0");
+  for (let i = 0, max = lines.length - 1; i < max; ) {
+    const file = configFilePath(lines[i++]);
+    let value = lines[i++];
+    let key = requestedKey;
+    if (value.includes("\n")) {
+      const line = splitOn(value, "\n");
+      key = line[0];
+      value = line[1];
+    }
+    yield { file, key, value };
+  }
+}
+__name(configParser, "configParser");
+var ConfigList;
+var init_ConfigList = __esm({
+  "src/lib/responses/ConfigList.ts"() {
+    "use strict";
+    init_utils();
+    ConfigList = class {
+      static {
+        __name(this, "ConfigList");
+      }
+      constructor() {
+        this.files = [];
+        this.values = /* @__PURE__ */ Object.create(null);
+      }
+      get all() {
+        if (!this._all) {
+          this._all = this.files.reduce((all, file) => {
+            return Object.assign(all, this.values[file]);
+          }, {});
+        }
+        return this._all;
+      }
+      addFile(file) {
+        if (!(file in this.values)) {
+          const latest = last(this.files);
+          this.values[file] = latest ? Object.create(this.values[latest]) : {};
+          this.files.push(file);
+        }
+        return this.values[file];
+      }
+      addValue(file, key, value) {
+        const values = this.addFile(file);
+        if (!Object.hasOwn(values, key)) {
+          values[key] = value;
+        } else if (Array.isArray(values[key])) {
+          values[key].push(value);
+        } else {
+          values[key] = [values[key], value];
+        }
+        this._all = void 0;
+      }
+    };
+  }
+});
+function asConfigScope(scope, fallback) {
+  if (typeof scope === "string" && Object.hasOwn(GitConfigScope, scope)) {
+    return scope;
+  }
+  return fallback;
+}
+__name(asConfigScope, "asConfigScope");
+function addConfigTask(key, value, append2, scope) {
+  const commands = ["config", `--${scope}`];
+  if (append2) {
+    commands.push("--add");
+  }
+  commands.push(key, value);
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return text;
+    }
+  };
+}
+__name(addConfigTask, "addConfigTask");
+function getConfigTask(key, scope) {
+  const commands = ["config", "--null", "--show-origin", "--get-all", key];
+  if (scope) {
+    commands.splice(1, 0, `--${scope}`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return configGetParser(text, key);
+    }
+  };
+}
+__name(getConfigTask, "getConfigTask");
+function listConfigTask(scope) {
+  const commands = ["config", "--list", "--show-origin", "--null"];
+  if (scope) {
+    commands.push(`--${scope}`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return configListParser(text);
+    }
+  };
+}
+__name(listConfigTask, "listConfigTask");
+function config_default() {
+  return {
+    addConfig(key, value, ...rest) {
+      return this._runTask(
+        addConfigTask(
+          key,
+          value,
+          rest[0] === true,
+          asConfigScope(
+            rest[1],
+            "local"
+            /* local */
+          )
+        ),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    getConfig(key, scope) {
+      return this._runTask(
+        getConfigTask(key, asConfigScope(scope, void 0)),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    listConfig(...rest) {
+      return this._runTask(
+        listConfigTask(asConfigScope(rest[0], void 0)),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(config_default, "config_default");
+var GitConfigScope;
+var init_config = __esm({
+  "src/lib/tasks/config.ts"() {
+    "use strict";
+    init_ConfigList();
+    init_utils();
+    GitConfigScope = /* @__PURE__ */ ((GitConfigScope2) => {
+      GitConfigScope2["system"] = "system";
+      GitConfigScope2["global"] = "global";
+      GitConfigScope2["local"] = "local";
+      GitConfigScope2["worktree"] = "worktree";
+      return GitConfigScope2;
+    })(GitConfigScope || {});
+  }
+});
+function isDiffNameStatus(input) {
+  return diffNameStatus.has(input);
+}
+__name(isDiffNameStatus, "isDiffNameStatus");
+var DiffNameStatus;
+var diffNameStatus;
+var init_diff_name_status = __esm({
+  "src/lib/tasks/diff-name-status.ts"() {
+    "use strict";
+    DiffNameStatus = /* @__PURE__ */ ((DiffNameStatus2) => {
+      DiffNameStatus2["ADDED"] = "A";
+      DiffNameStatus2["COPIED"] = "C";
+      DiffNameStatus2["DELETED"] = "D";
+      DiffNameStatus2["MODIFIED"] = "M";
+      DiffNameStatus2["RENAMED"] = "R";
+      DiffNameStatus2["CHANGED"] = "T";
+      DiffNameStatus2["UNMERGED"] = "U";
+      DiffNameStatus2["UNKNOWN"] = "X";
+      DiffNameStatus2["BROKEN"] = "B";
+      return DiffNameStatus2;
+    })(DiffNameStatus || {});
+    diffNameStatus = new Set(Object.values(DiffNameStatus));
+  }
+});
+function grepQueryBuilder(...params) {
+  return new GrepQuery().param(...params);
+}
+__name(grepQueryBuilder, "grepQueryBuilder");
+function parseGrep(grep) {
+  const paths = /* @__PURE__ */ new Set();
+  const results = {};
+  forEachLineWithContent(grep, (input) => {
+    const [path5, line, preview] = input.split(NULL);
+    paths.add(path5);
+    (results[path5] = results[path5] || []).push({
+      line: asNumber(line),
+      path: path5,
+      preview
+    });
+  });
+  return {
+    paths,
+    results
+  };
+}
+__name(parseGrep, "parseGrep");
+function grep_default() {
+  return {
+    grep(searchTerm) {
+      const then = trailingFunctionArgument(arguments);
+      const options = getTrailingOptions(arguments);
+      for (const option of disallowedOptions) {
+        if (options.includes(option)) {
+          return this._runTask(
+            configurationErrorTask(`git.grep: use of "${option}" is not supported.`),
+            then
+          );
+        }
+      }
+      if (typeof searchTerm === "string") {
+        searchTerm = grepQueryBuilder().param(searchTerm);
+      }
+      const commands = ["grep", "--null", "-n", "--full-name", ...options, ...searchTerm];
+      return this._runTask(
+        {
+          commands,
+          format: "utf-8",
+          parser(stdOut) {
+            return parseGrep(stdOut);
+          }
+        },
+        then
+      );
+    }
+  };
+}
+__name(grep_default, "grep_default");
+var disallowedOptions;
+var Query;
+var _a;
+var GrepQuery;
+var init_grep = __esm({
+  "src/lib/tasks/grep.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+    disallowedOptions = ["-h"];
+    Query = /* @__PURE__ */ Symbol("grepQuery");
+    GrepQuery = class {
+      static {
+        __name(this, "GrepQuery");
+      }
+      constructor() {
+        this[_a] = [];
+      }
+      *[(_a = Query, Symbol.iterator)]() {
+        for (const query of this[Query]) {
+          yield query;
+        }
+      }
+      and(...and) {
+        and.length && this[Query].push("--and", "(", ...prefixedArray(and, "-e"), ")");
+        return this;
+      }
+      param(...param) {
+        this[Query].push(...prefixedArray(param, "-e"));
+        return this;
+      }
+    };
+  }
+});
+var reset_exports = {};
+__export(reset_exports, {
+  ResetMode: /* @__PURE__ */ __name(() => ResetMode, "ResetMode"),
+  getResetMode: /* @__PURE__ */ __name(() => getResetMode, "getResetMode"),
+  resetTask: /* @__PURE__ */ __name(() => resetTask, "resetTask")
+});
+function resetTask(mode, customArgs) {
+  const commands = ["reset"];
+  if (isValidResetMode(mode)) {
+    commands.push(`--${mode}`);
+  }
+  commands.push(...customArgs);
+  return straightThroughStringTask(commands);
+}
+__name(resetTask, "resetTask");
+function getResetMode(mode) {
+  if (isValidResetMode(mode)) {
+    return mode;
+  }
+  switch (typeof mode) {
+    case "string":
+    case "undefined":
+      return "soft";
+  }
+  return;
+}
+__name(getResetMode, "getResetMode");
+function isValidResetMode(mode) {
+  return typeof mode === "string" && validResetModes.includes(mode);
+}
+__name(isValidResetMode, "isValidResetMode");
+var ResetMode;
+var validResetModes;
+var init_reset = __esm({
+  "src/lib/tasks/reset.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+    ResetMode = /* @__PURE__ */ ((ResetMode2) => {
+      ResetMode2["MIXED"] = "mixed";
+      ResetMode2["SOFT"] = "soft";
+      ResetMode2["HARD"] = "hard";
+      ResetMode2["MERGE"] = "merge";
+      ResetMode2["KEEP"] = "keep";
+      return ResetMode2;
+    })(ResetMode || {});
+    validResetModes = asStringArray(Object.values(ResetMode));
+  }
+});
+function createLog() {
+  return (0, import_debug.default)("simple-git");
+}
+__name(createLog, "createLog");
+function prefixedLogger(to, prefix, forward) {
+  if (!prefix || !String(prefix).replace(/\s*/, "")) {
+    return !forward ? to : (message, ...args) => {
+      to(message, ...args);
+      forward(message, ...args);
+    };
+  }
+  return (message, ...args) => {
+    to(`%s ${message}`, prefix, ...args);
+    if (forward) {
+      forward(message, ...args);
+    }
+  };
+}
+__name(prefixedLogger, "prefixedLogger");
+function childLoggerName(name, childDebugger, { namespace: parentNamespace }) {
+  if (typeof name === "string") {
+    return name;
+  }
+  const childNamespace = childDebugger && childDebugger.namespace || "";
+  if (childNamespace.startsWith(parentNamespace)) {
+    return childNamespace.substr(parentNamespace.length + 1);
+  }
+  return childNamespace || parentNamespace;
+}
+__name(childLoggerName, "childLoggerName");
+function createLogger(label, verbose, initialStep, infoDebugger = createLog()) {
+  const labelPrefix = label && `[${label}]` || "";
+  const spawned = [];
+  const debugDebugger = typeof verbose === "string" ? infoDebugger.extend(verbose) : verbose;
+  const key = childLoggerName(filterType(verbose, filterString), debugDebugger, infoDebugger);
+  return step(initialStep);
+  function sibling(name, initial) {
+    return append(
+      spawned,
+      createLogger(label, key.replace(/^[^:]+/, name), initial, infoDebugger)
+    );
+  }
+  __name(sibling, "sibling");
+  function step(phase) {
+    const stepPrefix = phase && `[${phase}]` || "";
+    const debug22 = debugDebugger && prefixedLogger(debugDebugger, stepPrefix) || NOOP;
+    const info2 = prefixedLogger(infoDebugger, `${labelPrefix} ${stepPrefix}`, debug22);
+    return Object.assign(debugDebugger ? debug22 : info2, {
+      label,
+      sibling,
+      info: info2,
+      step
+    });
+  }
+  __name(step, "step");
+}
+__name(createLogger, "createLogger");
+var init_git_logger = __esm({
+  "src/lib/git-logger.ts"() {
+    "use strict";
+    init_utils();
+    import_debug.default.formatters.L = (value) => String(filterHasLength(value) ? value.length : "-");
+    import_debug.default.formatters.B = (value) => {
+      if (Buffer.isBuffer(value)) {
+        return value.toString("utf8");
+      }
+      return objectToString(value);
+    };
+  }
+});
+var TasksPendingQueue;
+var init_tasks_pending_queue = __esm({
+  "src/lib/runners/tasks-pending-queue.ts"() {
+    "use strict";
+    init_git_error();
+    init_git_logger();
+    TasksPendingQueue = class _TasksPendingQueue {
+      static {
+        __name(this, "_TasksPendingQueue");
+      }
+      constructor(logLabel = "GitExecutor") {
+        this.logLabel = logLabel;
+        this._queue = /* @__PURE__ */ new Map();
+      }
+      withProgress(task) {
+        return this._queue.get(task);
+      }
+      createProgress(task) {
+        const name = _TasksPendingQueue.getName(task.commands[0]);
+        const logger = createLogger(this.logLabel, name);
+        return {
+          task,
+          logger,
+          name
+        };
+      }
+      push(task) {
+        const progress = this.createProgress(task);
+        progress.logger("Adding task to the queue, commands = %o", task.commands);
+        this._queue.set(task, progress);
+        return progress;
+      }
+      fatal(err) {
+        for (const [task, { logger }] of Array.from(this._queue.entries())) {
+          if (task === err.task) {
+            logger.info(`Failed %o`, err);
+            logger(
+              `Fatal exception, any as-yet un-started tasks run through this executor will not be attempted`
+            );
+          } else {
+            logger.info(
+              `A fatal exception occurred in a previous task, the queue has been purged: %o`,
+              err.message
+            );
+          }
+          this.complete(task);
+        }
+        if (this._queue.size !== 0) {
+          throw new Error(`Queue size should be zero after fatal: ${this._queue.size}`);
+        }
+      }
+      complete(task) {
+        const progress = this.withProgress(task);
+        if (progress) {
+          this._queue.delete(task);
+        }
+      }
+      attempt(task) {
+        const progress = this.withProgress(task);
+        if (!progress) {
+          throw new GitError(void 0, "TasksPendingQueue: attempt called for an unknown task");
+        }
+        progress.logger("Starting task");
+        return progress;
+      }
+      static getName(name = "empty") {
+        return `task:${name}:${++_TasksPendingQueue.counter}`;
+      }
+      static {
+        this.counter = 0;
+      }
+    };
+  }
+});
+function pluginContext(task, commands) {
+  return {
+    method: first(task.commands) || "",
+    commands
+  };
+}
+__name(pluginContext, "pluginContext");
+function onErrorReceived(target, logger) {
+  return (err) => {
+    logger(`[ERROR] child process exception %o`, err);
+    target.push(Buffer.from(String(err.stack), "ascii"));
+  };
+}
+__name(onErrorReceived, "onErrorReceived");
+function onDataReceived(target, name, logger, output) {
+  return (buffer) => {
+    logger(`%s received %L bytes`, name, buffer);
+    output(`%B`, buffer);
+    target.push(buffer);
+  };
+}
+__name(onDataReceived, "onDataReceived");
+var GitExecutorChain;
+var init_git_executor_chain = __esm({
+  "src/lib/runners/git-executor-chain.ts"() {
+    "use strict";
+    init_git_error();
+    init_task();
+    init_utils();
+    init_tasks_pending_queue();
+    GitExecutorChain = class {
+      static {
+        __name(this, "GitExecutorChain");
+      }
+      constructor(_executor, _scheduler, _plugins) {
+        this._executor = _executor;
+        this._scheduler = _scheduler;
+        this._plugins = _plugins;
+        this._chain = Promise.resolve();
+        this._queue = new TasksPendingQueue();
+      }
+      get cwd() {
+        return this._cwd || this._executor.cwd;
+      }
+      set cwd(cwd) {
+        this._cwd = cwd;
+      }
+      get env() {
+        return this._executor.env;
+      }
+      get outputHandler() {
+        return this._executor.outputHandler;
+      }
+      chain() {
+        return this;
+      }
+      push(task) {
+        this._queue.push(task);
+        return this._chain = this._chain.then(() => this.attemptTask(task));
+      }
+      async attemptTask(task) {
+        const onScheduleComplete = await this._scheduler.next();
+        const onQueueComplete = /* @__PURE__ */ __name(() => this._queue.complete(task), "onQueueComplete");
+        try {
+          const { logger } = this._queue.attempt(task);
+          return await (isEmptyTask(task) ? this.attemptEmptyTask(task, logger) : this.attemptRemoteTask(task, logger));
+        } catch (e) {
+          throw this.onFatalException(task, e);
+        } finally {
+          onQueueComplete();
+          onScheduleComplete();
+        }
+      }
+      onFatalException(task, e) {
+        const gitError = e instanceof GitError ? Object.assign(e, { task }) : new GitError(task, e && String(e));
+        this._chain = Promise.resolve();
+        this._queue.fatal(gitError);
+        return gitError;
+      }
+      async attemptRemoteTask(task, logger) {
+        const binary = this._plugins.exec("spawn.binary", "", pluginContext(task, task.commands));
+        const args = this._plugins.exec(
+          "spawn.args",
+          [...task.commands],
+          pluginContext(task, task.commands)
+        );
+        const raw = await this.gitResponse(
+          task,
+          binary,
+          args,
+          this.outputHandler,
+          logger.step("SPAWN")
+        );
+        const outputStreams = await this.handleTaskData(task, args, raw, logger.step("HANDLE"));
+        logger(`passing response to task's parser as a %s`, task.format);
+        if (isBufferTask(task)) {
+          return callTaskParser(task.parser, outputStreams);
+        }
+        return callTaskParser(task.parser, outputStreams.asStrings());
+      }
+      async attemptEmptyTask(task, logger) {
+        logger(`empty task bypassing child process to call to task's parser`);
+        return task.parser(this);
+      }
+      handleTaskData(task, args, result, logger) {
+        const { exitCode, rejection, stdOut, stdErr } = result;
+        return new Promise((done, fail) => {
+          logger(`Preparing to handle process response exitCode=%d stdOut=`, exitCode);
+          const { error: error2 } = this._plugins.exec(
+            "task.error",
+            { error: rejection },
+            {
+              ...pluginContext(task, args),
+              ...result
+            }
+          );
+          if (error2 && task.onError) {
+            logger.info(`exitCode=%s handling with custom error handler`);
+            return task.onError(
+              result,
+              error2,
+              (newStdOut) => {
+                logger.info(`custom error handler treated as success`);
+                logger(`custom error returned a %s`, objectToString(newStdOut));
+                done(
+                  new GitOutputStreams(
+                    Array.isArray(newStdOut) ? Buffer.concat(newStdOut) : newStdOut,
+                    Buffer.concat(stdErr)
+                  )
+                );
+              },
+              fail
+            );
+          }
+          if (error2) {
+            logger.info(
+              `handling as error: exitCode=%s stdErr=%s rejection=%o`,
+              exitCode,
+              stdErr.length,
+              rejection
+            );
+            return fail(error2);
+          }
+          logger.info(`retrieving task output complete`);
+          done(new GitOutputStreams(Buffer.concat(stdOut), Buffer.concat(stdErr)));
+        });
+      }
+      async gitResponse(task, command, args, outputHandler, logger) {
+        const outputLogger = logger.sibling("output");
+        const spawnOptions = this._plugins.exec(
+          "spawn.options",
+          {
+            cwd: this.cwd,
+            env: this.env,
+            windowsHide: true
+          },
+          pluginContext(task, task.commands)
+        );
+        return new Promise((done) => {
+          const stdOut = [];
+          const stdErr = [];
+          logger.info(`%s %o`, command, args);
+          logger("%O", spawnOptions);
+          let rejection = this._beforeSpawn(task, args);
+          if (rejection) {
+            return done({
+              stdOut,
+              stdErr,
+              exitCode: 9901,
+              rejection
+            });
+          }
+          this._plugins.exec("spawn.before", void 0, {
+            ...pluginContext(task, args),
+            kill(reason) {
+              rejection = reason || rejection;
+            }
+          });
+          const spawned = (0, import_child_process.spawn)(command, args, spawnOptions);
+          spawned.stdout.on(
+            "data",
+            onDataReceived(stdOut, "stdOut", logger, outputLogger.step("stdOut"))
+          );
+          spawned.stderr.on(
+            "data",
+            onDataReceived(stdErr, "stdErr", logger, outputLogger.step("stdErr"))
+          );
+          spawned.on("error", onErrorReceived(stdErr, logger));
+          if (outputHandler) {
+            logger(`Passing child process stdOut/stdErr to custom outputHandler`);
+            outputHandler(command, spawned.stdout, spawned.stderr, [...args]);
+          }
+          this._plugins.exec("spawn.after", void 0, {
+            ...pluginContext(task, args),
+            spawned,
+            close(exitCode, reason) {
+              done({
+                stdOut,
+                stdErr,
+                exitCode,
+                rejection: rejection || reason
+              });
+            },
+            kill(reason) {
+              if (spawned.killed) {
+                return;
+              }
+              rejection = reason;
+              spawned.kill("SIGINT");
+            }
+          });
+        });
+      }
+      _beforeSpawn(task, args) {
+        let rejection;
+        this._plugins.exec("spawn.before", void 0, {
+          ...pluginContext(task, args),
+          kill(reason) {
+            rejection = reason || rejection;
+          }
+        });
+        return rejection;
+      }
+    };
+  }
+});
+var git_executor_exports = {};
+__export(git_executor_exports, {
+  GitExecutor: /* @__PURE__ */ __name(() => GitExecutor, "GitExecutor")
+});
+var GitExecutor;
+var init_git_executor = __esm({
+  "src/lib/runners/git-executor.ts"() {
+    "use strict";
+    init_git_executor_chain();
+    GitExecutor = class {
+      static {
+        __name(this, "GitExecutor");
+      }
+      constructor(cwd, _scheduler, _plugins) {
+        this.cwd = cwd;
+        this._scheduler = _scheduler;
+        this._plugins = _plugins;
+        this._chain = new GitExecutorChain(this, this._scheduler, this._plugins);
+      }
+      chain() {
+        return new GitExecutorChain(this, this._scheduler, this._plugins);
+      }
+      push(task) {
+        return this._chain.push(task);
+      }
+    };
+  }
+});
+function taskCallback(task, response, callback = NOOP) {
+  const onSuccess = /* @__PURE__ */ __name((data) => {
+    callback(null, data);
+  }, "onSuccess");
+  const onError2 = /* @__PURE__ */ __name((err) => {
+    if (err?.task === task) {
+      callback(
+        err instanceof GitResponseError ? addDeprecationNoticeToError(err) : err,
+        void 0
+      );
+    }
+  }, "onError2");
+  response.then(onSuccess, onError2);
+}
+__name(taskCallback, "taskCallback");
+function addDeprecationNoticeToError(err) {
+  let log = /* @__PURE__ */ __name((name) => {
+    console.warn(
+      `simple-git deprecation notice: accessing GitResponseError.${name} should be GitResponseError.git.${name}, this wi\
+ll no longer be available in version 3`
+    );
+    log = NOOP;
+  }, "log");
+  return Object.create(err, Object.getOwnPropertyNames(err.git).reduce(descriptorReducer, {}));
+  function descriptorReducer(all, name) {
+    if (name in err) {
+      return all;
+    }
+    all[name] = {
+      enumerable: false,
+      configurable: false,
+      get() {
+        log(name);
+        return err.git[name];
+      }
+    };
+    return all;
+  }
+  __name(descriptorReducer, "descriptorReducer");
+}
+__name(addDeprecationNoticeToError, "addDeprecationNoticeToError");
+var init_task_callback = __esm({
+  "src/lib/task-callback.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_utils();
+  }
+});
+function changeWorkingDirectoryTask(directory, root) {
+  return adhocExecTask((instance) => {
+    if (!folderExists(directory)) {
+      throw new Error(`Git.cwd: cannot change to non-directory "${directory}"`);
+    }
+    return (root || instance).cwd = directory;
+  });
+}
+__name(changeWorkingDirectoryTask, "changeWorkingDirectoryTask");
+var init_change_working_directory = __esm({
+  "src/lib/tasks/change-working-directory.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+function checkoutTask(args) {
+  const commands = ["checkout", ...args];
+  if (commands[1] === "-b" && commands.includes("-B")) {
+    commands[1] = remove(commands, "-B");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(checkoutTask, "checkoutTask");
+function checkout_default() {
+  return {
+    checkout() {
+      return this._runTask(
+        checkoutTask(getTrailingOptions(arguments, 1)),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    checkoutBranch(branchName, startPoint) {
+      return this._runTask(
+        checkoutTask(["-b", branchName, startPoint, ...getTrailingOptions(arguments)]),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    checkoutLocalBranch(branchName) {
+      return this._runTask(
+        checkoutTask(["-b", branchName, ...getTrailingOptions(arguments)]),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(checkout_default, "checkout_default");
+var init_checkout = __esm({
+  "src/lib/tasks/checkout.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+function countObjectsResponse() {
+  return {
+    count: 0,
+    garbage: 0,
+    inPack: 0,
+    packs: 0,
+    prunePackable: 0,
+    size: 0,
+    sizeGarbage: 0,
+    sizePack: 0
+  };
+}
+__name(countObjectsResponse, "countObjectsResponse");
+function count_objects_default() {
+  return {
+    countObjects() {
+      return this._runTask({
+        commands: ["count-objects", "--verbose"],
+        format: "utf-8",
+        parser(stdOut) {
+          return parseStringResponse(countObjectsResponse(), [parser2], stdOut);
+        }
+      });
+    }
+  };
+}
+__name(count_objects_default, "count_objects_default");
+var parser2;
+var init_count_objects = __esm({
+  "src/lib/tasks/count-objects.ts"() {
+    "use strict";
+    init_utils();
+    parser2 = new LineParser(
+      /([a-z-]+): (\d+)$/,
+      (result, [key, value]) => {
+        const property = asCamelCase(key);
+        if (Object.hasOwn(result, property)) {
+          result[property] = asNumber(value);
+        }
+      }
+    );
+  }
+});
+function parseCommitResult(stdOut) {
+  const result = {
+    author: null,
+    branch: "",
+    commit: "",
+    root: false,
+    summary: {
+      changes: 0,
+      insertions: 0,
+      deletions: 0
+    }
+  };
+  return parseStringResponse(result, parsers, stdOut);
+}
+__name(parseCommitResult, "parseCommitResult");
+var parsers;
+var init_parse_commit = __esm({
+  "src/lib/parsers/parse-commit.ts"() {
+    "use strict";
+    init_utils();
+    parsers = [
+      new LineParser(/^\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
+        result.branch = branch;
+        result.commit = commit;
+        result.root = !!root;
+      }),
+      new LineParser(/\s*Author:\s(.+)/i, (result, [author]) => {
+        const parts = author.split("<");
+        const email = parts.pop();
+        if (!email || !email.includes("@")) {
+          return;
+        }
+        result.author = {
+          email: email.substr(0, email.length - 1),
+          name: parts.join("<").trim()
+        };
+      }),
+      new LineParser(
+        /(\d+)[^,]*(?:,\s*(\d+)[^,]*)(?:,\s*(\d+))/g,
+        (result, [changes, insertions, deletions]) => {
+          result.summary.changes = parseInt(changes, 10) || 0;
+          result.summary.insertions = parseInt(insertions, 10) || 0;
+          result.summary.deletions = parseInt(deletions, 10) || 0;
+        }
+      ),
+      new LineParser(
+        /^(\d+)[^,]*(?:,\s*(\d+)[^(]+\(([+-]))?/,
+        (result, [changes, lines, direction]) => {
+          result.summary.changes = parseInt(changes, 10) || 0;
+          const count = parseInt(lines, 10) || 0;
+          if (direction === "-") {
+            result.summary.deletions = count;
+          } else if (direction === "+") {
+            result.summary.insertions = count;
+          }
+        }
+      )
+    ];
+  }
+});
+function commitTask(message, files, customArgs) {
+  const commands = [
+    "-c",
+    "core.abbrev=40",
+    "commit",
+    ...prefixedArray(message, "-m"),
+    ...files,
+    ...customArgs
+  ];
+  return {
+    commands,
+    format: "utf-8",
+    parser: parseCommitResult
+  };
+}
+__name(commitTask, "commitTask");
+function commit_default() {
+  return {
+    commit(message, ...rest) {
+      const next = trailingFunctionArgument(arguments);
+      const task = rejectDeprecatedSignatures(message) || commitTask(
+        asArray(message),
+        asArray(filterType(rest[0], filterStringOrStringArray, [])),
+        [
+          ...asStringArray(filterType(rest[1], filterArray, [])),
+          ...getTrailingOptions(arguments, 0, true)
+        ]
+      );
+      return this._runTask(task, next);
+    }
+  };
+  function rejectDeprecatedSignatures(message) {
+    return !filterStringOrStringArray(message) && configurationErrorTask(
+      `git.commit: requires the commit message to be supplied as a string/string[]`
+    );
+  }
+  __name(rejectDeprecatedSignatures, "rejectDeprecatedSignatures");
+}
+__name(commit_default, "commit_default");
+var init_commit = __esm({
+  "src/lib/tasks/commit.ts"() {
+    "use strict";
+    init_parse_commit();
+    init_utils();
+    init_task();
+  }
+});
+function first_commit_default() {
+  return {
+    firstCommit() {
+      return this._runTask(
+        straightThroughStringTask(["rev-list", "--max-parents=0", "HEAD"], true),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(first_commit_default, "first_commit_default");
+var init_first_commit = __esm({
+  "src/lib/tasks/first-commit.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+function hashObjectTask(filePath, write) {
+  const commands = ["hash-object", filePath];
+  if (write) {
+    commands.push("-w");
+  }
+  return straightThroughStringTask(commands, true);
+}
+__name(hashObjectTask, "hashObjectTask");
+var init_hash_object = __esm({
+  "src/lib/tasks/hash-object.ts"() {
+    "use strict";
+    init_task();
+  }
+});
+function parseInit(bare, path5, text) {
+  const response = String(text).trim();
+  let result;
+  if (result = initResponseRegex.exec(response)) {
+    return new InitSummary(bare, path5, false, result[1]);
+  }
+  if (result = reInitResponseRegex.exec(response)) {
+    return new InitSummary(bare, path5, true, result[1]);
+  }
+  let gitDir = "";
+  const tokens = response.split(" ");
+  while (tokens.length) {
+    const token = tokens.shift();
+    if (token === "in") {
+      gitDir = tokens.join(" ");
+      break;
+    }
+  }
+  return new InitSummary(bare, path5, /^re/i.test(response), gitDir);
+}
+__name(parseInit, "parseInit");
+var InitSummary;
+var initResponseRegex;
+var reInitResponseRegex;
+var init_InitSummary = __esm({
+  "src/lib/responses/InitSummary.ts"() {
+    "use strict";
+    InitSummary = class {
+      static {
+        __name(this, "InitSummary");
+      }
+      constructor(bare, path5, existing, gitDir) {
+        this.bare = bare;
+        this.path = path5;
+        this.existing = existing;
+        this.gitDir = gitDir;
+      }
+    };
+    initResponseRegex = /^Init.+ repository in (.+)$/;
+    reInitResponseRegex = /^Rein.+ in (.+)$/;
+  }
+});
+function hasBareCommand(command) {
+  return command.includes(bareCommand);
+}
+__name(hasBareCommand, "hasBareCommand");
+function initTask(bare = false, path5, customArgs) {
+  const commands = ["init", ...customArgs];
+  if (bare && !hasBareCommand(commands)) {
+    commands.splice(1, 0, bareCommand);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return parseInit(commands.includes("--bare"), path5, text);
+    }
+  };
+}
+__name(initTask, "initTask");
+var bareCommand;
+var init_init = __esm({
+  "src/lib/tasks/init.ts"() {
+    "use strict";
+    init_InitSummary();
+    bareCommand = "--bare";
+  }
+});
+function logFormatFromCommand(customArgs) {
+  for (let i = 0; i < customArgs.length; i++) {
+    const format = logFormatRegex.exec(customArgs[i]);
+    if (format) {
+      return `--${format[1]}`;
+    }
+  }
+  return "";
+}
+__name(logFormatFromCommand, "logFormatFromCommand");
+function isLogFormat(customArg) {
+  return logFormatRegex.test(customArg);
+}
+__name(isLogFormat, "isLogFormat");
+var logFormatRegex;
+var init_log_format = __esm({
+  "src/lib/args/log-format.ts"() {
+    "use strict";
+    logFormatRegex = /^--(stat|numstat|name-only|name-status)(=|$)/;
+  }
+});
+var DiffSummary;
+var init_DiffSummary = __esm({
+  "src/lib/responses/DiffSummary.ts"() {
+    "use strict";
+    DiffSummary = class {
+      static {
+        __name(this, "DiffSummary");
+      }
+      constructor() {
+        this.changed = 0;
+        this.deletions = 0;
+        this.insertions = 0;
+        this.files = [];
+      }
+    };
+  }
+});
+function getDiffParser(format = "") {
+  const parser4 = diffSummaryParsers[format];
+  return (stdOut) => parseStringResponse(new DiffSummary(), parser4, stdOut, false);
+}
+__name(getDiffParser, "getDiffParser");
+var statParser;
+var numStatParser;
+var nameOnlyParser;
+var nameStatusParser;
+var diffSummaryParsers;
+var init_parse_diff_summary = __esm({
+  "src/lib/parsers/parse-diff-summary.ts"() {
+    "use strict";
+    init_log_format();
+    init_DiffSummary();
+    init_diff_name_status();
+    init_utils();
+    statParser = [
+      new LineParser(
+        /^(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/,
+        (result, [file, changes, alterations = ""]) => {
+          result.files.push({
+            file: file.trim(),
+            changes: asNumber(changes),
+            insertions: alterations.replace(/[^+]/g, "").length,
+            deletions: alterations.replace(/[^-]/g, "").length,
+            binary: false
+          });
+        }
+      ),
+      new LineParser(
+        /^(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/,
+        (result, [file, before, after]) => {
+          result.files.push({
+            file: file.trim(),
+            before: asNumber(before),
+            after: asNumber(after),
+            binary: true
+          });
+        }
+      ),
+      new LineParser(
+        /(\d+) files? changed\s*((?:, \d+ [^,]+){0,2})/,
+        (result, [changed, summary2]) => {
+          const inserted = /(\d+) i/.exec(summary2);
+          const deleted = /(\d+) d/.exec(summary2);
+          result.changed = asNumber(changed);
+          result.insertions = asNumber(inserted?.[1]);
+          result.deletions = asNumber(deleted?.[1]);
+        }
+      )
+    ];
+    numStatParser = [
+      new LineParser(
+        /(\d+)\t(\d+)\t(.+)$/,
+        (result, [changesInsert, changesDelete, file]) => {
+          const insertions = asNumber(changesInsert);
+          const deletions = asNumber(changesDelete);
+          result.changed++;
+          result.insertions += insertions;
+          result.deletions += deletions;
+          result.files.push({
+            file,
+            changes: insertions + deletions,
+            insertions,
+            deletions,
+            binary: false
+          });
+        }
+      ),
+      new LineParser(/-\t-\t(.+)$/, (result, [file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          after: 0,
+          before: 0,
+          binary: true
+        });
+      })
+    ];
+    nameOnlyParser = [
+      new LineParser(/(.+)$/, (result, [file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          changes: 0,
+          insertions: 0,
+          deletions: 0,
+          binary: false
+        });
+      })
+    ];
+    nameStatusParser = [
+      new LineParser(
+        /([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(\t(.[^\t]*))?$/,
+        (result, [status, similarity, from, _to, to]) => {
+          result.changed++;
+          result.files.push({
+            file: to ?? from,
+            changes: 0,
+            insertions: 0,
+            deletions: 0,
+            binary: false,
+            status: orVoid(isDiffNameStatus(status) && status),
+            from: orVoid(!!to && from !== to && from),
+            similarity: asNumber(similarity)
+          });
+        }
+      )
+    ];
+    diffSummaryParsers = {
+      [
+        ""
+        /* NONE */
+      ]: statParser,
+      [
+        "--stat"
+        /* STAT */
+      ]: statParser,
+      [
+        "--numstat"
+        /* NUM_STAT */
+      ]: numStatParser,
+      [
+        "--name-status"
+        /* NAME_STATUS */
+      ]: nameStatusParser,
+      [
+        "--name-only"
+        /* NAME_ONLY */
+      ]: nameOnlyParser
+    };
+  }
+});
+function lineBuilder(tokens, fields) {
+  return fields.reduce(
+    (line, field, index) => {
+      line[field] = tokens[index] || "";
+      return line;
+    },
+    /* @__PURE__ */ Object.create({ diff: null })
+  );
+}
+__name(lineBuilder, "lineBuilder");
+function createListLogSummaryParser(splitter = SPLITTER, fields = defaultFieldNames, logFormat = "") {
+  const parseDiffResult = getDiffParser(logFormat);
+  return function(stdOut) {
+    const all = toLinesWithContent(
+      stdOut.trim(),
+      false,
+      START_BOUNDARY
+    ).map(function(item) {
+      const lineDetail = item.split(COMMIT_BOUNDARY);
+      const listLogLine = lineBuilder(lineDetail[0].split(splitter), fields);
+      if (lineDetail.length > 1 && !!lineDetail[1].trim()) {
+        listLogLine.diff = parseDiffResult(lineDetail[1]);
+      }
+      return listLogLine;
+    });
+    return {
+      all,
+      latest: all.length && all[0] || null,
+      total: all.length
+    };
+  };
+}
+__name(createListLogSummaryParser, "createListLogSummaryParser");
+var START_BOUNDARY;
+var COMMIT_BOUNDARY;
+var SPLITTER;
+var defaultFieldNames;
+var init_parse_list_log_summary = __esm({
+  "src/lib/parsers/parse-list-log-summary.ts"() {
+    "use strict";
+    init_utils();
+    init_parse_diff_summary();
+    init_log_format();
+    START_BOUNDARY = "\xF2\xF2\xF2\xF2\xF2\xF2 ";
+    COMMIT_BOUNDARY = " \xF2\xF2";
+    SPLITTER = " \xF2 ";
+    defaultFieldNames = ["hash", "date", "message", "refs", "author_name", "author_email"];
+  }
+});
+var diff_exports = {};
+__export(diff_exports, {
+  diffSummaryTask: /* @__PURE__ */ __name(() => diffSummaryTask, "diffSummaryTask"),
+  validateLogFormatConfig: /* @__PURE__ */ __name(() => validateLogFormatConfig, "validateLogFormatConfig")
+});
+function diffSummaryTask(customArgs) {
+  let logFormat = logFormatFromCommand(customArgs);
+  const commands = ["diff"];
+  if (logFormat === "") {
+    logFormat = "--stat";
+    commands.push("--stat=4096");
+  }
+  commands.push(...customArgs);
+  return validateLogFormatConfig(commands) || {
+    commands,
+    format: "utf-8",
+    parser: getDiffParser(logFormat)
+  };
+}
+__name(diffSummaryTask, "diffSummaryTask");
+function validateLogFormatConfig(customArgs) {
+  const flags = customArgs.filter(isLogFormat);
+  if (flags.length > 1) {
+    return configurationErrorTask(
+      `Summary flags are mutually exclusive - pick one of ${flags.join(",")}`
+    );
+  }
+  if (flags.length && customArgs.includes("-z")) {
+    return configurationErrorTask(
+      `Summary flag ${flags} parsing is not compatible with null termination option '-z'`
+    );
+  }
+}
+__name(validateLogFormatConfig, "validateLogFormatConfig");
+var init_diff = __esm({
+  "src/lib/tasks/diff.ts"() {
+    "use strict";
+    init_log_format();
+    init_parse_diff_summary();
+    init_task();
+  }
+});
+function prettyFormat(format, splitter) {
+  const fields = [];
+  const formatStr = [];
+  Object.keys(format).forEach((field) => {
+    fields.push(field);
+    formatStr.push(String(format[field]));
+  });
+  return [fields, formatStr.join(splitter)];
+}
+__name(prettyFormat, "prettyFormat");
+function userOptions(input) {
+  return Object.keys(input).reduce((out, key) => {
+    if (!(key in excludeOptions)) {
+      out[key] = input[key];
+    }
+    return out;
+  }, {});
+}
+__name(userOptions, "userOptions");
+function parseLogOptions(opt = {}, customArgs = []) {
+  const splitter = filterType(opt.splitter, filterString, SPLITTER);
+  const format = filterPlainObject(opt.format) ? opt.format : {
+    hash: "%H",
+    date: opt.strictDate === false ? "%ai" : "%aI",
+    message: "%s",
+    refs: "%D",
+    body: opt.multiLine ? "%B" : "%b",
+    author_name: opt.mailMap !== false ? "%aN" : "%an",
+    author_email: opt.mailMap !== false ? "%aE" : "%ae"
+  };
+  const [fields, formatStr] = prettyFormat(format, splitter);
+  const suffix = [];
+  const command = [
+    `--pretty=format:${START_BOUNDARY}${formatStr}${COMMIT_BOUNDARY}`,
+    ...customArgs
+  ];
+  const maxCount = opt.n || opt["max-count"] || opt.maxCount;
+  if (maxCount) {
+    command.push(`--max-count=${maxCount}`);
+  }
+  if (opt.from || opt.to) {
+    const rangeOperator = opt.symmetric !== false ? "..." : "..";
+    suffix.push(`${opt.from || ""}${rangeOperator}${opt.to || ""}`);
+  }
+  if (filterString(opt.file)) {
+    command.push("--follow", pathspec(opt.file));
+  }
+  appendTaskOptions(userOptions(opt), command);
+  return {
+    fields,
+    splitter,
+    commands: [...command, ...suffix]
+  };
+}
+__name(parseLogOptions, "parseLogOptions");
+function logTask(splitter, fields, customArgs) {
+  const parser4 = createListLogSummaryParser(splitter, fields, logFormatFromCommand(customArgs));
+  return {
+    commands: ["log", ...customArgs],
+    format: "utf-8",
+    parser: parser4
+  };
+}
+__name(logTask, "logTask");
+function log_default() {
+  return {
+    log(...rest) {
+      const next = trailingFunctionArgument(arguments);
+      const options = parseLogOptions(
+        trailingOptionsArgument(arguments),
+        asStringArray(filterType(arguments[0], filterArray, []))
+      );
+      const task = rejectDeprecatedSignatures(...rest) || validateLogFormatConfig(options.commands) || createLogTask(options);
+      return this._runTask(task, next);
+    }
+  };
+  function createLogTask(options) {
+    return logTask(options.splitter, options.fields, options.commands);
+  }
+  __name(createLogTask, "createLogTask");
+  function rejectDeprecatedSignatures(from, to) {
+    return filterString(from) && filterString(to) && configurationErrorTask(
+      `git.log(string, string) should be replaced with git.log({ from: string, to: string })`
+    );
+  }
+  __name(rejectDeprecatedSignatures, "rejectDeprecatedSignatures");
+}
+__name(log_default, "log_default");
+var excludeOptions;
+var init_log = __esm({
+  "src/lib/tasks/log.ts"() {
+    "use strict";
+    init_log_format();
+    init_pathspec();
+    init_parse_list_log_summary();
+    init_utils();
+    init_task();
+    init_diff();
+    excludeOptions = /* @__PURE__ */ ((excludeOptions2) => {
+      excludeOptions2[excludeOptions2["--pretty"] = 0] = "--pretty";
+      excludeOptions2[excludeOptions2["max-count"] = 1] = "max-count";
+      excludeOptions2[excludeOptions2["maxCount"] = 2] = "maxCount";
+      excludeOptions2[excludeOptions2["n"] = 3] = "n";
+      excludeOptions2[excludeOptions2["file"] = 4] = "file";
+      excludeOptions2[excludeOptions2["format"] = 5] = "format";
+      excludeOptions2[excludeOptions2["from"] = 6] = "from";
+      excludeOptions2[excludeOptions2["to"] = 7] = "to";
+      excludeOptions2[excludeOptions2["splitter"] = 8] = "splitter";
+      excludeOptions2[excludeOptions2["symmetric"] = 9] = "symmetric";
+      excludeOptions2[excludeOptions2["mailMap"] = 10] = "mailMap";
+      excludeOptions2[excludeOptions2["multiLine"] = 11] = "multiLine";
+      excludeOptions2[excludeOptions2["strictDate"] = 12] = "strictDate";
+      return excludeOptions2;
+    })(excludeOptions || {});
+  }
+});
+var MergeSummaryConflict;
+var MergeSummaryDetail;
+var init_MergeSummary = __esm({
+  "src/lib/responses/MergeSummary.ts"() {
+    "use strict";
+    MergeSummaryConflict = class {
+      static {
+        __name(this, "MergeSummaryConflict");
+      }
+      constructor(reason, file = null, meta) {
+        this.reason = reason;
+        this.file = file;
+        this.meta = meta;
+      }
+      toString() {
+        return `${this.file}:${this.reason}`;
+      }
+    };
+    MergeSummaryDetail = class {
+      static {
+        __name(this, "MergeSummaryDetail");
+      }
+      constructor() {
+        this.conflicts = [];
+        this.merges = [];
+        this.result = "success";
+      }
+      get failed() {
+        return this.conflicts.length > 0;
+      }
+      get reason() {
+        return this.result;
+      }
+      toString() {
+        if (this.conflicts.length) {
+          return `CONFLICTS: ${this.conflicts.join(", ")}`;
+        }
+        return "OK";
+      }
+    };
+  }
+});
+var PullSummary;
+var PullFailedSummary;
+var init_PullSummary = __esm({
+  "src/lib/responses/PullSummary.ts"() {
+    "use strict";
+    PullSummary = class {
+      static {
+        __name(this, "PullSummary");
+      }
+      constructor() {
+        this.remoteMessages = {
+          all: []
+        };
+        this.created = [];
+        this.deleted = [];
+        this.files = [];
+        this.deletions = {};
+        this.insertions = {};
+        this.summary = {
+          changes: 0,
+          deletions: 0,
+          insertions: 0
+        };
+      }
+    };
+    PullFailedSummary = class {
+      static {
+        __name(this, "PullFailedSummary");
+      }
+      constructor() {
+        this.remote = "";
+        this.hash = {
+          local: "",
+          remote: ""
+        };
+        this.branch = {
+          local: "",
+          remote: ""
+        };
+        this.message = "";
+      }
+      toString() {
+        return this.message;
+      }
+    };
+  }
+});
+function objectEnumerationResult(remoteMessages) {
+  return remoteMessages.objects = remoteMessages.objects || {
+    compressing: 0,
+    counting: 0,
+    enumerating: 0,
+    packReused: 0,
+    reused: { count: 0, delta: 0 },
+    total: { count: 0, delta: 0 }
+  };
+}
+__name(objectEnumerationResult, "objectEnumerationResult");
+function asObjectCount(source) {
+  const count = /^\s*(\d+)/.exec(source);
+  const delta = /delta (\d+)/i.exec(source);
+  return {
+    count: asNumber(count && count[1] || "0"),
+    delta: asNumber(delta && delta[1] || "0")
+  };
+}
+__name(asObjectCount, "asObjectCount");
+var remoteMessagesObjectParsers;
+var init_parse_remote_objects = __esm({
+  "src/lib/parsers/parse-remote-objects.ts"() {
+    "use strict";
+    init_utils();
+    remoteMessagesObjectParsers = [
+      new RemoteLineParser(
+        /^remote:\s*(enumerating|counting|compressing) objects: (\d+),/i,
+        (result, [action, count]) => {
+          const key = action.toLowerCase();
+          const enumeration = objectEnumerationResult(result.remoteMessages);
+          Object.assign(enumeration, { [key]: asNumber(count) });
+        }
+      ),
+      new RemoteLineParser(
+        /^remote:\s*(enumerating|counting|compressing) objects: \d+% \(\d+\/(\d+)\),/i,
+        (result, [action, count]) => {
+          const key = action.toLowerCase();
+          const enumeration = objectEnumerationResult(result.remoteMessages);
+          Object.assign(enumeration, { [key]: asNumber(count) });
+        }
+      ),
+      new RemoteLineParser(
+        /total ([^,]+), reused ([^,]+), pack-reused (\d+)/i,
+        (result, [total, reused, packReused]) => {
+          const objects = objectEnumerationResult(result.remoteMessages);
+          objects.total = asObjectCount(total);
+          objects.reused = asObjectCount(reused);
+          objects.packReused = asNumber(packReused);
+        }
+      )
+    ];
+  }
+});
+function parseRemoteMessages(_stdOut, stdErr) {
+  return parseStringResponse({ remoteMessages: new RemoteMessageSummary() }, parsers2, stdErr);
+}
+__name(parseRemoteMessages, "parseRemoteMessages");
+var parsers2;
+var RemoteMessageSummary;
+var init_parse_remote_messages = __esm({
+  "src/lib/parsers/parse-remote-messages.ts"() {
+    "use strict";
+    init_utils();
+    init_parse_remote_objects();
+    parsers2 = [
+      new RemoteLineParser(/^remote:\s*(.+)$/, (result, [text]) => {
+        result.remoteMessages.all.push(text.trim());
+        return false;
+      }),
+      ...remoteMessagesObjectParsers,
+      new RemoteLineParser(
+        [/create a (?:pull|merge) request/i, /\s(https?:\/\/\S+)$/],
+        (result, [pullRequestUrl]) => {
+          result.remoteMessages.pullRequestUrl = pullRequestUrl;
+        }
+      ),
+      new RemoteLineParser(
+        [/found (\d+) vulnerabilities.+\(([^)]+)\)/i, /\s(https?:\/\/\S+)$/],
+        (result, [count, summary2, url]) => {
+          result.remoteMessages.vulnerabilities = {
+            count: asNumber(count),
+            summary: summary2,
+            url
+          };
+        }
+      )
+    ];
+    RemoteMessageSummary = class {
+      static {
+        __name(this, "RemoteMessageSummary");
+      }
+      constructor() {
+        this.all = [];
+      }
+    };
+  }
+});
+function parsePullErrorResult(stdOut, stdErr) {
+  const pullError = parseStringResponse(new PullFailedSummary(), errorParsers, [stdOut, stdErr]);
+  return pullError.message && pullError;
+}
+__name(parsePullErrorResult, "parsePullErrorResult");
+var FILE_UPDATE_REGEX;
+var SUMMARY_REGEX;
+var ACTION_REGEX;
+var parsers3;
+var errorParsers;
+var parsePullDetail;
+var parsePullResult;
+var init_parse_pull = __esm({
+  "src/lib/parsers/parse-pull.ts"() {
+    "use strict";
+    init_PullSummary();
+    init_utils();
+    init_parse_remote_messages();
+    FILE_UPDATE_REGEX = /^\s*(.+?)\s+\|\s+\d+\s*(\+*)(-*)/;
+    SUMMARY_REGEX = /(\d+)\D+((\d+)\D+\(\+\))?(\D+(\d+)\D+\(-\))?/;
+    ACTION_REGEX = /^(create|delete) mode \d+ (.+)/;
+    parsers3 = [
+      new LineParser(FILE_UPDATE_REGEX, (result, [file, insertions, deletions]) => {
+        result.files.push(file);
+        if (insertions) {
+          result.insertions[file] = insertions.length;
+        }
+        if (deletions) {
+          result.deletions[file] = deletions.length;
+        }
+      }),
+      new LineParser(SUMMARY_REGEX, (result, [changes, , insertions, , deletions]) => {
+        if (insertions !== void 0 || deletions !== void 0) {
+          result.summary.changes = +changes || 0;
+          result.summary.insertions = +insertions || 0;
+          result.summary.deletions = +deletions || 0;
+          return true;
+        }
+        return false;
+      }),
+      new LineParser(ACTION_REGEX, (result, [action, file]) => {
+        append(result.files, file);
+        append(action === "create" ? result.created : result.deleted, file);
+      })
+    ];
+    errorParsers = [
+      new LineParser(/^from\s(.+)$/i, (result, [remote]) => void (result.remote = remote)),
+      new LineParser(/^fatal:\s(.+)$/, (result, [message]) => void (result.message = message)),
+      new LineParser(
+        /([a-z0-9]+)\.\.([a-z0-9]+)\s+(\S+)\s+->\s+(\S+)$/,
+        (result, [hashLocal, hashRemote, branchLocal, branchRemote]) => {
+          result.branch.local = branchLocal;
+          result.hash.local = hashLocal;
+          result.branch.remote = branchRemote;
+          result.hash.remote = hashRemote;
+        }
+      )
+    ];
+    parsePullDetail = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return parseStringResponse(new PullSummary(), parsers3, [stdOut, stdErr]);
+    }, "parsePullDetail");
+    parsePullResult = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return Object.assign(
+        new PullSummary(),
+        parsePullDetail(stdOut, stdErr),
+        parseRemoteMessages(stdOut, stdErr)
+      );
+    }, "parsePullResult");
+  }
+});
+var parsers4;
+var parseMergeResult;
+var parseMergeDetail;
+var init_parse_merge = __esm({
+  "src/lib/parsers/parse-merge.ts"() {
+    "use strict";
+    init_MergeSummary();
+    init_utils();
+    init_parse_pull();
+    parsers4 = [
+      new LineParser(/^Auto-merging\s+(.+)$/, (summary2, [autoMerge]) => {
+        summary2.merges.push(autoMerge);
+      }),
+      new LineParser(/^CONFLICT\s+\((.+)\): Merge conflict in (.+)$/, (summary2, [reason, file]) => {
+        summary2.conflicts.push(new MergeSummaryConflict(reason, file));
+      }),
+      new LineParser(
+        /^CONFLICT\s+\((.+\/delete)\): (.+) deleted in (.+) and/,
+        (summary2, [reason, file, deleteRef]) => {
+          summary2.conflicts.push(new MergeSummaryConflict(reason, file, { deleteRef }));
+        }
+      ),
+      new LineParser(/^CONFLICT\s+\((.+)\):/, (summary2, [reason]) => {
+        summary2.conflicts.push(new MergeSummaryConflict(reason, null));
+      }),
+      new LineParser(/^Automatic merge failed;\s+(.+)$/, (summary2, [result]) => {
+        summary2.result = result;
+      })
+    ];
+    parseMergeResult = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return Object.assign(parseMergeDetail(stdOut, stdErr), parsePullResult(stdOut, stdErr));
+    }, "parseMergeResult");
+    parseMergeDetail = /* @__PURE__ */ __name((stdOut) => {
+      return parseStringResponse(new MergeSummaryDetail(), parsers4, stdOut);
+    }, "parseMergeDetail");
+  }
+});
+function mergeTask(customArgs) {
+  if (!customArgs.length) {
+    return configurationErrorTask("Git.merge requires at least one option");
+  }
+  return {
+    commands: ["merge", ...customArgs],
+    format: "utf-8",
+    parser(stdOut, stdErr) {
+      const merge = parseMergeResult(stdOut, stdErr);
+      if (merge.failed) {
+        throw new GitResponseError(merge);
+      }
+      return merge;
+    }
+  };
+}
+__name(mergeTask, "mergeTask");
+var init_merge = __esm({
+  "src/lib/tasks/merge.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_parse_merge();
+    init_task();
+  }
+});
+function pushResultPushedItem(local, remote, status) {
+  const deleted = status.includes("deleted");
+  const tag = status.includes("tag") || /^refs\/tags/.test(local);
+  const alreadyUpdated = !status.includes("new");
+  return {
+    deleted,
+    tag,
+    branch: !tag,
+    new: !alreadyUpdated,
+    alreadyUpdated,
+    local,
+    remote
+  };
+}
+__name(pushResultPushedItem, "pushResultPushedItem");
+var parsers5;
+var parsePushResult;
+var parsePushDetail;
+var init_parse_push = __esm({
+  "src/lib/parsers/parse-push.ts"() {
+    "use strict";
+    init_utils();
+    init_parse_remote_messages();
+    parsers5 = [
+      new LineParser(/^Pushing to (.+)$/, (result, [repo]) => {
+        result.repo = repo;
+      }),
+      new LineParser(/^updating local tracking ref '(.+)'/, (result, [local]) => {
+        result.ref = {
+          ...result.ref || {},
+          local
+        };
+      }),
+      new LineParser(/^[=*-]\s+([^:]+):(\S+)\s+\[(.+)]$/, (result, [local, remote, type]) => {
+        result.pushed.push(pushResultPushedItem(local, remote, type));
+      }),
+      new LineParser(
+        /^Branch '([^']+)' set up to track remote branch '([^']+)' from '([^']+)'/,
+        (result, [local, remote, remoteName]) => {
+          result.branch = {
+            ...result.branch || {},
+            local,
+            remote,
+            remoteName
+          };
+        }
+      ),
+      new LineParser(
+        /^([^:]+):(\S+)\s+([a-z0-9]+)\.\.([a-z0-9]+)$/,
+        (result, [local, remote, from, to]) => {
+          result.update = {
+            head: {
+              local,
+              remote
+            },
+            hash: {
+              from,
+              to
+            }
+          };
+        }
+      )
+    ];
+    parsePushResult = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      const pushDetail = parsePushDetail(stdOut, stdErr);
+      const responseDetail = parseRemoteMessages(stdOut, stdErr);
+      return {
+        ...pushDetail,
+        ...responseDetail
+      };
+    }, "parsePushResult");
+    parsePushDetail = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return parseStringResponse({ pushed: [] }, parsers5, [stdOut, stdErr]);
+    }, "parsePushDetail");
+  }
+});
+var push_exports = {};
+__export(push_exports, {
+  pushTagsTask: /* @__PURE__ */ __name(() => pushTagsTask, "pushTagsTask"),
+  pushTask: /* @__PURE__ */ __name(() => pushTask, "pushTask")
+});
+function pushTagsTask(ref = {}, customArgs) {
+  append(customArgs, "--tags");
+  return pushTask(ref, customArgs);
+}
+__name(pushTagsTask, "pushTagsTask");
+function pushTask(ref = {}, customArgs) {
+  const commands = ["push", ...customArgs];
+  if (ref.branch) {
+    commands.splice(1, 0, ref.branch);
+  }
+  if (ref.remote) {
+    commands.splice(1, 0, ref.remote);
+  }
+  remove(commands, "-v");
+  append(commands, "--verbose");
+  append(commands, "--porcelain");
+  return {
+    commands,
+    format: "utf-8",
+    parser: parsePushResult
+  };
+}
+__name(pushTask, "pushTask");
+var init_push = __esm({
+  "src/lib/tasks/push.ts"() {
+    "use strict";
+    init_parse_push();
+    init_utils();
+  }
+});
+function show_default() {
+  return {
+    showBuffer() {
+      const commands = ["show", ...getTrailingOptions(arguments, 1)];
+      if (!commands.includes("--binary")) {
+        commands.splice(1, 0, "--binary");
+      }
+      return this._runTask(
+        straightThroughBufferTask(commands),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    show() {
+      const commands = ["show", ...getTrailingOptions(arguments, 1)];
+      return this._runTask(
+        straightThroughStringTask(commands),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(show_default, "show_default");
+var init_show = __esm({
+  "src/lib/tasks/show.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+var fromPathRegex;
+var FileStatusSummary;
+var init_FileStatusSummary = __esm({
+  "src/lib/responses/FileStatusSummary.ts"() {
+    "use strict";
+    fromPathRegex = /^(.+)\0(.+)$/;
+    FileStatusSummary = class {
+      static {
+        __name(this, "FileStatusSummary");
+      }
+      constructor(path5, index, working_dir) {
+        this.path = path5;
+        this.index = index;
+        this.working_dir = working_dir;
+        if (index === "R" || working_dir === "R") {
+          const detail = fromPathRegex.exec(path5) || [null, path5, path5];
+          this.from = detail[2] || "";
+          this.path = detail[1] || "";
+        }
+      }
+    };
+  }
+});
+function renamedFile(line) {
+  const [to, from] = line.split(NULL);
+  return {
+    from: from || to,
+    to
+  };
+}
+__name(renamedFile, "renamedFile");
+function parser3(indexX, indexY, handler) {
+  return [`${indexX}${indexY}`, handler];
+}
+__name(parser3, "parser3");
+function conflicts(indexX, ...indexY) {
+  return indexY.map((y) => parser3(indexX, y, (result, file) => result.conflicted.push(file)));
+}
+__name(conflicts, "conflicts");
+function splitLine(result, lineStr) {
+  const trimmed2 = lineStr.trim();
+  switch (" ") {
+    case trimmed2.charAt(2):
+      return data(trimmed2.charAt(0), trimmed2.charAt(1), trimmed2.slice(3));
+    case trimmed2.charAt(1):
+      return data(" ", trimmed2.charAt(0), trimmed2.slice(2));
+    default:
+      return;
+  }
+  function data(index, workingDir, path5) {
+    const raw = `${index}${workingDir}`;
+    const handler = parsers6.get(raw);
+    if (handler) {
+      handler(result, path5);
+    }
+    if (raw !== "##" && raw !== "!!") {
+      result.files.push(new FileStatusSummary(path5, index, workingDir));
+    }
+  }
+  __name(data, "data");
+}
+__name(splitLine, "splitLine");
+var StatusSummary;
+var parsers6;
+var parseStatusSummary;
+var init_StatusSummary = __esm({
+  "src/lib/responses/StatusSummary.ts"() {
+    "use strict";
+    init_utils();
+    init_FileStatusSummary();
+    StatusSummary = class {
+      static {
+        __name(this, "StatusSummary");
+      }
+      constructor() {
+        this.not_added = [];
+        this.conflicted = [];
+        this.created = [];
+        this.deleted = [];
+        this.ignored = void 0;
+        this.modified = [];
+        this.renamed = [];
+        this.files = [];
+        this.staged = [];
+        this.ahead = 0;
+        this.behind = 0;
+        this.current = null;
+        this.tracking = null;
+        this.detached = false;
+        this.isClean = () => {
+          return !this.files.length;
+        };
+      }
+    };
+    parsers6 = new Map([
+      parser3(
+        " ",
+        "A",
+        (result, file) => result.created.push(file)
+      ),
+      parser3(
+        " ",
+        "D",
+        (result, file) => result.deleted.push(file)
+      ),
+      parser3(
+        " ",
+        "M",
+        (result, file) => result.modified.push(file)
+      ),
+      parser3("A", " ", (result, file) => {
+        result.created.push(file);
+        result.staged.push(file);
+      }),
+      parser3("A", "M", (result, file) => {
+        result.created.push(file);
+        result.staged.push(file);
+        result.modified.push(file);
+      }),
+      parser3("D", " ", (result, file) => {
+        result.deleted.push(file);
+        result.staged.push(file);
+      }),
+      parser3("M", " ", (result, file) => {
+        result.modified.push(file);
+        result.staged.push(file);
+      }),
+      parser3("M", "M", (result, file) => {
+        result.modified.push(file);
+        result.staged.push(file);
+      }),
+      parser3("R", " ", (result, file) => {
+        result.renamed.push(renamedFile(file));
+      }),
+      parser3("R", "M", (result, file) => {
+        const renamed = renamedFile(file);
+        result.renamed.push(renamed);
+        result.modified.push(renamed.to);
+      }),
+      parser3("!", "!", (_result, _file) => {
+        (_result.ignored = _result.ignored || []).push(_file);
+      }),
+      parser3(
+        "?",
+        "?",
+        (result, file) => result.not_added.push(file)
+      ),
+      ...conflicts(
+        "A",
+        "A",
+        "U"
+        /* UNMERGED */
+      ),
+      ...conflicts(
+        "D",
+        "D",
+        "U"
+        /* UNMERGED */
+      ),
+      ...conflicts(
+        "U",
+        "A",
+        "D",
+        "U"
+        /* UNMERGED */
+      ),
+      [
+        "##",
+        (result, line) => {
+          const aheadReg = /ahead (\d+)/;
+          const behindReg = /behind (\d+)/;
+          const currentReg = /^(.+?(?=(?:\.{3}|\s|$)))/;
+          const trackingReg = /\.{3}(\S*)/;
+          const onEmptyBranchReg = /\son\s(\S+?)(?=\.{3}|$)/;
+          let regexResult = aheadReg.exec(line);
+          result.ahead = regexResult && +regexResult[1] || 0;
+          regexResult = behindReg.exec(line);
+          result.behind = regexResult && +regexResult[1] || 0;
+          regexResult = currentReg.exec(line);
+          result.current = filterType(regexResult?.[1], filterString, null);
+          regexResult = trackingReg.exec(line);
+          result.tracking = filterType(regexResult?.[1], filterString, null);
+          regexResult = onEmptyBranchReg.exec(line);
+          if (regexResult) {
+            result.current = filterType(regexResult?.[1], filterString, result.current);
+          }
+          result.detached = /\(no branch\)/.test(line);
+        }
+      ]
+    ]);
+    parseStatusSummary = /* @__PURE__ */ __name(function(text) {
+      const lines = text.split(NULL);
+      const status = new StatusSummary();
+      for (let i = 0, l = lines.length; i < l; ) {
+        let line = lines[i++].trim();
+        if (!line) {
+          continue;
+        }
+        if (line.charAt(0) === "R") {
+          line += NULL + (lines[i++] || "");
+        }
+        splitLine(status, line);
+      }
+      return status;
+    }, "parseStatusSummary");
+  }
+});
+function statusTask(customArgs) {
+  const commands = [
+    "status",
+    "--porcelain",
+    "-b",
+    "-u",
+    "--null",
+    ...customArgs.filter((arg) => !ignoredOptions.includes(arg))
+  ];
+  return {
+    format: "utf-8",
+    commands,
+    parser(text) {
+      return parseStatusSummary(text);
+    }
+  };
+}
+__name(statusTask, "statusTask");
+var ignoredOptions;
+var init_status = __esm({
+  "src/lib/tasks/status.ts"() {
+    "use strict";
+    init_StatusSummary();
+    ignoredOptions = ["--null", "-z"];
+  }
+});
+function versionResponse(major = 0, minor = 0, patch = 0, agent = "", installed = true) {
+  return Object.defineProperty(
+    {
+      major,
+      minor,
+      patch,
+      agent,
+      installed
+    },
+    "toString",
+    {
+      value() {
+        return `${this.major}.${this.minor}.${this.patch}`;
+      },
+      configurable: false,
+      enumerable: false
+    }
+  );
+}
+__name(versionResponse, "versionResponse");
+function notInstalledResponse() {
+  return versionResponse(0, 0, 0, "", false);
+}
+__name(notInstalledResponse, "notInstalledResponse");
+function version_default() {
+  return {
+    version() {
+      return this._runTask({
+        commands: ["--version"],
+        format: "utf-8",
+        parser: versionParser,
+        onError(result, error2, done, fail) {
+          if (result.exitCode === -2) {
+            return done(Buffer.from(NOT_INSTALLED));
+          }
+          fail(error2);
+        }
+      });
+    }
+  };
+}
+__name(version_default, "version_default");
+function versionParser(stdOut) {
+  if (stdOut === NOT_INSTALLED) {
+    return notInstalledResponse();
+  }
+  return parseStringResponse(versionResponse(0, 0, 0, stdOut), parsers7, stdOut);
+}
+__name(versionParser, "versionParser");
+var NOT_INSTALLED;
+var parsers7;
+var init_version = __esm({
+  "src/lib/tasks/version.ts"() {
+    "use strict";
+    init_utils();
+    NOT_INSTALLED = "installed=false";
+    parsers7 = [
+      new LineParser(
+        /version (\d+)\.(\d+)\.(\d+)(?:\s*\((.+)\))?/,
+        (result, [major, minor, patch, agent = ""]) => {
+          Object.assign(
+            result,
+            versionResponse(asNumber(major), asNumber(minor), asNumber(patch), agent)
+          );
+        }
+      ),
+      new LineParser(
+        /version (\d+)\.(\d+)\.(\D+)(.+)?$/,
+        (result, [major, minor, patch, agent = ""]) => {
+          Object.assign(result, versionResponse(asNumber(major), asNumber(minor), patch, agent));
+        }
+      )
+    ];
+  }
+});
+function createCloneTask(api, task, repoPath, ...args) {
+  if (!filterString(repoPath)) {
+    return configurationErrorTask(`git.${api}() requires a string 'repoPath'`);
+  }
+  return task(repoPath, filterType(args[0], filterString), getTrailingOptions(arguments));
+}
+__name(createCloneTask, "createCloneTask");
+function clone_default() {
+  return {
+    clone(repo, ...rest) {
+      return this._runTask(
+        createCloneTask("clone", cloneTask, filterType(repo, filterString), ...rest),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    mirror(repo, ...rest) {
+      return this._runTask(
+        createCloneTask("mirror", cloneMirrorTask, filterType(repo, filterString), ...rest),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(clone_default, "clone_default");
+var cloneTask;
+var cloneMirrorTask;
+var init_clone = __esm({
+  "src/lib/tasks/clone.ts"() {
+    "use strict";
+    init_task();
+    init_utils();
+    init_pathspec();
+    cloneTask = /* @__PURE__ */ __name((repo, directory, customArgs) => {
+      const commands = ["clone", ...customArgs];
+      filterString(repo) && commands.push(pathspec(repo));
+      filterString(directory) && commands.push(pathspec(directory));
+      return straightThroughStringTask(commands);
+    }, "cloneTask");
+    cloneMirrorTask = /* @__PURE__ */ __name((repo, directory, customArgs) => {
+      append(customArgs, "--mirror");
+      return cloneTask(repo, directory, customArgs);
+    }, "cloneMirrorTask");
+  }
+});
+var simple_git_api_exports = {};
+__export(simple_git_api_exports, {
+  SimpleGitApi: /* @__PURE__ */ __name(() => SimpleGitApi, "SimpleGitApi")
+});
+var SimpleGitApi;
+var init_simple_git_api = __esm({
+  "src/lib/simple-git-api.ts"() {
+    "use strict";
+    init_task_callback();
+    init_change_working_directory();
+    init_checkout();
+    init_count_objects();
+    init_commit();
+    init_config();
+    init_first_commit();
+    init_grep();
+    init_hash_object();
+    init_init();
+    init_log();
+    init_merge();
+    init_push();
+    init_show();
+    init_status();
+    init_task();
+    init_version();
+    init_utils();
+    init_clone();
+    SimpleGitApi = class {
+      static {
+        __name(this, "SimpleGitApi");
+      }
+      constructor(_executor) {
+        this._executor = _executor;
+      }
+      _runTask(task, then) {
+        const chain = this._executor.chain();
+        const promise = chain.push(task);
+        if (then) {
+          taskCallback(task, promise, then);
+        }
+        return Object.create(this, {
+          then: { value: promise.then.bind(promise) },
+          catch: { value: promise.catch.bind(promise) },
+          _executor: { value: chain }
+        });
+      }
+      add(files) {
+        return this._runTask(
+          straightThroughStringTask(["add", ...asArray(files)]),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      cwd(directory) {
+        const next = trailingFunctionArgument(arguments);
+        if (typeof directory === "string") {
+          return this._runTask(changeWorkingDirectoryTask(directory, this._executor), next);
+        }
+        if (typeof directory?.path === "string") {
+          return this._runTask(
+            changeWorkingDirectoryTask(
+              directory.path,
+              directory.root && this._executor || void 0
+            ),
+            next
+          );
+        }
+        return this._runTask(
+          configurationErrorTask("Git.cwd: workingDirectory must be supplied as a string"),
+          next
+        );
+      }
+      hashObject(path5, write) {
+        return this._runTask(
+          hashObjectTask(path5, write === true),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      init(bare) {
+        return this._runTask(
+          initTask(bare === true, this._executor.cwd, getTrailingOptions(arguments)),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      merge() {
+        return this._runTask(
+          mergeTask(getTrailingOptions(arguments)),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      mergeFromTo(remote, branch) {
+        if (!(filterString(remote) && filterString(branch))) {
+          return this._runTask(
+            configurationErrorTask(
+              `Git.mergeFromTo requires that the 'remote' and 'branch' arguments are supplied as strings`
+            )
+          );
+        }
+        return this._runTask(
+          mergeTask([remote, branch, ...getTrailingOptions(arguments)]),
+          trailingFunctionArgument(arguments, false)
+        );
+      }
+      outputHandler(handler) {
+        this._executor.outputHandler = handler;
+        return this;
+      }
+      push() {
+        const task = pushTask(
+          {
+            remote: filterType(arguments[0], filterString),
+            branch: filterType(arguments[1], filterString)
+          },
+          getTrailingOptions(arguments)
+        );
+        return this._runTask(task, trailingFunctionArgument(arguments));
+      }
+      stash() {
+        return this._runTask(
+          straightThroughStringTask(["stash", ...getTrailingOptions(arguments)]),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      status() {
+        return this._runTask(
+          statusTask(getTrailingOptions(arguments)),
+          trailingFunctionArgument(arguments)
+        );
+      }
+    };
+    Object.assign(
+      SimpleGitApi.prototype,
+      checkout_default(),
+      clone_default(),
+      commit_default(),
+      config_default(),
+      count_objects_default(),
+      first_commit_default(),
+      grep_default(),
+      log_default(),
+      show_default(),
+      version_default()
+    );
+  }
+});
+var scheduler_exports = {};
+__export(scheduler_exports, {
+  Scheduler: /* @__PURE__ */ __name(() => Scheduler, "Scheduler")
+});
+var createScheduledTask;
+var Scheduler;
+var init_scheduler = __esm({
+  "src/lib/runners/scheduler.ts"() {
+    "use strict";
+    init_utils();
+    init_git_logger();
+    createScheduledTask = /* @__PURE__ */ (() => {
+      let id = 0;
+      return () => {
+        id++;
+        const { promise, done } = (0, import_promise_deferred.createDeferred)();
+        return {
+          promise,
+          done,
+          id
+        };
+      };
+    })();
+    Scheduler = class {
+      static {
+        __name(this, "Scheduler");
+      }
+      constructor(concurrency = 2) {
+        this.concurrency = concurrency;
+        this.logger = createLogger("", "scheduler");
+        this.pending = [];
+        this.running = [];
+        this.logger(`Constructed, concurrency=%s`, concurrency);
+      }
+      schedule() {
+        if (!this.pending.length || this.running.length >= this.concurrency) {
+          this.logger(
+            `Schedule attempt ignored, pending=%s running=%s concurrency=%s`,
+            this.pending.length,
+            this.running.length,
+            this.concurrency
+          );
+          return;
+        }
+        const task = append(this.running, this.pending.shift());
+        this.logger(`Attempting id=%s`, task.id);
+        task.done(() => {
+          this.logger(`Completing id=`, task.id);
+          remove(this.running, task);
+          this.schedule();
+        });
+      }
+      next() {
+        const { promise, id } = append(this.pending, createScheduledTask());
+        this.logger(`Scheduling id=%s`, id);
+        this.schedule();
+        return promise;
+      }
+    };
+  }
+});
+var apply_patch_exports = {};
+__export(apply_patch_exports, {
+  applyPatchTask: /* @__PURE__ */ __name(() => applyPatchTask, "applyPatchTask")
+});
+function applyPatchTask(patches, customArgs) {
+  return straightThroughStringTask(["apply", ...customArgs, ...patches]);
+}
+__name(applyPatchTask, "applyPatchTask");
+var init_apply_patch = __esm({
+  "src/lib/tasks/apply-patch.ts"() {
+    "use strict";
+    init_task();
+  }
+});
+function branchDeletionSuccess(branch, hash) {
+  return {
+    branch,
+    hash,
+    success: true
+  };
+}
+__name(branchDeletionSuccess, "branchDeletionSuccess");
+function branchDeletionFailure(branch) {
+  return {
+    branch,
+    hash: null,
+    success: false
+  };
+}
+__name(branchDeletionFailure, "branchDeletionFailure");
+var BranchDeletionBatch;
+var init_BranchDeleteSummary = __esm({
+  "src/lib/responses/BranchDeleteSummary.ts"() {
+    "use strict";
+    BranchDeletionBatch = class {
+      static {
+        __name(this, "BranchDeletionBatch");
+      }
+      constructor() {
+        this.all = [];
+        this.branches = {};
+        this.errors = [];
+      }
+      get success() {
+        return !this.errors.length;
+      }
+    };
+  }
+});
+function hasBranchDeletionError(data, processExitCode) {
+  return processExitCode === 1 && deleteErrorRegex.test(data);
+}
+__name(hasBranchDeletionError, "hasBranchDeletionError");
+var deleteSuccessRegex;
+var deleteErrorRegex;
+var parsers8;
+var parseBranchDeletions;
+var init_parse_branch_delete = __esm({
+  "src/lib/parsers/parse-branch-delete.ts"() {
+    "use strict";
+    init_BranchDeleteSummary();
+    init_utils();
+    deleteSuccessRegex = /(\S+)\s+\(\S+\s([^)]+)\)/;
+    deleteErrorRegex = /^error[^']+'([^']+)'/m;
+    parsers8 = [
+      new LineParser(deleteSuccessRegex, (result, [branch, hash]) => {
+        const deletion = branchDeletionSuccess(branch, hash);
+        result.all.push(deletion);
+        result.branches[branch] = deletion;
+      }),
+      new LineParser(deleteErrorRegex, (result, [branch]) => {
+        const deletion = branchDeletionFailure(branch);
+        result.errors.push(deletion);
+        result.all.push(deletion);
+        result.branches[branch] = deletion;
+      })
+    ];
+    parseBranchDeletions = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return parseStringResponse(new BranchDeletionBatch(), parsers8, [stdOut, stdErr]);
+    }, "parseBranchDeletions");
+  }
+});
+var BranchSummaryResult;
+var init_BranchSummary = __esm({
+  "src/lib/responses/BranchSummary.ts"() {
+    "use strict";
+    BranchSummaryResult = class {
+      static {
+        __name(this, "BranchSummaryResult");
+      }
+      constructor() {
+        this.all = [];
+        this.branches = {};
+        this.current = "";
+        this.detached = false;
+      }
+      push(status, detached, name, commit, label) {
+        if (status === "*") {
+          this.detached = detached;
+          this.current = name;
+        }
+        this.all.push(name);
+        this.branches[name] = {
+          current: status === "*",
+          linkedWorkTree: status === "+",
+          name,
+          commit,
+          label
+        };
+      }
+    };
+  }
+});
+function branchStatus(input) {
+  return input ? input.charAt(0) : "";
+}
+__name(branchStatus, "branchStatus");
+function parseBranchSummary(stdOut, currentOnly = false) {
+  return parseStringResponse(
+    new BranchSummaryResult(),
+    currentOnly ? [currentBranchParser] : parsers9,
+    stdOut
+  );
+}
+__name(parseBranchSummary, "parseBranchSummary");
+var parsers9;
+var currentBranchParser;
+var init_parse_branch = __esm({
+  "src/lib/parsers/parse-branch.ts"() {
+    "use strict";
+    init_BranchSummary();
+    init_utils();
+    parsers9 = [
+      new LineParser(
+        /^([*+]\s)?\((?:HEAD )?detached (?:from|at) (\S+)\)\s+([a-z0-9]+)\s(.*)$/,
+        (result, [current, name, commit, label]) => {
+          result.push(branchStatus(current), true, name, commit, label);
+        }
+      ),
+      new LineParser(
+        /^([*+]\s)?(\S+)\s+([a-z0-9]+)\s?(.*)$/s,
+        (result, [current, name, commit, label]) => {
+          result.push(branchStatus(current), false, name, commit, label);
+        }
+      )
+    ];
+    currentBranchParser = new LineParser(/^(\S+)$/s, (result, [name]) => {
+      result.push("*", false, name, "", "");
+    });
+  }
+});
+var branch_exports = {};
+__export(branch_exports, {
+  branchLocalTask: /* @__PURE__ */ __name(() => branchLocalTask, "branchLocalTask"),
+  branchTask: /* @__PURE__ */ __name(() => branchTask, "branchTask"),
+  containsDeleteBranchCommand: /* @__PURE__ */ __name(() => containsDeleteBranchCommand, "containsDeleteBranchCommand"),
+  deleteBranchTask: /* @__PURE__ */ __name(() => deleteBranchTask, "deleteBranchTask"),
+  deleteBranchesTask: /* @__PURE__ */ __name(() => deleteBranchesTask, "deleteBranchesTask")
+});
+function containsDeleteBranchCommand(commands) {
+  const deleteCommands = ["-d", "-D", "--delete"];
+  return commands.some((command) => deleteCommands.includes(command));
+}
+__name(containsDeleteBranchCommand, "containsDeleteBranchCommand");
+function branchTask(customArgs) {
+  const isDelete = containsDeleteBranchCommand(customArgs);
+  const isCurrentOnly = customArgs.includes("--show-current");
+  const commands = ["branch", ...customArgs];
+  if (commands.length === 1) {
+    commands.push("-a");
+  }
+  if (!commands.includes("-v")) {
+    commands.splice(1, 0, "-v");
+  }
+  return {
+    format: "utf-8",
+    commands,
+    parser(stdOut, stdErr) {
+      if (isDelete) {
+        return parseBranchDeletions(stdOut, stdErr).all[0];
+      }
+      return parseBranchSummary(stdOut, isCurrentOnly);
+    }
+  };
+}
+__name(branchTask, "branchTask");
+function branchLocalTask() {
+  return {
+    format: "utf-8",
+    commands: ["branch", "-v"],
+    parser(stdOut) {
+      return parseBranchSummary(stdOut);
+    }
+  };
+}
+__name(branchLocalTask, "branchLocalTask");
+function deleteBranchesTask(branches, forceDelete = false) {
+  return {
+    format: "utf-8",
+    commands: ["branch", "-v", forceDelete ? "-D" : "-d", ...branches],
+    parser(stdOut, stdErr) {
+      return parseBranchDeletions(stdOut, stdErr);
+    },
+    onError({ exitCode, stdOut }, error2, done, fail) {
+      if (!hasBranchDeletionError(String(error2), exitCode)) {
+        return fail(error2);
+      }
+      done(stdOut);
+    }
+  };
+}
+__name(deleteBranchesTask, "deleteBranchesTask");
+function deleteBranchTask(branch, forceDelete = false) {
+  const task = {
+    format: "utf-8",
+    commands: ["branch", "-v", forceDelete ? "-D" : "-d", branch],
+    parser(stdOut, stdErr) {
+      return parseBranchDeletions(stdOut, stdErr).branches[branch];
+    },
+    onError({ exitCode, stdErr, stdOut }, error2, _, fail) {
+      if (!hasBranchDeletionError(String(error2), exitCode)) {
+        return fail(error2);
+      }
+      throw new GitResponseError(
+        task.parser(bufferToString(stdOut), bufferToString(stdErr)),
+        String(error2)
+      );
+    }
+  };
+  return task;
+}
+__name(deleteBranchTask, "deleteBranchTask");
+var init_branch = __esm({
+  "src/lib/tasks/branch.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_parse_branch_delete();
+    init_parse_branch();
+    init_utils();
+  }
+});
+function toPath(input) {
+  const path5 = input.trim().replace(/^["']|["']$/g, "");
+  return path5 && (0, import_node_path.normalize)(path5);
+}
+__name(toPath, "toPath");
+var parseCheckIgnore;
+var init_CheckIgnore = __esm({
+  "src/lib/responses/CheckIgnore.ts"() {
+    "use strict";
+    parseCheckIgnore = /* @__PURE__ */ __name((text) => {
+      return text.split(/\n/g).map(toPath).filter(Boolean);
+    }, "parseCheckIgnore");
+  }
+});
+var check_ignore_exports = {};
+__export(check_ignore_exports, {
+  checkIgnoreTask: /* @__PURE__ */ __name(() => checkIgnoreTask, "checkIgnoreTask")
+});
+function checkIgnoreTask(paths) {
+  return {
+    commands: ["check-ignore", ...paths],
+    format: "utf-8",
+    parser: parseCheckIgnore
+  };
+}
+__name(checkIgnoreTask, "checkIgnoreTask");
+var init_check_ignore = __esm({
+  "src/lib/tasks/check-ignore.ts"() {
+    "use strict";
+    init_CheckIgnore();
+  }
+});
+function parseFetchResult(stdOut, stdErr) {
+  const result = {
+    raw: stdOut,
+    remote: null,
+    branches: [],
+    tags: [],
+    updated: [],
+    deleted: []
+  };
+  return parseStringResponse(result, parsers10, [stdOut, stdErr]);
+}
+__name(parseFetchResult, "parseFetchResult");
+var parsers10;
+var init_parse_fetch = __esm({
+  "src/lib/parsers/parse-fetch.ts"() {
+    "use strict";
+    init_utils();
+    parsers10 = [
+      new LineParser(/From (.+)$/, (result, [remote]) => {
+        result.remote = remote;
+      }),
+      new LineParser(/\* \[new branch]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
+        result.branches.push({
+          name,
+          tracking
+        });
+      }),
+      new LineParser(/\* \[new tag]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
+        result.tags.push({
+          name,
+          tracking
+        });
+      }),
+      new LineParser(/- \[deleted]\s+\S+\s*-> (.+)$/, (result, [tracking]) => {
+        result.deleted.push({
+          tracking
+        });
+      }),
+      new LineParser(
+        /\s*([^.]+)\.\.(\S+)\s+(\S+)\s*-> (.+)$/,
+        (result, [from, to, name, tracking]) => {
+          result.updated.push({
+            name,
+            tracking,
+            to,
+            from
+          });
+        }
+      )
+    ];
+  }
+});
+var fetch_exports = {};
+__export(fetch_exports, {
+  fetchTask: /* @__PURE__ */ __name(() => fetchTask, "fetchTask")
+});
+function disallowedCommand(command) {
+  return /^--upload-pack(=|$)/.test(command);
+}
+__name(disallowedCommand, "disallowedCommand");
+function fetchTask(remote, branch, customArgs) {
+  const commands = ["fetch", ...customArgs];
+  if (remote && branch) {
+    commands.push(remote, branch);
+  }
+  const banned = commands.find(disallowedCommand);
+  if (banned) {
+    return configurationErrorTask(`git.fetch: potential exploit argument blocked.`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser: parseFetchResult
+  };
+}
+__name(fetchTask, "fetchTask");
+var init_fetch = __esm({
+  "src/lib/tasks/fetch.ts"() {
+    "use strict";
+    init_parse_fetch();
+    init_task();
+  }
+});
+function parseMoveResult(stdOut) {
+  return parseStringResponse({ moves: [] }, parsers11, stdOut);
+}
+__name(parseMoveResult, "parseMoveResult");
+var parsers11;
+var init_parse_move = __esm({
+  "src/lib/parsers/parse-move.ts"() {
+    "use strict";
+    init_utils();
+    parsers11 = [
+      new LineParser(/^Renaming (.+) to (.+)$/, (result, [from, to]) => {
+        result.moves.push({ from, to });
+      })
+    ];
+  }
+});
+var move_exports = {};
+__export(move_exports, {
+  moveTask: /* @__PURE__ */ __name(() => moveTask, "moveTask")
+});
+function moveTask(from, to) {
+  return {
+    commands: ["mv", "-v", ...asArray(from), to],
+    format: "utf-8",
+    parser: parseMoveResult
+  };
+}
+__name(moveTask, "moveTask");
+var init_move = __esm({
+  "src/lib/tasks/move.ts"() {
+    "use strict";
+    init_parse_move();
+    init_utils();
+  }
+});
+var pull_exports = {};
+__export(pull_exports, {
+  pullTask: /* @__PURE__ */ __name(() => pullTask, "pullTask")
+});
+function pullTask(remote, branch, customArgs) {
+  const commands = ["pull", ...customArgs];
+  if (remote && branch) {
+    commands.splice(1, 0, remote, branch);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(stdOut, stdErr) {
+      return parsePullResult(stdOut, stdErr);
+    },
+    onError(result, _error, _done, fail) {
+      const pullError = parsePullErrorResult(
+        bufferToString(result.stdOut),
+        bufferToString(result.stdErr)
+      );
+      if (pullError) {
+        return fail(new GitResponseError(pullError));
+      }
+      fail(_error);
+    }
+  };
+}
+__name(pullTask, "pullTask");
+var init_pull = __esm({
+  "src/lib/tasks/pull.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_parse_pull();
+    init_utils();
+  }
+});
+function parseGetRemotes(text) {
+  const remotes = {};
+  forEach(text, ([name]) => remotes[name] = { name });
+  return Object.values(remotes);
+}
+__name(parseGetRemotes, "parseGetRemotes");
+function parseGetRemotesVerbose(text) {
+  const remotes = {};
+  forEach(text, ([name, url, purpose]) => {
+    if (!Object.hasOwn(remotes, name)) {
+      remotes[name] = {
+        name,
+        refs: { fetch: "", push: "" }
+      };
+    }
+    if (purpose && url) {
+      remotes[name].refs[purpose.replace(/[^a-z]/g, "")] = url;
+    }
+  });
+  return Object.values(remotes);
+}
+__name(parseGetRemotesVerbose, "parseGetRemotesVerbose");
+function forEach(text, handler) {
+  forEachLineWithContent(text, (line) => handler(line.split(/\s+/)));
+}
+__name(forEach, "forEach");
+var init_GetRemoteSummary = __esm({
+  "src/lib/responses/GetRemoteSummary.ts"() {
+    "use strict";
+    init_utils();
+  }
+});
+var remote_exports = {};
+__export(remote_exports, {
+  addRemoteTask: /* @__PURE__ */ __name(() => addRemoteTask, "addRemoteTask"),
+  getRemotesTask: /* @__PURE__ */ __name(() => getRemotesTask, "getRemotesTask"),
+  listRemotesTask: /* @__PURE__ */ __name(() => listRemotesTask, "listRemotesTask"),
+  remoteTask: /* @__PURE__ */ __name(() => remoteTask, "remoteTask"),
+  removeRemoteTask: /* @__PURE__ */ __name(() => removeRemoteTask, "removeRemoteTask")
+});
+function addRemoteTask(remoteName, remoteRepo, customArgs) {
+  return straightThroughStringTask(["remote", "add", ...customArgs, remoteName, remoteRepo]);
+}
+__name(addRemoteTask, "addRemoteTask");
+function getRemotesTask(verbose) {
+  const commands = ["remote"];
+  if (verbose) {
+    commands.push("-v");
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser: verbose ? parseGetRemotesVerbose : parseGetRemotes
+  };
+}
+__name(getRemotesTask, "getRemotesTask");
+function listRemotesTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "ls-remote") {
+    commands.unshift("ls-remote");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(listRemotesTask, "listRemotesTask");
+function remoteTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "remote") {
+    commands.unshift("remote");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(remoteTask, "remoteTask");
+function removeRemoteTask(remoteName) {
+  return straightThroughStringTask(["remote", "remove", remoteName]);
+}
+__name(removeRemoteTask, "removeRemoteTask");
+var init_remote = __esm({
+  "src/lib/tasks/remote.ts"() {
+    "use strict";
+    init_GetRemoteSummary();
+    init_task();
+  }
+});
+var stash_list_exports = {};
+__export(stash_list_exports, {
+  stashListTask: /* @__PURE__ */ __name(() => stashListTask, "stashListTask")
+});
+function stashListTask(opt = {}, customArgs) {
+  const options = parseLogOptions(opt);
+  const commands = ["stash", "list", ...options.commands, ...customArgs];
+  const parser4 = createListLogSummaryParser(
+    options.splitter,
+    options.fields,
+    logFormatFromCommand(commands)
+  );
+  return validateLogFormatConfig(commands) || {
+    commands,
+    format: "utf-8",
+    parser: parser4
+  };
+}
+__name(stashListTask, "stashListTask");
+var init_stash_list = __esm({
+  "src/lib/tasks/stash-list.ts"() {
+    "use strict";
+    init_log_format();
+    init_parse_list_log_summary();
+    init_diff();
+    init_log();
+  }
+});
+var sub_module_exports = {};
+__export(sub_module_exports, {
+  addSubModuleTask: /* @__PURE__ */ __name(() => addSubModuleTask, "addSubModuleTask"),
+  initSubModuleTask: /* @__PURE__ */ __name(() => initSubModuleTask, "initSubModuleTask"),
+  subModuleTask: /* @__PURE__ */ __name(() => subModuleTask, "subModuleTask"),
+  updateSubModuleTask: /* @__PURE__ */ __name(() => updateSubModuleTask, "updateSubModuleTask")
+});
+function addSubModuleTask(repo, path5) {
+  return subModuleTask(["add", repo, path5]);
+}
+__name(addSubModuleTask, "addSubModuleTask");
+function initSubModuleTask(customArgs) {
+  return subModuleTask(["init", ...customArgs]);
+}
+__name(initSubModuleTask, "initSubModuleTask");
+function subModuleTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "submodule") {
+    commands.unshift("submodule");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(subModuleTask, "subModuleTask");
+function updateSubModuleTask(customArgs) {
+  return subModuleTask(["update", ...customArgs]);
+}
+__name(updateSubModuleTask, "updateSubModuleTask");
+var init_sub_module = __esm({
+  "src/lib/tasks/sub-module.ts"() {
+    "use strict";
+    init_task();
+  }
+});
+function singleSorted(a, b) {
+  const aIsNum = Number.isNaN(a);
+  const bIsNum = Number.isNaN(b);
+  if (aIsNum !== bIsNum) {
+    return aIsNum ? 1 : -1;
+  }
+  return aIsNum ? sorted(a, b) : 0;
+}
+__name(singleSorted, "singleSorted");
+function sorted(a, b) {
+  return a === b ? 0 : a > b ? 1 : -1;
+}
+__name(sorted, "sorted");
+function trimmed(input) {
+  return input.trim();
+}
+__name(trimmed, "trimmed");
+function toNumber(input) {
+  if (typeof input === "string") {
+    return parseInt(input.replace(/^\D+/g, ""), 10) || 0;
+  }
+  return 0;
+}
+__name(toNumber, "toNumber");
+var TagList;
+var parseTagList;
+var init_TagList = __esm({
+  "src/lib/responses/TagList.ts"() {
+    "use strict";
+    TagList = class {
+      static {
+        __name(this, "TagList");
+      }
+      constructor(all, latest) {
+        this.all = all;
+        this.latest = latest;
+      }
+    };
+    parseTagList = /* @__PURE__ */ __name(function(data, customSort = false) {
+      const tags = data.split("\n").map(trimmed).filter(Boolean);
+      if (!customSort) {
+        tags.sort(function(tagA, tagB) {
+          const partsA = tagA.split(".");
+          const partsB = tagB.split(".");
+          if (partsA.length === 1 || partsB.length === 1) {
+            return singleSorted(toNumber(partsA[0]), toNumber(partsB[0]));
+          }
+          for (let i = 0, l = Math.max(partsA.length, partsB.length); i < l; i++) {
+            const diff = sorted(toNumber(partsA[i]), toNumber(partsB[i]));
+            if (diff) {
+              return diff;
+            }
+          }
+          return 0;
+        });
+      }
+      const latest = customSort ? tags[0] : [...tags].reverse().find((tag) => tag.indexOf(".") >= 0);
+      return new TagList(tags, latest);
+    }, "parseTagList");
+  }
+});
+var tag_exports = {};
+__export(tag_exports, {
+  addAnnotatedTagTask: /* @__PURE__ */ __name(() => addAnnotatedTagTask, "addAnnotatedTagTask"),
+  addTagTask: /* @__PURE__ */ __name(() => addTagTask, "addTagTask"),
+  tagListTask: /* @__PURE__ */ __name(() => tagListTask, "tagListTask")
+});
+function tagListTask(customArgs = []) {
+  const hasCustomSort = customArgs.some((option) => /^--sort=/.test(option));
+  return {
+    format: "utf-8",
+    commands: ["tag", "-l", ...customArgs],
+    parser(text) {
+      return parseTagList(text, hasCustomSort);
+    }
+  };
+}
+__name(tagListTask, "tagListTask");
+function addTagTask(name) {
+  return {
+    format: "utf-8",
+    commands: ["tag", name],
+    parser() {
+      return { name };
+    }
+  };
+}
+__name(addTagTask, "addTagTask");
+function addAnnotatedTagTask(name, tagMessage) {
+  return {
+    format: "utf-8",
+    commands: ["tag", "-a", "-m", tagMessage, name],
+    parser() {
+      return { name };
+    }
+  };
+}
+__name(addAnnotatedTagTask, "addAnnotatedTagTask");
+var init_tag = __esm({
+  "src/lib/tasks/tag.ts"() {
+    "use strict";
+    init_TagList();
+  }
+});
+var require_git = __commonJS2({
+  "src/git.js"(exports2, module2) {
+    "use strict";
+    var { GitExecutor: GitExecutor2 } = (init_git_executor(), __toCommonJS(git_executor_exports));
+    var { SimpleGitApi: SimpleGitApi2 } = (init_simple_git_api(), __toCommonJS(simple_git_api_exports));
+    var { Scheduler: Scheduler2 } = (init_scheduler(), __toCommonJS(scheduler_exports));
+    var { adhocExecTask: adhocExecTask2, configurationErrorTask: configurationErrorTask2 } = (init_task(), __toCommonJS(
+    task_exports));
+    var {
+      asArray: asArray2,
+      filterArray: filterArray2,
+      filterPrimitives: filterPrimitives2,
+      filterString: filterString2,
+      filterStringOrStringArray: filterStringOrStringArray2,
+      filterType: filterType2,
+      getTrailingOptions: getTrailingOptions2,
+      trailingFunctionArgument: trailingFunctionArgument2,
+      trailingOptionsArgument: trailingOptionsArgument2
+    } = (init_utils(), __toCommonJS(utils_exports));
+    var { applyPatchTask: applyPatchTask2 } = (init_apply_patch(), __toCommonJS(apply_patch_exports));
+    var {
+      branchTask: branchTask2,
+      branchLocalTask: branchLocalTask2,
+      deleteBranchesTask: deleteBranchesTask2,
+      deleteBranchTask: deleteBranchTask2
+    } = (init_branch(), __toCommonJS(branch_exports));
+    var { checkIgnoreTask: checkIgnoreTask2 } = (init_check_ignore(), __toCommonJS(check_ignore_exports));
+    var { checkIsRepoTask: checkIsRepoTask2 } = (init_check_is_repo(), __toCommonJS(check_is_repo_exports));
+    var { cleanWithOptionsTask: cleanWithOptionsTask2, isCleanOptionsArray: isCleanOptionsArray2 } = (init_clean(), __toCommonJS(
+    clean_exports));
+    var { diffSummaryTask: diffSummaryTask2 } = (init_diff(), __toCommonJS(diff_exports));
+    var { fetchTask: fetchTask2 } = (init_fetch(), __toCommonJS(fetch_exports));
+    var { moveTask: moveTask2 } = (init_move(), __toCommonJS(move_exports));
+    var { pullTask: pullTask2 } = (init_pull(), __toCommonJS(pull_exports));
+    var { pushTagsTask: pushTagsTask2 } = (init_push(), __toCommonJS(push_exports));
+    var {
+      addRemoteTask: addRemoteTask2,
+      getRemotesTask: getRemotesTask2,
+      listRemotesTask: listRemotesTask2,
+      remoteTask: remoteTask2,
+      removeRemoteTask: removeRemoteTask2
+    } = (init_remote(), __toCommonJS(remote_exports));
+    var { getResetMode: getResetMode2, resetTask: resetTask2 } = (init_reset(), __toCommonJS(reset_exports));
+    var { stashListTask: stashListTask2 } = (init_stash_list(), __toCommonJS(stash_list_exports));
+    var {
+      addSubModuleTask: addSubModuleTask2,
+      initSubModuleTask: initSubModuleTask2,
+      subModuleTask: subModuleTask2,
+      updateSubModuleTask: updateSubModuleTask2
+    } = (init_sub_module(), __toCommonJS(sub_module_exports));
+    var { addAnnotatedTagTask: addAnnotatedTagTask2, addTagTask: addTagTask2, tagListTask: tagListTask2 } = (init_tag(),
+    __toCommonJS(tag_exports));
+    var { straightThroughBufferTask: straightThroughBufferTask2, straightThroughStringTask: straightThroughStringTask2 } = (init_task(),
+    __toCommonJS(task_exports));
+    function Git2(options, plugins) {
+      this._plugins = plugins;
+      this._executor = new GitExecutor2(
+        options.baseDir,
+        new Scheduler2(options.maxConcurrentProcesses),
+        plugins
+      );
+      this._trimmed = options.trimmed;
+    }
+    __name(Git2, "Git2");
+    (Git2.prototype = Object.create(SimpleGitApi2.prototype)).constructor = Git2;
+    Git2.prototype.customBinary = function(command) {
+      this._plugins.reconfigure("binary", command);
+      return this;
+    };
+    Git2.prototype.env = function(name, value) {
+      if (arguments.length === 1 && typeof name === "object") {
+        this._executor.env = name;
+      } else {
+        (this._executor.env = this._executor.env || {})[name] = value;
+      }
+      return this;
+    };
+    Git2.prototype.stashList = function(options) {
+      return this._runTask(
+        stashListTask2(
+          trailingOptionsArgument2(arguments) || {},
+          filterArray2(options) && options || []
+        ),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.mv = function(from, to) {
+      return this._runTask(moveTask2(from, to), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.checkoutLatestTag = function(then) {
+      var git = this;
+      return this.pull(function() {
+        git.tags(function(err, tags) {
+          git.checkout(tags.latest, then);
+        });
+      });
+    };
+    Git2.prototype.pull = function(remote, branch, options, then) {
+      return this._runTask(
+        pullTask2(
+          filterType2(remote, filterString2),
+          filterType2(branch, filterString2),
+          getTrailingOptions2(arguments)
+        ),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.fetch = function(remote, branch) {
+      return this._runTask(
+        fetchTask2(
+          filterType2(remote, filterString2),
+          filterType2(branch, filterString2),
+          getTrailingOptions2(arguments)
+        ),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.silent = function(silence) {
+      return this._runTask(
+        adhocExecTask2(
+          () => console.warn(
+            "simple-git deprecation notice: git.silent: logging should be configured using the `debug` library / `DEBUG`\
+ environment variable, this method will be removed."
+          )
+        )
+      );
+    };
+    Git2.prototype.tags = function(options, then) {
+      return this._runTask(
+        tagListTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.rebase = function() {
+      return this._runTask(
+        straightThroughStringTask2(["rebase", ...getTrailingOptions2(arguments)]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.reset = function(mode) {
+      return this._runTask(
+        resetTask2(getResetMode2(mode), getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.revert = function(commit) {
+      const next = trailingFunctionArgument2(arguments);
+      if (typeof commit !== "string") {
+        return this._runTask(configurationErrorTask2("Commit must be a string"), next);
+      }
+      return this._runTask(
+        straightThroughStringTask2(["revert", ...getTrailingOptions2(arguments, 0, true), commit]),
+        next
+      );
+    };
+    Git2.prototype.addTag = function(name) {
+      const task = typeof name === "string" ? addTagTask2(name) : configurationErrorTask2("Git.addTag requires a tag nam\
+e");
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.addAnnotatedTag = function(tagName, tagMessage) {
+      return this._runTask(
+        addAnnotatedTagTask2(tagName, tagMessage),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.deleteLocalBranch = function(branchName, forceDelete, then) {
+      return this._runTask(
+        deleteBranchTask2(branchName, typeof forceDelete === "boolean" ? forceDelete : false),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.deleteLocalBranches = function(branchNames, forceDelete, then) {
+      return this._runTask(
+        deleteBranchesTask2(branchNames, typeof forceDelete === "boolean" ? forceDelete : false),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.branch = function(options, then) {
+      return this._runTask(
+        branchTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.branchLocal = function(then) {
+      return this._runTask(branchLocalTask2(), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.raw = function(commands) {
+      const createRestCommands = !Array.isArray(commands);
+      const command = [].slice.call(createRestCommands ? arguments : commands, 0);
+      for (let i = 0; i < command.length && createRestCommands; i++) {
+        if (!filterPrimitives2(command[i])) {
+          command.splice(i, command.length - i);
+          break;
+        }
+      }
+      command.push(...getTrailingOptions2(arguments, 0, true));
+      var next = trailingFunctionArgument2(arguments);
+      if (!command.length) {
+        return this._runTask(
+          configurationErrorTask2("Raw: must supply one or more command to execute"),
+          next
+        );
+      }
+      return this._runTask(straightThroughStringTask2(command, this._trimmed), next);
+    };
+    Git2.prototype.submoduleAdd = function(repo, path5, then) {
+      return this._runTask(addSubModuleTask2(repo, path5), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.submoduleUpdate = function(args, then) {
+      return this._runTask(
+        updateSubModuleTask2(getTrailingOptions2(arguments, true)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.submoduleInit = function(args, then) {
+      return this._runTask(
+        initSubModuleTask2(getTrailingOptions2(arguments, true)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.subModule = function(options, then) {
+      return this._runTask(
+        subModuleTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.listRemote = function() {
+      return this._runTask(
+        listRemotesTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.addRemote = function(remoteName, remoteRepo, then) {
+      return this._runTask(
+        addRemoteTask2(remoteName, remoteRepo, getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.removeRemote = function(remoteName, then) {
+      return this._runTask(removeRemoteTask2(remoteName), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.getRemotes = function(verbose, then) {
+      return this._runTask(getRemotesTask2(verbose === true), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.remote = function(options, then) {
+      return this._runTask(
+        remoteTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.tag = function(options, then) {
+      const command = getTrailingOptions2(arguments);
+      if (command[0] !== "tag") {
+        command.unshift("tag");
+      }
+      return this._runTask(straightThroughStringTask2(command), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.updateServerInfo = function(then) {
+      return this._runTask(
+        straightThroughStringTask2(["update-server-info"]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.pushTags = function(remote, then) {
+      const task = pushTagsTask2(
+        { remote: filterType2(remote, filterString2) },
+        getTrailingOptions2(arguments)
+      );
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.rm = function(files) {
+      return this._runTask(
+        straightThroughStringTask2(["rm", "-f", ...asArray2(files)]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.rmKeepLocal = function(files) {
+      return this._runTask(
+        straightThroughStringTask2(["rm", "--cached", ...asArray2(files)]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.catFile = function(options, then) {
+      return this._catFile("utf-8", arguments);
+    };
+    Git2.prototype.binaryCatFile = function() {
+      return this._catFile("buffer", arguments);
+    };
+    Git2.prototype._catFile = function(format, args) {
+      var handler = trailingFunctionArgument2(args);
+      var command = ["cat-file"];
+      var options = args[0];
+      if (typeof options === "string") {
+        return this._runTask(
+          configurationErrorTask2("Git.catFile: options must be supplied as an array of strings"),
+          handler
+        );
+      }
+      if (Array.isArray(options)) {
+        command.push.apply(command, options);
+      }
+      const task = format === "buffer" ? straightThroughBufferTask2(command) : straightThroughStringTask2(command);
+      return this._runTask(task, handler);
+    };
+    Git2.prototype.diff = function(options, then) {
+      const task = filterString2(options) ? configurationErrorTask2(
+        "git.diff: supplying options as a single string is no longer supported, switch to an array of strings"
+      ) : straightThroughStringTask2(["diff", ...getTrailingOptions2(arguments)]);
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.diffSummary = function() {
+      return this._runTask(
+        diffSummaryTask2(getTrailingOptions2(arguments, 1)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.applyPatch = function(patches) {
+      const task = !filterStringOrStringArray2(patches) ? configurationErrorTask2(
+        `git.applyPatch requires one or more string patches as the first argument`
+      ) : applyPatchTask2(asArray2(patches), getTrailingOptions2([].slice.call(arguments, 1)));
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.revparse = function() {
+      const commands = ["rev-parse", ...getTrailingOptions2(arguments, true)];
+      return this._runTask(
+        straightThroughStringTask2(commands, true),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.clean = function(mode, options, then) {
+      const usingCleanOptionsArray = isCleanOptionsArray2(mode);
+      const cleanMode = usingCleanOptionsArray && mode.join("") || filterType2(mode, filterString2) || "";
+      const customArgs = getTrailingOptions2([].slice.call(arguments, usingCleanOptionsArray ? 1 : 0));
+      return this._runTask(
+        cleanWithOptionsTask2(cleanMode, customArgs),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.exec = function(then) {
+      const task = {
+        commands: [],
+        format: "utf-8",
+        parser() {
+          if (typeof then === "function") {
+            then();
+          }
+        }
+      };
+      return this._runTask(task);
+    };
+    Git2.prototype.clearQueue = function() {
+      return this._runTask(
+        adhocExecTask2(
+          () => console.warn(
+            "simple-git deprecation notice: clearQueue() is deprecated and will be removed, switch to using the abortPlu\
+gin instead."
+          )
+        )
+      );
+    };
+    Git2.prototype.checkIgnore = function(pathnames, then) {
+      return this._runTask(
+        checkIgnoreTask2(asArray2(filterType2(pathnames, filterStringOrStringArray2, []))),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.checkIsRepo = function(checkType, then) {
+      return this._runTask(
+        checkIsRepoTask2(filterType2(checkType, filterString2)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    module2.exports = Git2;
+  }
+});
+init_pathspec();
+init_git_error();
+init_git_error();
+init_git_error();
+var GitPluginError = class extends GitError {
+  static {
+    __name(this, "GitPluginError");
+  }
+  constructor(task, plugin, message) {
+    super(task, message);
+    this.task = task;
+    this.plugin = plugin;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+};
+init_git_response_error();
+init_task_configuration_error();
+init_check_is_repo();
+init_clean();
+init_config();
+init_diff_name_status();
+init_grep();
+init_reset();
+function isConfigSwitch(arg) {
+  return typeof arg === "string" && arg.trim().toLowerCase() === "-c";
+}
+__name(isConfigSwitch, "isConfigSwitch");
+function preventConfigBuilder(config, setting, message = String(config)) {
+  const regex = typeof config === "string" ? new RegExp(`\\s*${config}`, "i") : config;
+  return /* @__PURE__ */ __name(function preventCommand(options, arg, next) {
+    if (options[setting] !== true && isConfigSwitch(arg) && regex.test(next)) {
+      throw new GitPluginError(
+        void 0,
+        "unsafe",
+        `Configuring ${message} is not permitted without enabling ${setting}`
+      );
+    }
+  }, "preventCommand");
+}
+__name(preventConfigBuilder, "preventConfigBuilder");
+var preventUnsafeConfig = [
+  preventConfigBuilder(
+    /^\s*protocol(.[a-z]+)?.allow/i,
+    "allowUnsafeProtocolOverride",
+    "protocol.allow"
+  ),
+  preventConfigBuilder("core.sshCommand", "allowUnsafeSshCommand"),
+  preventConfigBuilder("core.gitProxy", "allowUnsafeGitProxy"),
+  preventConfigBuilder("core.hooksPath", "allowUnsafeHooksPath"),
+  preventConfigBuilder("diff.external", "allowUnsafeDiffExternal")
+];
+init_utils();
+init_utils();
+var never = (0, import_promise_deferred2.deferred)().promise;
+init_utils();
+init_git_error();
+init_utils();
+init_utils();
+init_utils();
+init_pathspec();
+init_utils();
+var Git = require_git();
+init_git_response_error();
+
 // node_modules/@actions/core/lib/command.js
 var os = __toESM(require("os"), 1);
 
@@ -20435,13 +27737,13 @@ var Command = class {
     let cmdStr = CMD_STRING + this.command;
     if (this.properties && Object.keys(this.properties).length > 0) {
       cmdStr += " ";
-      let first = true;
+      let first2 = true;
       for (const key in this.properties) {
         if (this.properties.hasOwnProperty(key)) {
           const val = this.properties[key];
           if (val) {
-            if (first) {
-              first = false;
+            if (first2) {
+              first2 = false;
             } else {
               cmdStr += ",";
             }
@@ -20613,7 +27915,7 @@ supports job summaries.`);
       }
       try {
         yield access(pathFromEnv, import_fs.constants.R_OK | import_fs.constants.W_OK);
-      } catch (_a) {
+      } catch (_a2) {
         throw new Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permi\
 ssions.`);
       }
@@ -20897,7 +28199,7 @@ var __awaiter2 = function(thisArg, _arguments, P, generator) {
 var { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs2.promises;
 var IS_WINDOWS = process.platform === "win32";
 var READONLY = fs2.constants.O_RDONLY;
-function exists(fsPath) {
+function exists2(fsPath) {
   return __awaiter2(this, void 0, void 0, function* () {
     try {
       yield stat(fsPath);
@@ -20910,7 +28212,7 @@ function exists(fsPath) {
     return true;
   });
 }
-__name(exists, "exists");
+__name(exists2, "exists");
 function isRooted(p) {
   p = normalizeSeparators(p);
   if (!p) {
@@ -21363,14 +28665,14 @@ var ToolRunner = class extends events.EventEmitter {
         state.on("debug", (message) => {
           this._debug(message);
         });
-        if (this.options.cwd && !(yield exists(this.options.cwd))) {
+        if (this.options.cwd && !(yield exists2(this.options.cwd))) {
           return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
         }
         const fileName = this._getSpawnFileName();
-        const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+        const cp2 = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
         let stdbuffer = "";
-        if (cp.stdout) {
-          cp.stdout.on("data", (data) => {
+        if (cp2.stdout) {
+          cp2.stdout.on("data", (data) => {
             if (this.options.listeners && this.options.listeners.stdout) {
               this.options.listeners.stdout(data);
             }
@@ -21385,8 +28687,8 @@ var ToolRunner = class extends events.EventEmitter {
           });
         }
         let errbuffer = "";
-        if (cp.stderr) {
-          cp.stderr.on("data", (data) => {
+        if (cp2.stderr) {
+          cp2.stderr.on("data", (data) => {
             state.processStderr = true;
             if (this.options.listeners && this.options.listeners.stderr) {
               this.options.listeners.stderr(data);
@@ -21402,44 +28704,44 @@ var ToolRunner = class extends events.EventEmitter {
             });
           });
         }
-        cp.on("error", (err) => {
+        cp2.on("error", (err) => {
           state.processError = err.message;
           state.processExited = true;
           state.processClosed = true;
           state.CheckComplete();
         });
-        cp.on("exit", (code) => {
+        cp2.on("exit", (code) => {
           state.processExitCode = code;
           state.processExited = true;
           this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
           state.CheckComplete();
         });
-        cp.on("close", (code) => {
+        cp2.on("close", (code) => {
           state.processExitCode = code;
           state.processExited = true;
           state.processClosed = true;
           this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
           state.CheckComplete();
         });
-        state.on("done", (error, exitCode) => {
+        state.on("done", (error2, exitCode) => {
           if (stdbuffer.length > 0) {
             this.emit("stdline", stdbuffer);
           }
           if (errbuffer.length > 0) {
             this.emit("errline", errbuffer);
           }
-          cp.removeAllListeners();
-          if (error) {
-            reject(error);
+          cp2.removeAllListeners();
+          if (error2) {
+            reject(error2);
           } else {
             resolve2(exitCode);
           }
         });
         if (this.options.input) {
-          if (!cp.stdin) {
+          if (!cp2.stdin) {
             throw new Error("child process missing stdin");
           }
-          cp.stdin.end(this.options.input);
+          cp2.stdin.end(this.options.input);
         }
       }));
     });
@@ -21450,26 +28752,26 @@ function argStringToArray(argString) {
   let inQuotes = false;
   let escaped = false;
   let arg = "";
-  function append(c) {
+  function append2(c) {
     if (escaped && c !== '"') {
       arg += "\\";
     }
     arg += c;
     escaped = false;
   }
-  __name(append, "append");
+  __name(append2, "append");
   for (let i = 0; i < argString.length; i++) {
     const c = argString.charAt(i);
     if (c === '"') {
       if (!escaped) {
         inQuotes = !inQuotes;
       } else {
-        append(c);
+        append2(c);
       }
       continue;
     }
     if (c === "\\" && escaped) {
-      append(c);
+      append2(c);
       continue;
     }
     if (c === "\\" && inQuotes) {
@@ -21483,7 +28785,7 @@ function argStringToArray(argString) {
       }
       continue;
     }
-    append(c);
+    append2(c);
   }
   if (arg.length > 0) {
     args.push(arg.trim());
@@ -21528,16 +28830,16 @@ var ExecState = class _ExecState extends events.EventEmitter {
     this.emit("debug", message);
   }
   _setResult() {
-    let error;
+    let error2;
     if (this.processExited) {
       if (this.processError) {
-        error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indica\
-te the process failed to start. Error: ${this.processError}`);
+        error2 = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indic\
+ate the process failed to start. Error: ${this.processError}`);
       } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-        error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+        error2 = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
       } else if (this.processStderr && this.options.failOnStdErr) {
-        error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR st\
-ream`);
+        error2 = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR s\
+tream`);
       }
     }
     if (this.timeout) {
@@ -21545,7 +28847,7 @@ ream`);
       this.timeout = null;
     }
     this.done = true;
-    this.emit("done", error, this.processExitCode);
+    this.emit("done", error2, this.processExitCode);
   }
   static HandleTimeout(state) {
     if (state.done) {
@@ -21607,13 +28909,13 @@ function exec(commandLine, args, options) {
 __name(exec, "exec");
 function getExecOutput(commandLine, args, options) {
   return __awaiter5(this, void 0, void 0, function* () {
-    var _a, _b;
+    var _a2, _b;
     let stdout = "";
     let stderr = "";
     const stdoutDecoder = new import_string_decoder.StringDecoder("utf8");
     const stderrDecoder = new import_string_decoder.StringDecoder("utf8");
-    const originalStdoutListener = (_a = options === null || options === void 0 ? void 0 : options.listeners) === null ||
-    _a === void 0 ? void 0 : _a.stdout;
+    const originalStdoutListener = (_a2 = options === null || options === void 0 ? void 0 : options.listeners) === null ||
+    _a2 === void 0 ? void 0 : _a2.stdout;
     const originalStdErrListener = (_b = options === null || options === void 0 ? void 0 : options.listeners) === null ||
     _b === void 0 ? void 0 : _b.stderr;
     const stdErrListener = /* @__PURE__ */ __name((data) => {
@@ -21666,10 +28968,19 @@ function setSecret(secret) {
   issueCommand("add-mask", {}, secret);
 }
 __name(setSecret, "setSecret");
-function debug(message) {
+function setFailed(message) {
+  process.exitCode = ExitCode.Failure;
+  error(message);
+}
+__name(setFailed, "setFailed");
+function debug2(message) {
   issueCommand("debug", {}, message);
 }
-__name(debug, "debug");
+__name(debug2, "debug");
+function error(message, properties = {}) {
+  issueCommand("error", toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+}
+__name(error, "error");
 function warning(message, properties = {}) {
   issueCommand("warning", toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
@@ -21683,9 +28994,27 @@ function getState(name) {
 }
 __name(getState, "getState");
 
+// utils/src/run.js
+var run = /* @__PURE__ */ __name(async (action) => {
+  try {
+    await action();
+  } catch (err) {
+    setFailed(err.message);
+  }
+}, "run");
+var run_default = run;
+
+// node_modules/@actions/tool-cache/lib/manifest.js
+var semver = __toESM(require_semver2(), 1);
+
+// node_modules/@actions/tool-cache/lib/tool-cache.js
+var semver2 = __toESM(require_semver2(), 1);
+var IS_WINDOWS3 = process.platform === "win32";
+var IS_MAC = process.platform === "darwin";
+
 // setup-gcloud/src/auth-stack.js
 var import_node_fs = __toESM(require("node:fs"), 1);
-var import_node_path = __toESM(require("node:path"), 1);
+var import_node_path2 = __toESM(require("node:path"), 1);
 
 // setup-gcloud/src/job-scope.js
 function getJobScope({ prefix = "setup-gcloud" } = {}) {
@@ -21702,7 +29031,7 @@ __name(getJobScope, "getJobScope");
 // setup-gcloud/src/auth-stack.js
 function authStackFilePath() {
   const jobScope = getJobScope();
-  return import_node_path.default.join(jobScope, "auth_stack.json");
+  return import_node_path2.default.join(jobScope, "auth_stack.json");
 }
 __name(authStackFilePath, "authStackFilePath");
 function loadAuthStack() {
@@ -21770,13 +29099,13 @@ var getAccessToken = /* @__PURE__ */ __name(async () => {
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
-      debug(`Export ${key}`);
+      debug2(`Export ${key}`);
       exportVariable(key, value);
     }
     process.env[key] = value;
   } else {
     if (exportVariable2) {
-      debug(`Unset ${key}`);
+      debug2(`Unset ${key}`);
       exportVariable(key, "");
     }
     delete process.env[key];
@@ -21825,7 +29154,7 @@ function deleteCredentialFiles(credentialFiles) {
     try {
       if (import_node_fs2.default.existsSync(filePath)) {
         import_node_fs2.default.rmSync(filePath);
-        debug(`Deleted credential file: ${filePath}`);
+        debug2(`Deleted credential file: ${filePath}`);
       }
     } catch (err) {
       warning(
@@ -21840,7 +29169,7 @@ function deleteJobScopedDirectory() {
     const jobScopedDir = getJobScope();
     if (import_node_fs2.default.existsSync(jobScopedDir)) {
       import_node_fs2.default.rmSync(jobScopedDir, { recursive: true });
-      debug(`Deleted job-scoped credential directory: ${jobScopedDir}`);
+      debug2(`Deleted job-scoped credential directory: ${jobScopedDir}`);
     }
   } catch (err) {
     warning(`Failed to delete job-scoped directory: ${err.message}`);
@@ -21852,7 +29181,7 @@ function deleteGcloudConfigDirectory() {
     const cloudSdkConfigPath = process.env.CLOUDSDK_CONFIG;
     if (cloudSdkConfigPath && import_node_fs2.default.existsSync(cloudSdkConfigPath)) {
       import_node_fs2.default.rmSync(cloudSdkConfigPath, { recursive: true });
-      debug(`Deleted CLOUDSDK_CONFIG directory: ${cloudSdkConfigPath}`);
+      debug2(`Deleted CLOUDSDK_CONFIG directory: ${cloudSdkConfigPath}`);
     }
   } catch (err) {
     warning(`Failed to delete CLOUDSDK_CONFIG directory: ${err.message}`);
@@ -21881,7 +29210,7 @@ var postAction = /* @__PURE__ */ __name(async () => {
   cleanupCredentials(credentialFiles);
   await resetAuthStack();
 }, "postAction");
-postAction();
+run_default(postAction);
 /*! Bundled license information:
 
 undici/lib/web/fetch/body.js:

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -33,7 +33,7 @@ var require_tunnel = __commonJS({
     var tls = require("tls");
     var http = require("http");
     var https = require("https");
-    var events = require("events");
+    var events2 = require("events");
     var assert = require("assert");
     var util = require("util");
     exports2.httpOverHttp = httpOverHttp2;
@@ -90,7 +90,7 @@ var require_tunnel = __commonJS({
       }, "onFree"));
     }
     __name(TunnelingAgent, "TunnelingAgent");
-    util.inherits(TunnelingAgent, events.EventEmitter);
+    util.inherits(TunnelingAgent, events2.EventEmitter);
     TunnelingAgent.prototype.addRequest = /* @__PURE__ */ __name(function addRequest(req, host, port, localAddress) {
       var self = this;
       var options = mergeOptions({ request: req }, self.options, toOptions(host, port, localAddress));
@@ -1171,14 +1171,14 @@ eger.");
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path5 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path && path[0] !== "/") {
-          path = `/${path}`;
+        if (path5 && path5[0] !== "/") {
+          path5 = `/${path5}`;
         }
-        return new URL(`${origin}${path}`);
+        return new URL(`${origin}${path5}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1669,39 +1669,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path, origin }
+          request: { method, path: path5, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path);
+        debuglog("sending request to %s %s/%s", method, origin, path5);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path, origin },
+          request: { method, path: path5, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path,
+          path5,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path, origin }
+          request: { method, path: path5, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path);
+        debuglog("trailers received from %s %s/%s", method, origin, path5);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path, origin },
+          request: { method, path: path5, origin },
           error
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path,
+          path5,
           error.message
         );
       });
@@ -1750,9 +1750,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path, origin }
+            request: { method, path: path5, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path);
+          debuglog("sending request to %s %s/%s", method, origin, path5);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1818,7 +1818,7 @@ var require_request = __commonJS({
         __name(this, "Request");
       }
       constructor(origin, {
-        path,
+        path: path5,
         method,
         body,
         headers,
@@ -1833,12 +1833,12 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path !== "string") {
+        if (typeof path5 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path[0] !== "/" && !(path.startsWith("http://") || path.startsWith("https://")) && method !== "CONNEC\
-T") {
+        } else if (path5[0] !== "/" && !(path5.startsWith("http://") || path5.startsWith("https://")) && method !== "CON\
+NECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path)) {
+        } else if (invalidPathRegex.test(path5)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -1905,7 +1905,7 @@ terable");
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path, query) : path;
+        this.path = query ? buildURL(path5, query) : path5;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -2129,8 +2129,8 @@ terable");
 var require_dispatcher = __commonJS({
   "node_modules/undici/lib/dispatcher/dispatcher.js"(exports2, module2) {
     "use strict";
-    var EventEmitter = require("node:events");
-    var Dispatcher = class extends EventEmitter {
+    var EventEmitter2 = require("node:events");
+    var Dispatcher = class extends EventEmitter2 {
       static {
         __name(this, "Dispatcher");
       }
@@ -2233,9 +2233,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback) {
         if (callback === void 0) {
-          return new Promise((resolve, reject) => {
+          return new Promise((resolve2, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve(data);
+              return err ? reject(err) : resolve2(data);
             });
           });
         }
@@ -2273,12 +2273,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback === void 0) {
-          return new Promise((resolve, reject) => {
+          return new Promise((resolve2, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve(data);
+              ) : resolve2(data);
             });
           });
         }
@@ -5283,11 +5283,11 @@ var require_util2 = __commonJS({
     var { isUint8Array } = require("node:util/types");
     var { webidl } = require_webidl();
     var supportedHashes = [];
-    var crypto;
+    var crypto2;
     try {
-      crypto = require("node:crypto");
+      crypto2 = require("node:crypto");
       const possibleRelevantHashes = ["sha256", "sha384", "sha512"];
-      supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash));
+      supportedHashes = crypto2.getHashes().filter((hash) => possibleRelevantHashes.includes(hash));
     } catch {
     }
     function responseURL(response) {
@@ -5590,7 +5590,7 @@ ption");
     }
     __name(isURLPotentiallyTrustworthy, "isURLPotentiallyTrustworthy");
     function bytesMatch(bytes, metadataList) {
-      if (crypto === void 0) {
+      if (crypto2 === void 0) {
         return true;
       }
       const parsedMetadata = parseMetadata(metadataList);
@@ -5605,7 +5605,7 @@ ption");
       for (const item of metadata) {
         const algorithm = item.algo;
         const expectedValue = item.hash;
-        let actualValue = crypto.createHash(algorithm).update(bytes).digest("base64");
+        let actualValue = crypto2.createHash(algorithm).update(bytes).digest("base64");
         if (actualValue[actualValue.length - 1] === "=") {
           if (actualValue[actualValue.length - 2] === "=") {
             actualValue = actualValue.slice(0, -2);
@@ -5705,8 +5705,8 @@ ption");
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise = new Promise((resolve, reject) => {
-        res = resolve;
+      const promise = new Promise((resolve2, reject) => {
+        res = resolve2;
         rej = reject;
       });
       return { promise, resolve: res, reject: rej };
@@ -6734,8 +6734,8 @@ var require_body = __commonJS({
     var { multipartFormDataParser } = require_formdata_parser();
     var random;
     try {
-      const crypto = require("node:crypto");
-      random = /* @__PURE__ */ __name((max) => crypto.randomInt(0, max), "random");
+      const crypto2 = require("node:crypto");
+      random = /* @__PURE__ */ __name((max) => crypto2.randomInt(0, max), "random");
     } catch {
       random = /* @__PURE__ */ __name((max) => Math.floor(Math.random(max)), "random");
     }
@@ -7676,7 +7676,7 @@ var require_client_h1 = __commonJS({
     }
     __name(shouldSendContentLength, "shouldSendContentLength");
     function writeH1(client, request) {
-      const { method, path, host, upgrade, blocking, reset } = request;
+      const { method, path: path5, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method ===
       "PROPFIND" || method === "PROPPATCH";
@@ -7744,7 +7744,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path} HTTP/1.1\r
+      let header = `${method} ${path5} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -7936,12 +7936,12 @@ upgrade: ${upgrade}\r
         }
       }
       __name(onDrain, "onDrain");
-      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve, reject) => {
+      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve2, reject) => {
         assert(callback === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback = resolve;
+          callback = resolve2;
         }
       }), "waitForDrain");
       socket.on("close", onDrain).on("drain", onDrain);
@@ -8288,7 +8288,7 @@ var require_client_h2 = __commonJS({
     __name(shouldSendContentLength, "shouldSendContentLength");
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path5, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -8355,7 +8355,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path;
+      headers[HTTP2_HEADER_PATH] = path5;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -8599,12 +8599,12 @@ var require_client_h2 = __commonJS({
         }
       }
       __name(onDrain, "onDrain");
-      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve, reject) => {
+      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve2, reject) => {
         assert(callback === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback = resolve;
+          callback = resolve2;
         }
       }), "waitForDrain");
       h2stream.on("close", onDrain).on("drain", onDrain);
@@ -8726,9 +8726,9 @@ var require_redirect_handler = __commonJS({
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.
         path, this.opts.origin)));
-        const path = search ? `${pathname}${search}` : pathname;
+        const path5 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path;
+        this.opts.path = path5;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -9100,16 +9100,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve) => {
+        return new Promise((resolve2) => {
           if (this[kSize]) {
-            this[kClosedResolve] = resolve;
+            this[kClosedResolve] = resolve2;
           } else {
-            resolve(null);
+            resolve2(null);
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve) => {
+        return new Promise((resolve2) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i = 0; i < requests.length; i++) {
             const request = requests[i];
@@ -9120,7 +9120,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve(null);
+            resolve2(null);
           }, "callback");
           if (this[kHTTPContext]) {
             this[kHTTPContext].destroy(err, callback);
@@ -9172,7 +9172,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve, reject) => {
+        const socket = await new Promise((resolve2, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -9184,7 +9184,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve(socket2);
+              resolve2(socket2);
             }
           });
         });
@@ -9537,8 +9537,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           await Promise.all(this[kClients].map((c) => c.close()));
         } else {
-          await new Promise((resolve) => {
-            this[kClosedResolve] = resolve;
+          await new Promise((resolve2) => {
+            this[kClosedResolve] = resolve2;
           });
         }
       }
@@ -10018,10 +10018,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path = "/",
+          path: path5 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path;
+        opts.path = origin + path5;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10806,7 +10806,7 @@ var require_readable = __commonJS({
         if (this._readableState.closeEmitted) {
           return null;
         }
-        return await new Promise((resolve, reject) => {
+        return await new Promise((resolve2, reject) => {
           if (this[kContentLength] > limit) {
             this.destroy(new AbortError());
           }
@@ -10819,7 +10819,7 @@ var require_readable = __commonJS({
             if (signal?.aborted) {
               reject(signal.reason ?? new AbortError());
             } else {
-              resolve(null);
+              resolve2(null);
             }
           }).on("error", noop).on("data", function(chunk) {
             limit -= chunk.length;
@@ -10840,7 +10840,7 @@ var require_readable = __commonJS({
     __name(isUnusable, "isUnusable");
     async function consume(stream, type) {
       assert(!stream[kConsume]);
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve2, reject) => {
         if (isUnusable(stream)) {
           const rState = stream._readableState;
           if (rState.destroyed && rState.closeEmitted === false) {
@@ -10857,7 +10857,7 @@ var require_readable = __commonJS({
             stream[kConsume] = {
               type,
               stream,
-              resolve,
+              resolve: resolve2,
               reject,
               length: 0,
               body: []
@@ -10931,18 +10931,18 @@ var require_readable = __commonJS({
     }
     __name(chunksConcat, "chunksConcat");
     function consumeEnd(consume2) {
-      const { type, body, resolve, stream, length } = consume2;
+      const { type, body, resolve: resolve2, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve(chunksDecode(body, length));
+          resolve2(chunksDecode(body, length));
         } else if (type === "json") {
-          resolve(JSON.parse(chunksDecode(body, length)));
+          resolve2(JSON.parse(chunksDecode(body, length)));
         } else if (type === "arrayBuffer") {
-          resolve(chunksConcat(body, length).buffer);
+          resolve2(chunksConcat(body, length).buffer);
         } else if (type === "blob") {
-          resolve(new Blob(body, { type: stream[kContentType] }));
+          resolve2(new Blob(body, { type: stream[kContentType] }));
         } else if (type === "bytes") {
-          resolve(chunksConcat(body, length));
+          resolve2(chunksConcat(body, length));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -11210,9 +11210,9 @@ var require_api_request = __commonJS({
     };
     function request(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           request.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -11442,9 +11442,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -11743,9 +11743,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -11841,9 +11841,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -12017,21 +12017,21 @@ var require_mock_utils = __commonJS({
       return true;
     }
     __name(matchHeaders, "matchHeaders");
-    function safeUrl(path) {
-      if (typeof path !== "string") {
-        return path;
+    function safeUrl(path5) {
+      if (typeof path5 !== "string") {
+        return path5;
       }
-      const pathSegments = path.split("?");
+      const pathSegments = path5.split("?");
       if (pathSegments.length !== 2) {
-        return path;
+        return path5;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
     __name(safeUrl, "safeUrl");
-    function matchKey(mockDispatch2, { path, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path);
+    function matchKey(mockDispatch2, { path: path5, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path5);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -12055,8 +12055,8 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path }) => matchValue(safeUrl(
-      path), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path5 }) => matchValue(
+      safeUrl(path5), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -12098,9 +12098,9 @@ var require_mock_utils = __commonJS({
     }
     __name(deleteMockDispatch, "deleteMockDispatch");
     function buildKey(opts) {
-      const { path, method, body, headers, query } = opts;
+      const { path: path5, method, body, headers, query } = opts;
       return {
-        path,
+        path: path5,
         method,
         body,
         headers,
@@ -12593,10 +12593,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path5, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path,
+            Path: path5,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -13389,10 +13389,10 @@ var require_headers = __commonJS({
         const lowercaseName = isLowerCase ? name : name.toLowerCase();
         const exists2 = this[kHeadersMap].get(lowercaseName);
         if (exists2) {
-          const delimiter = lowercaseName === "cookie" ? "; " : ", ";
+          const delimiter2 = lowercaseName === "cookie" ? "; " : ", ";
           this[kHeadersMap].set(lowercaseName, {
             name: exists2.name,
-            value: `${exists2.value}${delimiter}${value}`
+            value: `${exists2.value}${delimiter2}${value}`
           });
         } else {
           this[kHeadersMap].set(lowercaseName, { name, value });
@@ -15840,7 +15840,7 @@ processBodyError");
       function dispatch({ body }) {
         const url = requestCurrentURL(request);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve, reject) => agent.dispatch(
+        return new Promise((resolve2, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -15917,7 +15917,7 @@ processBodyError");
                 }
               }
               const onError = this.onError.bind(this);
-              resolve({
+              resolve2({
                 status,
                 statusText,
                 headersList,
@@ -15963,7 +15963,7 @@ processBodyError");
               for (let i = 0; i < rawHeaders.length; i += 2) {
                 headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i]), rawHeaders[i + 1].toString("latin1"), true);
               }
-              resolve({
+              resolve2({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList,
@@ -16374,7 +16374,7 @@ var require_util4 = __commonJS({
     var { getEncoding } = require_encoding();
     var { serializeAMimeType, parseMIMEType } = require_data_url();
     var { types } = require("node:util");
-    var { StringDecoder } = require("string_decoder");
+    var { StringDecoder: StringDecoder2 } = require("string_decoder");
     var { btoa } = require("node:buffer");
     var staticPropertyDescriptors = {
       enumerable: true,
@@ -16467,7 +16467,7 @@ var require_util4 = __commonJS({
             dataURL += serializeAMimeType(parsed);
           }
           dataURL += ";base64,";
-          const decoder = new StringDecoder("latin1");
+          const decoder = new StringDecoder2("latin1");
           for (const chunk of bytes) {
             dataURL += btoa(decoder.write(chunk));
           }
@@ -16496,7 +16496,7 @@ var require_util4 = __commonJS({
         }
         case "BinaryString": {
           let binaryString = "";
-          const decoder = new StringDecoder("latin1");
+          const decoder = new StringDecoder2("latin1");
           for (const chunk of bytes) {
             binaryString += decoder.write(chunk);
           }
@@ -17592,9 +17592,9 @@ var require_util6 = __commonJS({
       }
     }
     __name(validateCookieValue, "validateCookieValue");
-    function validateCookiePath(path) {
-      for (let i = 0; i < path.length; ++i) {
-        const code = path.charCodeAt(i);
+    function validateCookiePath(path5) {
+      for (let i = 0; i < path5.length; ++i) {
+        const code = path5.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18527,13 +18527,13 @@ var require_frame = __commonJS({
     "use strict";
     var { maxUnsigned16Bit } = require_constants5();
     var BUFFER_SIZE = 16386;
-    var crypto;
+    var crypto2;
     var buffer = null;
     var bufIdx = BUFFER_SIZE;
     try {
-      crypto = require("node:crypto");
+      crypto2 = require("node:crypto");
     } catch {
-      crypto = {
+      crypto2 = {
         // not full compatibility, but minimum.
         randomFillSync: /* @__PURE__ */ __name(function randomFillSync(buffer2, _offset, _size) {
           for (let i = 0; i < buffer2.length; ++i) {
@@ -18546,7 +18546,7 @@ var require_frame = __commonJS({
     function generateMask() {
       if (bufIdx === BUFFER_SIZE) {
         bufIdx = 0;
-        crypto.randomFillSync(buffer ??= Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE);
+        crypto2.randomFillSync(buffer ??= Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE);
       }
       return [buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++]];
     }
@@ -18622,9 +18622,9 @@ var require_connection = __commonJS({
     var { Headers: Headers2, getHeadersList } = require_headers();
     var { getDecodeSplit } = require_util2();
     var { WebsocketFrameSend } = require_frame();
-    var crypto;
+    var crypto2;
     try {
-      crypto = require("node:crypto");
+      crypto2 = require("node:crypto");
     } catch {
     }
     function establishWebSocketConnection(url, protocols, client, ws, onEstablish, options) {
@@ -18644,7 +18644,7 @@ var require_connection = __commonJS({
         const headersList = getHeadersList(new Headers2(options.headers));
         request.headersList = headersList;
       }
-      const keyValue = crypto.randomBytes(16).toString("base64");
+      const keyValue = crypto2.randomBytes(16).toString("base64");
       request.headersList.append("sec-websocket-key", keyValue);
       request.headersList.append("sec-websocket-version", "13");
       for (const protocol of protocols) {
@@ -18674,7 +18674,7 @@ var require_connection = __commonJS({
             return;
           }
           const secWSAccept = response.headersList.get("Sec-WebSocket-Accept");
-          const digest = crypto.createHash("sha1").update(keyValue + uid).digest("base64");
+          const digest = crypto2.createHash("sha1").update(keyValue + uid).digest("base64");
           if (secWSAccept !== digest) {
             failWebsocketConnection(ws, "Incorrect hash received in Sec-WebSocket-Accept header.");
             return;
@@ -19695,8 +19695,8 @@ var require_util8 = __commonJS({
     }
     __name(isASCIINumber, "isASCIINumber");
     function delay(ms) {
-      return new Promise((resolve) => {
-        setTimeout(resolve, ms).unref();
+      return new Promise((resolve2) => {
+        setTimeout(resolve2, ms).unref();
       });
     }
     __name(delay, "delay");
@@ -20308,11 +20308,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path = opts.path;
+          let path5 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path = `/${path}`;
+            path5 = `/${path5}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path);
+          url = new URL(util.parseOrigin(url).origin + path5);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -20383,9 +20383,6 @@ var require_undici = __commonJS({
     module2.exports.EventSource = EventSource;
   }
 });
-
-// setup-gcloud/src/cleanup.js
-var import_node_fs = __toESM(require("node:fs"), 1);
 
 // node_modules/@actions/core/lib/command.js
 var os = __toESM(require("os"), 1);
@@ -20467,8 +20464,38 @@ function escapeProperty(s) {
 }
 __name(escapeProperty, "escapeProperty");
 
+// node_modules/@actions/core/lib/file-command.js
+var crypto = __toESM(require("crypto"), 1);
+var fs = __toESM(require("fs"), 1);
+var os2 = __toESM(require("os"), 1);
+function issueFileCommand(command, message) {
+  const filePath = process.env[`GITHUB_${command}`];
+  if (!filePath) {
+    throw new Error(`Unable to find environment variable for file command ${command}`);
+  }
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing file at path: ${filePath}`);
+  }
+  fs.appendFileSync(filePath, `${toCommandValue(message)}${os2.EOL}`, {
+    encoding: "utf8"
+  });
+}
+__name(issueFileCommand, "issueFileCommand");
+function prepareKeyValueMessage(key, value) {
+  const delimiter2 = `ghadelimiter_${crypto.randomUUID()}`;
+  const convertedValue = toCommandValue(value);
+  if (key.includes(delimiter2)) {
+    throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter2}"`);
+  }
+  if (convertedValue.includes(delimiter2)) {
+    throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter2}"`);
+  }
+  return `${key}<<${delimiter2}${os2.EOL}${convertedValue}${os2.EOL}${delimiter2}`;
+}
+__name(prepareKeyValueMessage, "prepareKeyValueMessage");
+
 // node_modules/@actions/core/lib/core.js
-var os3 = __toESM(require("os"), 1);
+var os5 = __toESM(require("os"), 1);
 
 // node_modules/@actions/http-client/lib/index.js
 var tunnel = __toESM(require_tunnel2(), 1);
@@ -20530,12 +20557,12 @@ var import_os = require("os");
 var import_fs = require("fs");
 var __awaiter = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve) {
-      resolve(value);
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
     });
   }
   __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve, reject) {
+  return new (P || (P = Promise))(function(resolve2, reject) {
     function fulfilled(value) {
       try {
         step(generator.next(value));
@@ -20553,7 +20580,7 @@ var __awaiter = function(thisArg, _arguments, P, generator) {
     }
     __name(rejected, "rejected");
     function step(result) {
-      result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
     }
     __name(step, "step");
     step((generator = generator.apply(thisArg, _arguments || [])).next());
@@ -20821,14 +20848,799 @@ var _summary = new Summary();
 // node_modules/@actions/core/lib/platform.js
 var import_os2 = __toESM(require("os"), 1);
 
-// node_modules/@actions/io/lib/io-util.js
-var fs = __toESM(require("fs"), 1);
-var { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises;
-var IS_WINDOWS = process.platform === "win32";
-var READONLY = fs.constants.O_RDONLY;
+// node_modules/@actions/exec/lib/exec.js
+var import_string_decoder = require("string_decoder");
 
 // node_modules/@actions/exec/lib/toolrunner.js
+var os3 = __toESM(require("os"), 1);
+var events = __toESM(require("events"), 1);
+var child = __toESM(require("child_process"), 1);
+var path3 = __toESM(require("path"), 1);
+
+// node_modules/@actions/io/lib/io.js
+var path2 = __toESM(require("path"), 1);
+
+// node_modules/@actions/io/lib/io-util.js
+var fs2 = __toESM(require("fs"), 1);
+var path = __toESM(require("path"), 1);
+var __awaiter2 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+var { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs2.promises;
+var IS_WINDOWS = process.platform === "win32";
+var READONLY = fs2.constants.O_RDONLY;
+function exists(fsPath) {
+  return __awaiter2(this, void 0, void 0, function* () {
+    try {
+      yield stat(fsPath);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        return false;
+      }
+      throw err;
+    }
+    return true;
+  });
+}
+__name(exists, "exists");
+function isRooted(p) {
+  p = normalizeSeparators(p);
+  if (!p) {
+    throw new Error('isRooted() parameter "p" cannot be empty');
+  }
+  if (IS_WINDOWS) {
+    return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+  }
+  return p.startsWith("/");
+}
+__name(isRooted, "isRooted");
+function tryGetExecutablePath(filePath, extensions) {
+  return __awaiter2(this, void 0, void 0, function* () {
+    let stats = void 0;
+    try {
+      stats = yield stat(filePath);
+    } catch (err) {
+      if (err.code !== "ENOENT") {
+        console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+      }
+    }
+    if (stats && stats.isFile()) {
+      if (IS_WINDOWS) {
+        const upperExt = path.extname(filePath).toUpperCase();
+        if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+          return filePath;
+        }
+      } else {
+        if (isUnixExecutable(stats)) {
+          return filePath;
+        }
+      }
+    }
+    const originalFilePath = filePath;
+    for (const extension of extensions) {
+      filePath = originalFilePath + extension;
+      stats = void 0;
+      try {
+        stats = yield stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+        }
+      }
+      if (stats && stats.isFile()) {
+        if (IS_WINDOWS) {
+          try {
+            const directory = path.dirname(filePath);
+            const upperName = path.basename(filePath).toUpperCase();
+            for (const actualName of yield readdir(directory)) {
+              if (upperName === actualName.toUpperCase()) {
+                filePath = path.join(directory, actualName);
+                break;
+              }
+            }
+          } catch (err) {
+            console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+          }
+          return filePath;
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+    }
+    return "";
+  });
+}
+__name(tryGetExecutablePath, "tryGetExecutablePath");
+function normalizeSeparators(p) {
+  p = p || "";
+  if (IS_WINDOWS) {
+    p = p.replace(/\//g, "\\");
+    return p.replace(/\\\\+/g, "\\");
+  }
+  return p.replace(/\/\/+/g, "/");
+}
+__name(normalizeSeparators, "normalizeSeparators");
+function isUnixExecutable(stats) {
+  return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.
+  mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+__name(isUnixExecutable, "isUnixExecutable");
+
+// node_modules/@actions/io/lib/io.js
+var __awaiter3 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+function which(tool, check) {
+  return __awaiter3(this, void 0, void 0, function* () {
+    if (!tool) {
+      throw new Error("parameter 'tool' is required");
+    }
+    if (check) {
+      const result = yield which(tool, false);
+      if (!result) {
+        if (IS_WINDOWS) {
+          throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the f\
+ile can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extensi\
+on for an executable file.`);
+        } else {
+          throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the f\
+ile can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the f\
+ile is executable.`);
+        }
+      }
+      return result;
+    }
+    const matches = yield findInPath(tool);
+    if (matches && matches.length > 0) {
+      return matches[0];
+    }
+    return "";
+  });
+}
+__name(which, "which");
+function findInPath(tool) {
+  return __awaiter3(this, void 0, void 0, function* () {
+    if (!tool) {
+      throw new Error("parameter 'tool' is required");
+    }
+    const extensions = [];
+    if (IS_WINDOWS && process.env["PATHEXT"]) {
+      for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+        if (extension) {
+          extensions.push(extension);
+        }
+      }
+    }
+    if (isRooted(tool)) {
+      const filePath = yield tryGetExecutablePath(tool, extensions);
+      if (filePath) {
+        return [filePath];
+      }
+      return [];
+    }
+    if (tool.includes(path2.sep)) {
+      return [];
+    }
+    const directories = [];
+    if (process.env.PATH) {
+      for (const p of process.env.PATH.split(path2.delimiter)) {
+        if (p) {
+          directories.push(p);
+        }
+      }
+    }
+    const matches = [];
+    for (const directory of directories) {
+      const filePath = yield tryGetExecutablePath(path2.join(directory, tool), extensions);
+      if (filePath) {
+        matches.push(filePath);
+      }
+    }
+    return matches;
+  });
+}
+__name(findInPath, "findInPath");
+
+// node_modules/@actions/exec/lib/toolrunner.js
+var import_timers = require("timers");
+var __awaiter4 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
 var IS_WINDOWS2 = process.platform === "win32";
+var ToolRunner = class extends events.EventEmitter {
+  static {
+    __name(this, "ToolRunner");
+  }
+  constructor(toolPath, args, options) {
+    super();
+    if (!toolPath) {
+      throw new Error("Parameter 'toolPath' cannot be null or empty.");
+    }
+    this.toolPath = toolPath;
+    this.args = args || [];
+    this.options = options || {};
+  }
+  _debug(message) {
+    if (this.options.listeners && this.options.listeners.debug) {
+      this.options.listeners.debug(message);
+    }
+  }
+  _getCommandString(options, noPrefix) {
+    const toolPath = this._getSpawnFileName();
+    const args = this._getSpawnArgs(options);
+    let cmd = noPrefix ? "" : "[command]";
+    if (IS_WINDOWS2) {
+      if (this._isCmdFile()) {
+        cmd += toolPath;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      } else if (options.windowsVerbatimArguments) {
+        cmd += `"${toolPath}"`;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      } else {
+        cmd += this._windowsQuoteCmdArg(toolPath);
+        for (const a of args) {
+          cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+        }
+      }
+    } else {
+      cmd += toolPath;
+      for (const a of args) {
+        cmd += ` ${a}`;
+      }
+    }
+    return cmd;
+  }
+  _processLineBuffer(data, strBuffer, onLine) {
+    try {
+      let s = strBuffer + data.toString();
+      let n = s.indexOf(os3.EOL);
+      while (n > -1) {
+        const line = s.substring(0, n);
+        onLine(line);
+        s = s.substring(n + os3.EOL.length);
+        n = s.indexOf(os3.EOL);
+      }
+      return s;
+    } catch (err) {
+      this._debug(`error processing line. Failed with error ${err}`);
+      return "";
+    }
+  }
+  _getSpawnFileName() {
+    if (IS_WINDOWS2) {
+      if (this._isCmdFile()) {
+        return process.env["COMSPEC"] || "cmd.exe";
+      }
+    }
+    return this.toolPath;
+  }
+  _getSpawnArgs(options) {
+    if (IS_WINDOWS2) {
+      if (this._isCmdFile()) {
+        let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+        for (const a of this.args) {
+          argline += " ";
+          argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+        }
+        argline += '"';
+        return [argline];
+      }
+    }
+    return this.args;
+  }
+  _endsWith(str, end) {
+    return str.endsWith(end);
+  }
+  _isCmdFile() {
+    const upperToolPath = this.toolPath.toUpperCase();
+    return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
+  }
+  _windowsQuoteCmdArg(arg) {
+    if (!this._isCmdFile()) {
+      return this._uvQuoteCmdArg(arg);
+    }
+    if (!arg) {
+      return '""';
+    }
+    const cmdSpecialChars = [
+      " ",
+      "	",
+      "&",
+      "(",
+      ")",
+      "[",
+      "]",
+      "{",
+      "}",
+      "^",
+      "=",
+      ";",
+      "!",
+      "'",
+      "+",
+      ",",
+      "`",
+      "~",
+      "|",
+      "<",
+      ">",
+      '"'
+    ];
+    let needsQuotes = false;
+    for (const char of arg) {
+      if (cmdSpecialChars.some((x) => x === char)) {
+        needsQuotes = true;
+        break;
+      }
+    }
+    if (!needsQuotes) {
+      return arg;
+    }
+    let reverse = '"';
+    let quoteHit = true;
+    for (let i = arg.length; i > 0; i--) {
+      reverse += arg[i - 1];
+      if (quoteHit && arg[i - 1] === "\\") {
+        reverse += "\\";
+      } else if (arg[i - 1] === '"') {
+        quoteHit = true;
+        reverse += '"';
+      } else {
+        quoteHit = false;
+      }
+    }
+    reverse += '"';
+    return reverse.split("").reverse().join("");
+  }
+  _uvQuoteCmdArg(arg) {
+    if (!arg) {
+      return '""';
+    }
+    if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+      return arg;
+    }
+    if (!arg.includes('"') && !arg.includes("\\")) {
+      return `"${arg}"`;
+    }
+    let reverse = '"';
+    let quoteHit = true;
+    for (let i = arg.length; i > 0; i--) {
+      reverse += arg[i - 1];
+      if (quoteHit && arg[i - 1] === "\\") {
+        reverse += "\\";
+      } else if (arg[i - 1] === '"') {
+        quoteHit = true;
+        reverse += "\\";
+      } else {
+        quoteHit = false;
+      }
+    }
+    reverse += '"';
+    return reverse.split("").reverse().join("");
+  }
+  _cloneExecOptions(options) {
+    options = options || {};
+    const result = {
+      cwd: options.cwd || process.cwd(),
+      env: options.env || process.env,
+      silent: options.silent || false,
+      windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+      failOnStdErr: options.failOnStdErr || false,
+      ignoreReturnCode: options.ignoreReturnCode || false,
+      delay: options.delay || 1e4
+    };
+    result.outStream = options.outStream || process.stdout;
+    result.errStream = options.errStream || process.stderr;
+    return result;
+  }
+  _getSpawnOptions(options, toolPath) {
+    options = options || {};
+    const result = {};
+    result.cwd = options.cwd;
+    result.env = options.env;
+    result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+    if (options.windowsVerbatimArguments) {
+      result.argv0 = `"${toolPath}"`;
+    }
+    return result;
+  }
+  /**
+   * Exec a tool.
+   * Output will be streamed to the live console.
+   * Returns promise with return code
+   *
+   * @param     tool     path to tool to exec
+   * @param     options  optional exec options.  See ExecOptions
+   * @returns   number
+   */
+  exec() {
+    return __awaiter4(this, void 0, void 0, function* () {
+      if (!isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS2 && this.toolPath.includes("\\"))) {
+        this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+      }
+      this.toolPath = yield which(this.toolPath, true);
+      return new Promise((resolve2, reject) => __awaiter4(this, void 0, void 0, function* () {
+        this._debug(`exec tool: ${this.toolPath}`);
+        this._debug("arguments:");
+        for (const arg of this.args) {
+          this._debug(`   ${arg}`);
+        }
+        const optionsNonNull = this._cloneExecOptions(this.options);
+        if (!optionsNonNull.silent && optionsNonNull.outStream) {
+          optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os3.EOL);
+        }
+        const state = new ExecState(optionsNonNull, this.toolPath);
+        state.on("debug", (message) => {
+          this._debug(message);
+        });
+        if (this.options.cwd && !(yield exists(this.options.cwd))) {
+          return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
+        }
+        const fileName = this._getSpawnFileName();
+        const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+        let stdbuffer = "";
+        if (cp.stdout) {
+          cp.stdout.on("data", (data) => {
+            if (this.options.listeners && this.options.listeners.stdout) {
+              this.options.listeners.stdout(data);
+            }
+            if (!optionsNonNull.silent && optionsNonNull.outStream) {
+              optionsNonNull.outStream.write(data);
+            }
+            stdbuffer = this._processLineBuffer(data, stdbuffer, (line) => {
+              if (this.options.listeners && this.options.listeners.stdline) {
+                this.options.listeners.stdline(line);
+              }
+            });
+          });
+        }
+        let errbuffer = "";
+        if (cp.stderr) {
+          cp.stderr.on("data", (data) => {
+            state.processStderr = true;
+            if (this.options.listeners && this.options.listeners.stderr) {
+              this.options.listeners.stderr(data);
+            }
+            if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+              const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+              s.write(data);
+            }
+            errbuffer = this._processLineBuffer(data, errbuffer, (line) => {
+              if (this.options.listeners && this.options.listeners.errline) {
+                this.options.listeners.errline(line);
+              }
+            });
+          });
+        }
+        cp.on("error", (err) => {
+          state.processError = err.message;
+          state.processExited = true;
+          state.processClosed = true;
+          state.CheckComplete();
+        });
+        cp.on("exit", (code) => {
+          state.processExitCode = code;
+          state.processExited = true;
+          this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+          state.CheckComplete();
+        });
+        cp.on("close", (code) => {
+          state.processExitCode = code;
+          state.processExited = true;
+          state.processClosed = true;
+          this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+          state.CheckComplete();
+        });
+        state.on("done", (error, exitCode) => {
+          if (stdbuffer.length > 0) {
+            this.emit("stdline", stdbuffer);
+          }
+          if (errbuffer.length > 0) {
+            this.emit("errline", errbuffer);
+          }
+          cp.removeAllListeners();
+          if (error) {
+            reject(error);
+          } else {
+            resolve2(exitCode);
+          }
+        });
+        if (this.options.input) {
+          if (!cp.stdin) {
+            throw new Error("child process missing stdin");
+          }
+          cp.stdin.end(this.options.input);
+        }
+      }));
+    });
+  }
+};
+function argStringToArray(argString) {
+  const args = [];
+  let inQuotes = false;
+  let escaped = false;
+  let arg = "";
+  function append(c) {
+    if (escaped && c !== '"') {
+      arg += "\\";
+    }
+    arg += c;
+    escaped = false;
+  }
+  __name(append, "append");
+  for (let i = 0; i < argString.length; i++) {
+    const c = argString.charAt(i);
+    if (c === '"') {
+      if (!escaped) {
+        inQuotes = !inQuotes;
+      } else {
+        append(c);
+      }
+      continue;
+    }
+    if (c === "\\" && escaped) {
+      append(c);
+      continue;
+    }
+    if (c === "\\" && inQuotes) {
+      escaped = true;
+      continue;
+    }
+    if (c === " " && !inQuotes) {
+      if (arg.length > 0) {
+        args.push(arg);
+        arg = "";
+      }
+      continue;
+    }
+    append(c);
+  }
+  if (arg.length > 0) {
+    args.push(arg.trim());
+  }
+  return args;
+}
+__name(argStringToArray, "argStringToArray");
+var ExecState = class _ExecState extends events.EventEmitter {
+  static {
+    __name(this, "ExecState");
+  }
+  constructor(options, toolPath) {
+    super();
+    this.processClosed = false;
+    this.processError = "";
+    this.processExitCode = 0;
+    this.processExited = false;
+    this.processStderr = false;
+    this.delay = 1e4;
+    this.done = false;
+    this.timeout = null;
+    if (!toolPath) {
+      throw new Error("toolPath must not be empty");
+    }
+    this.options = options;
+    this.toolPath = toolPath;
+    if (options.delay) {
+      this.delay = options.delay;
+    }
+  }
+  CheckComplete() {
+    if (this.done) {
+      return;
+    }
+    if (this.processClosed) {
+      this._setResult();
+    } else if (this.processExited) {
+      this.timeout = (0, import_timers.setTimeout)(_ExecState.HandleTimeout, this.delay, this);
+    }
+  }
+  _debug(message) {
+    this.emit("debug", message);
+  }
+  _setResult() {
+    let error;
+    if (this.processExited) {
+      if (this.processError) {
+        error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indica\
+te the process failed to start. Error: ${this.processError}`);
+      } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+        error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+      } else if (this.processStderr && this.options.failOnStdErr) {
+        error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR st\
+ream`);
+      }
+    }
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+    }
+    this.done = true;
+    this.emit("done", error, this.processExitCode);
+  }
+  static HandleTimeout(state) {
+    if (state.done) {
+      return;
+    }
+    if (!state.processClosed && state.processExited) {
+      const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from proces\
+s '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+      state._debug(message);
+    }
+    state._setResult();
+  }
+};
+
+// node_modules/@actions/exec/lib/exec.js
+var __awaiter5 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+function exec(commandLine, args, options) {
+  return __awaiter5(this, void 0, void 0, function* () {
+    const commandArgs = argStringToArray(commandLine);
+    if (commandArgs.length === 0) {
+      throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+    }
+    const toolPath = commandArgs[0];
+    args = commandArgs.slice(1).concat(args || []);
+    const runner = new ToolRunner(toolPath, args, options);
+    return runner.exec();
+  });
+}
+__name(exec, "exec");
+function getExecOutput(commandLine, args, options) {
+  return __awaiter5(this, void 0, void 0, function* () {
+    var _a, _b;
+    let stdout = "";
+    let stderr = "";
+    const stdoutDecoder = new import_string_decoder.StringDecoder("utf8");
+    const stderrDecoder = new import_string_decoder.StringDecoder("utf8");
+    const originalStdoutListener = (_a = options === null || options === void 0 ? void 0 : options.listeners) === null ||
+    _a === void 0 ? void 0 : _a.stdout;
+    const originalStdErrListener = (_b = options === null || options === void 0 ? void 0 : options.listeners) === null ||
+    _b === void 0 ? void 0 : _b.stderr;
+    const stdErrListener = /* @__PURE__ */ __name((data) => {
+      stderr += stderrDecoder.write(data);
+      if (originalStdErrListener) {
+        originalStdErrListener(data);
+      }
+    }, "stdErrListener");
+    const stdOutListener = /* @__PURE__ */ __name((data) => {
+      stdout += stdoutDecoder.write(data);
+      if (originalStdoutListener) {
+        originalStdoutListener(data);
+      }
+    }, "stdOutListener");
+    const listeners = Object.assign(Object.assign({}, options === null || options === void 0 ? void 0 : options.listeners),
+    { stdout: stdOutListener, stderr: stdErrListener });
+    const exitCode = yield exec(commandLine, args, Object.assign(Object.assign({}, options), { listeners }));
+    stdout += stdoutDecoder.end();
+    stderr += stderrDecoder.end();
+    return {
+      exitCode,
+      stdout,
+      stderr
+    };
+  });
+}
+__name(getExecOutput, "getExecOutput");
 
 // node_modules/@actions/core/lib/platform.js
 var platform = import_os2.default.platform();
@@ -20840,6 +21652,20 @@ var ExitCode;
   ExitCode2[ExitCode2["Success"] = 0] = "Success";
   ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
 })(ExitCode || (ExitCode = {}));
+function exportVariable(name, val) {
+  const convertedVal = toCommandValue(val);
+  process.env[name] = convertedVal;
+  const filePath = process.env["GITHUB_ENV"] || "";
+  if (filePath) {
+    return issueFileCommand("ENV", prepareKeyValueMessage(name, val));
+  }
+  issueCommand("set-env", { name }, convertedVal);
+}
+__name(exportVariable, "exportVariable");
+function setSecret(secret) {
+  issueCommand("add-mask", {}, secret);
+}
+__name(setSecret, "setSecret");
 function debug(message) {
   issueCommand("debug", {}, message);
 }
@@ -20849,13 +21675,17 @@ function warning(message, properties = {}) {
 }
 __name(warning, "warning");
 function info(message) {
-  process.stdout.write(message + os3.EOL);
+  process.stdout.write(message + os5.EOL);
 }
 __name(info, "info");
 function getState(name) {
   return process.env[`STATE_${name}`] || "";
 }
 __name(getState, "getState");
+
+// setup-gcloud/src/auth-stack.js
+var import_node_fs = __toESM(require("node:fs"), 1);
+var import_node_path = __toESM(require("node:path"), 1);
 
 // setup-gcloud/src/job-scope.js
 function getJobScope({ prefix = "setup-gcloud" } = {}) {
@@ -20869,12 +21699,132 @@ function getJobScope({ prefix = "setup-gcloud" } = {}) {
 }
 __name(getJobScope, "getJobScope");
 
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs.default.existsSync(authStackFilePath())) {
+    import_node_fs.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+
 // setup-gcloud/src/cleanup.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
 function deleteCredentialFiles(credentialFiles) {
   for (const filePath of credentialFiles) {
     try {
-      if (import_node_fs.default.existsSync(filePath)) {
-        import_node_fs.default.rmSync(filePath);
+      if (import_node_fs2.default.existsSync(filePath)) {
+        import_node_fs2.default.rmSync(filePath);
         debug(`Deleted credential file: ${filePath}`);
       }
     } catch (err) {
@@ -20888,8 +21838,8 @@ __name(deleteCredentialFiles, "deleteCredentialFiles");
 function deleteJobScopedDirectory() {
   try {
     const jobScopedDir = getJobScope();
-    if (import_node_fs.default.existsSync(jobScopedDir)) {
-      import_node_fs.default.rmSync(jobScopedDir, { recursive: true });
+    if (import_node_fs2.default.existsSync(jobScopedDir)) {
+      import_node_fs2.default.rmSync(jobScopedDir, { recursive: true });
       debug(`Deleted job-scoped credential directory: ${jobScopedDir}`);
     }
   } catch (err) {
@@ -20900,8 +21850,8 @@ __name(deleteJobScopedDirectory, "deleteJobScopedDirectory");
 function deleteGcloudConfigDirectory() {
   try {
     const cloudSdkConfigPath = process.env.CLOUDSDK_CONFIG;
-    if (cloudSdkConfigPath && import_node_fs.default.existsSync(cloudSdkConfigPath)) {
-      import_node_fs.default.rmSync(cloudSdkConfigPath, { recursive: true });
+    if (cloudSdkConfigPath && import_node_fs2.default.existsSync(cloudSdkConfigPath)) {
+      import_node_fs2.default.rmSync(cloudSdkConfigPath, { recursive: true });
       debug(`Deleted CLOUDSDK_CONFIG directory: ${cloudSdkConfigPath}`);
     }
   } catch (err) {
@@ -20926,9 +21876,10 @@ function cleanupCredentials(credentialFiles) {
 __name(cleanupCredentials, "cleanupCredentials");
 
 // setup-gcloud/src/post.js
-var postAction = /* @__PURE__ */ __name(() => {
+var postAction = /* @__PURE__ */ __name(async () => {
   const credentialFiles = getCredentialFilesFromState();
   cleanupCredentials(credentialFiles);
+  await resetAuthStack();
 }, "postAction");
 postAction();
 /*! Bundled license information:

--- a/setup-gcloud/src/auth-gcloud.js
+++ b/setup-gcloud/src/auth-gcloud.js
@@ -6,6 +6,7 @@ import {
   workloadIdentityFederation,
 } from './auth-wid-federation.js';
 import createJobScopedCredential from './create-job-scoped-credential.js';
+import { execGcloud } from './exec-gcloud.js';
 
 const authType = {
   jsonKey: 'json_key',
@@ -92,6 +93,16 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 
+const getAccessToken = async () => {
+  const accessToken = await execGcloud(
+    ['auth', 'print-access-token'],
+    'gcloud',
+    true,
+  );
+  core.setSecret(accessToken);
+  return accessToken;
+};
+
 const setEnvironmentVariable = (key, value, exportVariable) => {
   if (isNonEmptyString(value)) {
     if (exportVariable) {
@@ -108,7 +119,7 @@ const setEnvironmentVariable = (key, value, exportVariable) => {
   }
 };
 
-const populateEnvironment = ({
+const populateEnvironment = async ({
   projectId,
   credentialsFilePath,
   exportCredentials,
@@ -122,6 +133,11 @@ const populateEnvironment = ({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials,
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === '' ? '' : await getAccessToken(),
     exportCredentials,
   );
 };
@@ -196,7 +212,7 @@ export async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
 
   return projectId;
@@ -230,11 +246,11 @@ export function getCurrentAccount() {
 /**
  * Reset all tracked gcloud authentications and clear auth-related environment variables.
  */
-export function resetAuthStack() {
+export async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: '',
       credentialsFilePath: '',
@@ -266,7 +282,7 @@ export async function restorePreviousAccount(previousAccount) {
   saveAuthStack(authStack);
 
   // Restore the environment variables.
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
 
   return true;
 }

--- a/setup-gcloud/src/post.js
+++ b/setup-gcloud/src/post.js
@@ -1,12 +1,16 @@
+import { resetAuthStack } from './auth-gcloud.js';
 import { cleanupCredentials, getCredentialFilesFromState } from './cleanup.js';
 
 /**
  * Post-step cleanup for setup-gcloud action.
  * Runs at the end of the job to delete all credential files and directories.
  */
-const postAction = () => {
+const postAction = async () => {
   const credentialFiles = getCredentialFilesFromState();
   cleanupCredentials(credentialFiles);
+
+  // Reset auth stack to clear environment variables such as access tokens
+  await resetAuthStack();
 };
 
 postAction();

--- a/setup-gcloud/src/post.js
+++ b/setup-gcloud/src/post.js
@@ -1,6 +1,7 @@
+import { run } from 'action-utils';
+
 import { resetAuthStack } from './auth-gcloud.js';
 import { cleanupCredentials, getCredentialFilesFromState } from './cleanup.js';
-
 /**
  * Post-step cleanup for setup-gcloud action.
  * Runs at the end of the job to delete all credential files and directories.
@@ -13,4 +14,4 @@ const postAction = async () => {
   await resetAuthStack();
 };
 
-postAction();
+run(postAction);

--- a/setup-gcloud/src/with-gcloud.js
+++ b/setup-gcloud/src/with-gcloud.js
@@ -45,7 +45,7 @@ const withGcloud = async (serviceAccountKey, fn) => {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
       // Unset exported env vars and remove persistent files.
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/setup-gcloud/test/auth-gcloud-refresh.test.js
+++ b/setup-gcloud/test/auth-gcloud-refresh.test.js
@@ -6,10 +6,12 @@ import {
   workloadIdentityFederation,
 } from '../src/auth-wid-federation.js';
 import createJobScopedCredential from '../src/create-job-scoped-credential.js';
+import { execGcloud } from '../src/exec-gcloud.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/create-job-scoped-credential.js');
 vi.mock('../src/auth-wid-federation.js');
+vi.mock('../src/exec-gcloud.js');
 
 vi.mock('../src/auth-stack.js', () => {
   let authStack = [];
@@ -29,15 +31,16 @@ const encodeCredentials = (credentials) =>
   Buffer.from(JSON.stringify(credentials), 'utf8').toString('base64');
 
 describe('auth-gcloud refresh token', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     process.env.CLOUDSDK_CORE_PROJECT = undefined;
     process.env.GOOGLE_APPLICATION_CREDENTIALS = undefined;
     process.env.CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE = undefined;
-    resetAuthStack();
+    await resetAuthStack();
+    execGcloud.mockResolvedValue('token-123');
   });
 
-  afterEach(() => {
-    resetAuthStack();
+  afterEach(async () => {
+    await resetAuthStack();
     vi.clearAllMocks();
   });
 

--- a/setup-gcloud/test/auth-gcloud.test.js
+++ b/setup-gcloud/test/auth-gcloud.test.js
@@ -239,6 +239,101 @@ describe('auth-gcloud', () => {
     );
   });
 
+  test('authenticateGcloud sets CLOUDSDK_AUTH_ACCESS_TOKEN and masks it via core.setSecret', async () => {
+    createJobScopedCredential.mockReturnValueOnce(
+      '/runner/temp/setup-gcloud-xxx/credential-key.json',
+    );
+
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key',
+        client_email: 'json-sa@example.iam.gserviceaccount.com',
+        project_id: 'project-a',
+      }),
+      true,
+    );
+
+    expect(execGcloud).toHaveBeenCalledWith(
+      ['auth', 'print-access-token'],
+      'gcloud',
+      true,
+    );
+    expect(core.setSecret).toHaveBeenCalledWith('token-123');
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      'token-123',
+    );
+  });
+
+  test('resetAuthStack clears CLOUDSDK_AUTH_ACCESS_TOKEN without shelling out to gcloud', async () => {
+    createJobScopedCredential.mockReturnValueOnce(
+      '/runner/temp/setup-gcloud-xxx/credential-key.json',
+    );
+
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key',
+        client_email: 'json-sa@example.iam.gserviceaccount.com',
+        project_id: 'project-a',
+      }),
+      true,
+    );
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
+
+    vi.clearAllMocks();
+    await resetAuthStack();
+
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBeUndefined();
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      '',
+    );
+    // credentialsFilePath is '' during reset — must not shell out to gcloud
+    expect(execGcloud).not.toHaveBeenCalled();
+  });
+
+  test('restorePreviousAccount re-fetches and sets CLOUDSDK_AUTH_ACCESS_TOKEN', async () => {
+    createJobScopedCredential
+      .mockReturnValueOnce(
+        '/runner/temp/setup-gcloud-xxx/credential-first.json',
+      )
+      .mockReturnValueOnce(
+        '/runner/temp/setup-gcloud-xxx/credential-second.json',
+      );
+
+    execGcloud.mockResolvedValue('token-first');
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key-a',
+        client_email: 'first@example.iam.gserviceaccount.com',
+        project_id: 'project-first',
+      }),
+      true,
+    );
+    const previousAccount = getCurrentAccount();
+
+    execGcloud.mockResolvedValue('token-second');
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key-b',
+        client_email: 'second@example.iam.gserviceaccount.com',
+        project_id: 'project-second',
+      }),
+      true,
+    );
+
+    execGcloud.mockResolvedValue('token-restored');
+    await restorePreviousAccount(previousAccount);
+
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-restored');
+    expect(core.setSecret).toHaveBeenCalledWith('token-restored');
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      'token-restored',
+    );
+  });
+
   test('rejects when decoded credentials are not valid JSON', async () => {
     await expect(
       authenticateGcloud(Buffer.from('not-json', 'utf8').toString('base64')),

--- a/setup-gcloud/test/auth-gcloud.test.js
+++ b/setup-gcloud/test/auth-gcloud.test.js
@@ -11,10 +11,12 @@ import {
 } from '../src/auth-gcloud.js';
 import { workloadIdentityFederation } from '../src/auth-wid-federation.js';
 import createJobScopedCredential from '../src/create-job-scoped-credential.js';
+import { execGcloud } from '../src/exec-gcloud.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/create-job-scoped-credential.js');
 vi.mock('../src/auth-wid-federation.js');
+vi.mock('../src/exec-gcloud.js');
 
 const encodeCredentials = (credentials) =>
   Buffer.from(JSON.stringify(credentials), 'utf8').toString('base64');
@@ -22,7 +24,7 @@ const encodeCredentials = (credentials) =>
 describe('auth-gcloud', () => {
   let orgEnv;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockFs({
       '/runner/temp': {},
     });
@@ -36,11 +38,12 @@ describe('auth-gcloud', () => {
       GOOGLE_APPLICATION_CREDENTIALS: undefined,
       CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: undefined,
     };
-    resetAuthStack();
+    await resetAuthStack();
+    execGcloud.mockResolvedValue('token-123');
   });
 
-  afterEach(() => {
-    resetAuthStack();
+  afterEach(async () => {
+    await resetAuthStack();
     process.env = orgEnv;
     mockFs.restore();
     vi.clearAllMocks();
@@ -216,7 +219,7 @@ describe('auth-gcloud', () => {
     expect(getCurrentAccount()).toBeTruthy();
     expect(process.env.CLOUDSDK_CORE_PROJECT).toBe('project-a');
 
-    resetAuthStack();
+    await resetAuthStack();
 
     expect(getCurrentAccount()).toBeUndefined();
     expect(process.env.CLOUDSDK_CORE_PROJECT).toBeUndefined();

--- a/setup-gcloud/test/post.test.js
+++ b/setup-gcloud/test/post.test.js
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const getCredentialFilesFromState = vi.fn();
 const cleanupCredentials = vi.fn();
+const resetAuthStack = vi.fn();
 
 vi.mock('../src/cleanup.js', () => ({
   getCredentialFilesFromState,
   cleanupCredentials,
+}));
+
+vi.mock('../src/auth-gcloud.js', () => ({
+  resetAuthStack,
 }));
 
 describe('post cleanup', () => {
@@ -23,6 +28,7 @@ describe('post cleanup', () => {
       '/tmp/a.json',
       '/tmp/b.json',
     ]);
+    resetAuthStack.mockResolvedValueOnce(undefined);
 
     await import('../src/post.js');
 
@@ -31,14 +37,17 @@ describe('post cleanup', () => {
       '/tmp/a.json',
       '/tmp/b.json',
     ]);
+    expect(resetAuthStack).toHaveBeenCalledTimes(1);
   });
 
   test('passes empty list to cleanup when no state exists', async () => {
     getCredentialFilesFromState.mockReturnValueOnce([]);
+    resetAuthStack.mockResolvedValueOnce(undefined);
 
     await import('../src/post.js');
 
     expect(getCredentialFilesFromState).toHaveBeenCalledTimes(1);
     expect(cleanupCredentials).toHaveBeenCalledWith([]);
+    expect(resetAuthStack).toHaveBeenCalledTimes(1);
   });
 });

--- a/slack-message/dist/index.cjs
+++ b/slack-message/dist/index.cjs
@@ -75638,16 +75638,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -75756,13 +75756,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -75792,7 +75792,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -75818,7 +75818,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -75840,7 +75840,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -75851,7 +75851,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -75872,7 +75872,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -106661,6 +106661,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -106676,7 +106685,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -106690,6 +106699,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -106737,7 +106751,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -106763,11 +106777,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -106785,7 +106799,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -107005,7 +107019,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/slack-notify/dist/index.cjs
+++ b/slack-notify/dist/index.cjs
@@ -68805,16 +68805,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -68923,13 +68923,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -68959,7 +68959,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -68985,7 +68985,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69007,7 +69007,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69018,7 +69018,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69039,7 +69039,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99827,6 +99827,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99842,7 +99851,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99856,6 +99865,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -99903,7 +99917,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -99929,11 +99943,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -99951,7 +99965,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100171,7 +100185,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/status-check/dist/index.cjs
+++ b/status-check/dist/index.cjs
@@ -73543,16 +73543,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -73661,13 +73661,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -73697,7 +73697,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -73723,7 +73723,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -73745,7 +73745,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -73756,7 +73756,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -73777,7 +73777,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -104568,6 +104568,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -104583,7 +104592,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -104597,6 +104606,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -104644,7 +104658,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -104670,11 +104684,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -104692,7 +104706,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -104912,7 +104926,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/test-pod/dist/index.cjs
+++ b/test-pod/dist/index.cjs
@@ -71119,16 +71119,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -71237,13 +71237,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -71273,7 +71273,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -71299,7 +71299,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -71321,7 +71321,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -71332,7 +71332,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -71353,7 +71353,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -102131,6 +102131,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -102146,7 +102155,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -102160,6 +102169,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -102199,7 +102213,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/trivy-scan/dist/index.cjs
+++ b/trivy-scan/dist/index.cjs
@@ -68902,16 +68902,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69020,13 +69020,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69056,7 +69056,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69082,7 +69082,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69104,7 +69104,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69115,7 +69115,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69136,7 +69136,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -99924,6 +99924,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -99939,7 +99948,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -99953,6 +99962,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100000,7 +100014,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -100026,11 +100040,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -100048,7 +100062,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100268,7 +100282,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/txengine-deploy/dist/index.cjs
+++ b/txengine-deploy/dist/index.cjs
@@ -70288,16 +70288,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70406,13 +70406,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70442,7 +70442,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70468,7 +70468,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70490,7 +70490,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70501,7 +70501,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70522,7 +70522,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101313,6 +101313,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101328,7 +101337,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101342,6 +101351,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101389,7 +101403,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -101415,11 +101429,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -101437,7 +101451,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -101657,7 +101671,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }


### PR DESCRIPTION
This pull request updates the `setup-gcloud` action to improve how Google Cloud authentication environment variables, especially access tokens, are managed and cleaned up. The main enhancements include fetching and exporting the access token as an environment variable, making environment population asynchronous, and ensuring that authentication state is properly reset and tested at the end of jobs.

**Authentication and Environment Management Improvements:**

* The `populateEnvironment` function is now asynchronous and sets the access token environment variable by fetching it using `gcloud auth print-access-token` via the new `getAccessToken` helper. This ensures the access token is always available when credentials are set. [[1]](diffhunk://#diff-7e8780278b911efb54ed6c4cc1d31da0a996bf56ee0d91071f94a4660abe8fa1R96-R105) [[2]](diffhunk://#diff-7e8780278b911efb54ed6c4cc1d31da0a996bf56ee0d91071f94a4660abe8fa1L111-R122) [[3]](diffhunk://#diff-7e8780278b911efb54ed6c4cc1d31da0a996bf56ee0d91071f94a4660abe8fa1R138-R142)
* All functions that modify or reset authentication state (`authenticateGcloud`, `resetAuthStack`, `restorePreviousAccount`, and usages in `withGcloud.js`) now properly await the asynchronous environment population to avoid race conditions. [[1]](diffhunk://#diff-7e8780278b911efb54ed6c4cc1d31da0a996bf56ee0d91071f94a4660abe8fa1L199-R215) [[2]](diffhunk://#diff-7e8780278b911efb54ed6c4cc1d31da0a996bf56ee0d91071f94a4660abe8fa1L233-R253) [[3]](diffhunk://#diff-7e8780278b911efb54ed6c4cc1d31da0a996bf56ee0d91071f94a4660abe8fa1L269-R285) [[4]](diffhunk://#diff-be0c0ef3c979a4315692c4c1b6771d293cc0d31d57ff424c14c5530a1939442fL48-R48)

**Cleanup and Post-Step Handling:**

* The post-job cleanup script (`post.js`) now awaits `resetAuthStack` to ensure all authentication-related environment variables, including access tokens, are cleared at the end of the job.

**Testing Enhancements:**

* Test suites for authentication and cleanup (`auth-gcloud.test.js`, `auth-gcloud-refresh.test.js`, and `post.test.js`) have been updated to handle the asynchronous `resetAuthStack` and to mock/fake access token fetching. Tests now verify that `resetAuthStack` is called as expected during cleanup. [[1]](diffhunk://#diff-497dc9a43fb9be83dc786a0055dadbb05413f42fabc61611ca47100aec145ab1R9-R14) [[2]](diffhunk://#diff-497dc9a43fb9be83dc786a0055dadbb05413f42fabc61611ca47100aec145ab1L32-R43) [[3]](diffhunk://#diff-2991f904840f7af1948c80118dcbadeab8cf95cf21253811599276b40867448eR14-R27) [[4]](diffhunk://#diff-2991f904840f7af1948c80118dcbadeab8cf95cf21253811599276b40867448eL39-R46) [[5]](diffhunk://#diff-2991f904840f7af1948c80118dcbadeab8cf95cf21253811599276b40867448eL219-R222) [[6]](diffhunk://#diff-bf2aa70c8ec890f28382a9378c29f2369a42e30fc4a80aba58b326bb7c77a17fR5-R15) [[7]](diffhunk://#diff-bf2aa70c8ec890f28382a9378c29f2369a42e30fc4a80aba58b326bb7c77a17fR31) [[8]](diffhunk://#diff-bf2aa70c8ec890f28382a9378c29f2369a42e30fc4a80aba58b326bb7c77a17fR40-R51)

These changes ensure that the setup-gcloud action handles authentication state more reliably, especially in CI environments where environment variables must be carefully managed and cleaned up between jobs.