### PR TITLE
fix(setup-gcloud): Set CLOUDSDK_ACCESS_TOKEN with a 1 hr GCP token

### DIFF
--- a/.github/actions/build-dist/action.yml
+++ b/.github/actions/build-dist/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
         cache: npm

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,6 +55,8 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   verify-dist:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -75,6 +80,9 @@ jobs:
     runs-on: windows-latest
     needs:
       - verify-dist
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -143,6 +151,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - verify-dist
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -190,6 +201,14 @@ jobs:
             echo "Second secret does not match"
             exit 1
           fi
+
+      - name: GCP Secret Manager WIF
+        uses: ./gcp-secret-manager
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH_WIF }}
+          secrets: |
+            TEST3_TOKEN: sonarqube-token
+            TEST4_TOKEN: sonarqube-token
 
       - name: Setup Gcloud
         uses: ./setup-gcloud
@@ -241,6 +260,7 @@ jobs:
       - acceptance-linux
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -202,6 +202,12 @@ jobs:
             exit 1
           fi
 
+      - name: Setup Gcloud
+        uses: ./setup-gcloud
+        id: gcloud
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
       - name: GCP Secret Manager WIF
         uses: ./gcp-secret-manager
         with:
@@ -210,18 +216,18 @@ jobs:
             TEST3_TOKEN: sonarqube-token
             TEST4_TOKEN: sonarqube-token
 
-      - name: Setup Gcloud
-        uses: ./setup-gcloud
-        id: gcloud
-        with:
-          service-account-key: ${{ secrets.SECRET_AUTH }}
-
       - name: Test Gcloud
         run: |
           gcloud --version
           gsutil --version
           if [ "${{ steps.gcloud.outputs.project-id }}" == "" ]; then
             echo "Failed to set project-id"
+            exit 1
+          fi
+          projects=$(gcloud projects list)
+          echo "$projects"
+          if [ -z "$projects" ]; then
+            echo "Project list is empty"
             exit 1
           fi
 

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
-      - name: GCP Secret Manager WIF
+      - name: GCP Secret Manager Does Not Interfere with Gcloud
         uses: ./gcp-secret-manager
         with:
           service-account-key: ${{ secrets.SECRET_AUTH_WIF }}
@@ -224,7 +224,7 @@ jobs:
             echo "Failed to set project-id"
             exit 1
           fi
-          projects=$(gcloud projects list)
+          projects=$(gcloud projects list --format='value(projectId)')
           echo "$projects"
           if [ -z "$projects" ]; then
             echo "Project list is empty"

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -131,6 +131,14 @@ jobs:
             exit 1
           fi
 
+      - name: GCP Secret Manager WIF
+        uses: ./gcp-secret-manager
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH_WIF }}
+          secrets: |
+            TEST3_TOKEN: sonarqube-token
+            TEST4_TOKEN: sonarqube-token
+
   acceptance-linux:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create signed commit
         id: commit
-        uses: qoomon/actions--create-commit@v1
+        uses: qoomon/actions--create-commit@0f4cc87a8ad11282dfed4639db11c6e4ac09b25b
         with:
           message: "build: Update dist files after dependency update [skip dependabot]"
           skip-empty: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/setup-python@v6
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
         with:
           extra_args: --from-ref=${{ github.event.pull_request.base.sha }} --to-ref=${{ github.sha }}

--- a/binary-auth-attestation/dist/index.cjs
+++ b/binary-auth-attestation/dist/index.cjs
@@ -100078,18 +100078,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100110,6 +100116,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100128,7 +100135,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/binary-auth-attestation/dist/index.cjs
+++ b/binary-auth-attestation/dist/index.cjs
@@ -65421,15 +65421,318 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65467,10 +65770,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65478,7 +65781,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65518,7 +65821,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65556,10 +65859,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65630,13 +65933,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65653,12 +65956,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65677,8 +65980,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65689,12 +65992,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65730,7 +66033,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65755,8 +66058,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65794,10 +66097,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -66040,7 +66343,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -66064,7 +66367,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -66074,7 +66377,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66110,7 +66413,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66122,10 +66425,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66181,8 +66484,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66282,16 +66585,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66309,7 +66612,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66332,7 +66635,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66378,7 +66681,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66415,7 +66718,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66430,11 +66733,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68430,7 +68733,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68438,7 +68741,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94556,7 +94859,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94596,7 +94899,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94608,8 +94911,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97533,7 +97836,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97812,7 +98115,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97838,7 +98141,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97957,7 +98260,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -97976,12 +98279,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98284,7 +98587,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98298,7 +98601,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98309,7 +98612,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98351,26 +98654,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98394,9 +98697,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98418,26 +98721,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98455,9 +98758,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98479,27 +98782,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98524,9 +98827,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98552,27 +98855,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98603,9 +98906,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98631,26 +98934,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98682,9 +98985,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98714,29 +99017,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98767,9 +99070,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98795,26 +99098,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98847,9 +99150,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98879,29 +99182,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98932,9 +99235,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98960,21 +99263,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99246,7 +99549,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99322,16 +99625,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99381,7 +99684,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99390,7 +99693,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99406,7 +99709,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99415,7 +99718,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99458,7 +99761,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99584,7 +99887,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99655,7 +99958,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99721,7 +100024,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99796,7 +100099,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99872,335 +100175,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/binary-auth-attestation/dist/index.cjs
+++ b/binary-auth-attestation/dist/index.cjs
@@ -69065,16 +69065,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69183,13 +69183,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69219,7 +69219,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69245,7 +69245,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69267,7 +69267,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69278,7 +69278,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69299,7 +69299,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100078,6 +100078,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100093,7 +100102,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100107,6 +100116,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100146,7 +100160,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/binary-auth-attestation/dist/index.cjs
+++ b/binary-auth-attestation/dist/index.cjs
@@ -100078,13 +100078,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100104,6 +100111,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100120,7 +100128,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/cloud-deploy-plan/dist/index.cjs
+++ b/cloud-deploy-plan/dist/index.cjs
@@ -67586,15 +67586,318 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth2, current) {
+  if (current) {
+    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -67632,10 +67935,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -67643,7 +67946,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -67683,7 +67986,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -67721,10 +68024,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -67795,13 +68098,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -67818,12 +68121,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -67842,8 +68145,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -67854,12 +68157,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -67895,7 +68198,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -67920,8 +68223,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -67959,10 +68262,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -68205,7 +68508,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -68229,7 +68532,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -68239,7 +68542,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -68275,7 +68578,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -68287,10 +68590,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -68346,8 +68649,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -68447,16 +68750,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -68474,7 +68777,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths2.push(".");
@@ -68497,7 +68800,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -68543,7 +68846,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -68580,7 +68883,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -68595,11 +68898,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -70595,7 +70898,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -70603,7 +70906,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -96724,7 +97027,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -96764,7 +97067,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -96776,8 +97079,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -99701,7 +100004,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -99980,7 +100283,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient2 = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient2.get(archiveLocation);
@@ -100006,7 +100309,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient2 = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -100125,7 +100428,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -100144,12 +100447,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -100452,7 +100755,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -100466,7 +100769,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient2, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient2, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -100477,7 +100780,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -100519,26 +100822,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -100562,9 +100865,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100586,26 +100889,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -100623,9 +100926,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100647,27 +100950,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -100692,9 +100995,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100720,27 +101023,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -100771,9 +101074,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100799,26 +101102,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -100850,9 +101153,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100882,29 +101185,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -100935,9 +101238,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100963,26 +101266,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -101015,9 +101318,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101047,29 +101350,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -101100,9 +101403,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101128,21 +101431,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -101414,7 +101717,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -101490,16 +101793,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -101549,7 +101852,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -101558,7 +101861,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -101574,7 +101877,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -101583,7 +101886,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -101626,7 +101929,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -101752,7 +102055,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -101823,7 +102126,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -101889,7 +102192,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101964,7 +102267,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -102040,335 +102343,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth2, current) {
-  if (current) {
-    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);
@@ -102528,7 +102502,7 @@ async function getIdToken(audience) {
     throw new Error("No authenticated service account");
   }
   const args = ["auth", "print-identity-token", `--audiences=${audience}`];
-  if (account.type === "wid_federation") {
+  if (account.type === authType.widFederation) {
     args.push(
       `--impersonate-service-account=${account.email}`,
       "--include-email"

--- a/cloud-deploy-plan/dist/index.cjs
+++ b/cloud-deploy-plan/dist/index.cjs
@@ -102246,18 +102246,24 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -102278,6 +102284,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -102296,7 +102303,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/cloud-deploy-plan/dist/index.cjs
+++ b/cloud-deploy-plan/dist/index.cjs
@@ -71230,16 +71230,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -71348,13 +71348,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -71384,7 +71384,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -71410,7 +71410,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -71432,7 +71432,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -71443,7 +71443,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -71464,7 +71464,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -102246,6 +102246,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -102261,7 +102270,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -102275,6 +102284,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -102314,7 +102328,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/cloud-deploy-plan/dist/index.cjs
+++ b/cloud-deploy-plan/dist/index.cjs
@@ -102246,13 +102246,20 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -102272,6 +102279,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -102288,7 +102296,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/cloud-deploy/dist/index.cjs
+++ b/cloud-deploy/dist/index.cjs
@@ -101499,18 +101499,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type2, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type2 === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -101531,6 +101537,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type: type2,
   projectId,
   email,
   credentialsFilePath,
@@ -101549,7 +101556,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type2, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/cloud-deploy/dist/index.cjs
+++ b/cloud-deploy/dist/index.cjs
@@ -66831,15 +66831,363 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary: binary2, version: v
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type: type2, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type: type2,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -66877,10 +67225,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -66888,7 +67236,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -66928,7 +67276,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -66966,10 +67314,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -67040,13 +67388,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -67063,12 +67411,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -67087,8 +67435,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -67099,12 +67447,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -67140,7 +67488,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -67165,8 +67513,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -67204,10 +67552,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -67450,7 +67798,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -67474,7 +67822,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -67484,7 +67832,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -67520,7 +67868,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -67532,10 +67880,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -67591,8 +67939,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -67692,16 +68040,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -67719,7 +68067,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -67742,7 +68090,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -67788,7 +68136,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -67825,7 +68173,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -67840,11 +68188,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -69840,7 +70188,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -69848,7 +70196,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map2) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map2.set("Bun", `${versions.bun} (${osInfo})`);
@@ -95967,7 +96315,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -96007,7 +96355,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -96019,8 +96367,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -98944,7 +99292,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -99223,7 +99571,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -99249,7 +99597,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -99368,7 +99716,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -99387,12 +99735,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -99695,7 +100043,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -99709,7 +100057,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -99720,7 +100068,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -99762,26 +100110,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -99805,9 +100153,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99829,26 +100177,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -99866,9 +100214,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99890,27 +100238,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -99935,9 +100283,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99963,27 +100311,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -100014,9 +100362,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100042,26 +100390,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -100093,9 +100441,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100125,29 +100473,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -100178,9 +100526,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100206,26 +100554,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -100258,9 +100606,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100290,29 +100638,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -100343,9 +100691,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100371,21 +100719,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -100657,7 +101005,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -100733,16 +101081,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type2) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -100792,7 +101140,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -100801,7 +101149,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -100817,7 +101165,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -100826,7 +101174,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -100869,7 +101217,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -100995,7 +101343,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -101066,7 +101414,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -101132,7 +101480,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101207,7 +101555,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101283,380 +101631,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type2, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type2 === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type: type2,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type2, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type: type2, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type: type2,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);
@@ -101887,7 +101861,7 @@ async function getIdToken(audience) {
     throw new Error("No authenticated service account");
   }
   const args = ["auth", "print-identity-token", `--audiences=${audience}`];
-  if (account.type === "wid_federation") {
+  if (account.type === authType.widFederation) {
     args.push(
       `--impersonate-service-account=${account.email}`,
       "--include-email"

--- a/cloud-deploy/dist/index.cjs
+++ b/cloud-deploy/dist/index.cjs
@@ -101499,13 +101499,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -101525,6 +101532,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -101541,7 +101549,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101622,6 +101630,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/cloud-deploy/dist/index.cjs
+++ b/cloud-deploy/dist/index.cjs
@@ -70475,16 +70475,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70593,13 +70593,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70629,7 +70629,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70655,7 +70655,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70677,7 +70677,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70688,7 +70688,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70709,7 +70709,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101499,6 +101499,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101514,7 +101523,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101528,6 +101537,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101575,7 +101589,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -101601,11 +101615,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -101623,7 +101637,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -101843,7 +101857,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/cloud-run-traffic/dist/index.cjs
+++ b/cloud-run-traffic/dist/index.cjs
@@ -92444,18 +92444,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -92476,6 +92482,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -92494,7 +92501,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/cloud-run-traffic/dist/index.cjs
+++ b/cloud-run-traffic/dist/index.cjs
@@ -61431,16 +61431,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61549,13 +61549,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61585,7 +61585,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61611,7 +61611,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61633,7 +61633,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61644,7 +61644,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61665,7 +61665,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92444,6 +92444,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92459,7 +92468,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92473,6 +92482,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92512,7 +92526,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/cloud-run-traffic/dist/index.cjs
+++ b/cloud-run-traffic/dist/index.cjs
@@ -92444,13 +92444,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -92470,6 +92477,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -92486,7 +92494,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/cloud-run-traffic/dist/index.cjs
+++ b/cloud-run-traffic/dist/index.cjs
@@ -57787,15 +57787,318 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -57833,10 +58136,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -57844,7 +58147,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -57884,7 +58187,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -57922,10 +58225,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -57996,13 +58299,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -58019,12 +58322,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -58043,8 +58346,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -58055,12 +58358,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -58096,7 +58399,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -58121,8 +58424,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -58160,10 +58463,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -58406,7 +58709,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -58430,7 +58733,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -58440,7 +58743,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -58476,7 +58779,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -58488,10 +58791,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -58547,8 +58850,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -58648,16 +58951,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -58675,7 +58978,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -58698,7 +59001,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -58744,7 +59047,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -58781,7 +59084,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -58796,11 +59099,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -60796,7 +61099,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -60804,7 +61107,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -86922,7 +87225,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -86962,7 +87265,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -86974,8 +87277,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -89899,7 +90202,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -90178,7 +90481,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -90204,7 +90507,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -90323,7 +90626,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -90342,12 +90645,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -90650,7 +90953,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -90664,7 +90967,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -90675,7 +90978,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -90717,26 +91020,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -90760,9 +91063,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90784,26 +91087,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -90821,9 +91124,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90845,27 +91148,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -90890,9 +91193,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90918,27 +91221,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -90969,9 +91272,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90997,26 +91300,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -91048,9 +91351,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91080,29 +91383,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -91133,9 +91436,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91161,26 +91464,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -91213,9 +91516,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91245,29 +91548,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -91298,9 +91601,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91326,21 +91629,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -91612,7 +91915,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -91688,16 +91991,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -91747,7 +92050,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -91756,7 +92059,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -91772,7 +92075,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -91781,7 +92084,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -91824,7 +92127,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -91950,7 +92253,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -92021,7 +92324,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -92087,7 +92390,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92162,7 +92465,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92238,335 +92541,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/customer-config/dist/index.cjs
+++ b/customer-config/dist/index.cjs
@@ -115966,13 +115966,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -115992,6 +115999,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -116008,7 +116016,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -116089,6 +116097,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/customer-config/dist/index.cjs
+++ b/customer-config/dist/index.cjs
@@ -84942,16 +84942,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -85060,13 +85060,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -85096,7 +85096,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -85122,7 +85122,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -85144,7 +85144,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -85155,7 +85155,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -85176,7 +85176,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -115966,6 +115966,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -115981,7 +115990,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -115995,6 +116004,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -116042,7 +116056,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -116068,11 +116082,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -116090,7 +116104,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -116310,7 +116324,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/customer-config/dist/index.cjs
+++ b/customer-config/dist/index.cjs
@@ -115966,18 +115966,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type2, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type2 === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -115998,6 +116004,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type: type2,
   projectId,
   email,
   credentialsFilePath,
@@ -116016,7 +116023,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type2, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/customer-config/dist/index.cjs
+++ b/customer-config/dist/index.cjs
@@ -81298,15 +81298,363 @@ __name(loadDefinitions, "loadDefinitions");
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type: type2, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type: type2,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -81344,10 +81692,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -81355,7 +81703,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -81395,7 +81743,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -81433,10 +81781,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -81507,13 +81855,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -81530,12 +81878,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -81554,8 +81902,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -81566,12 +81914,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -81607,7 +81955,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -81632,8 +81980,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -81671,10 +82019,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -81917,7 +82265,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -81941,7 +82289,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -81951,7 +82299,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -81987,7 +82335,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -81999,10 +82347,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -82058,8 +82406,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -82159,16 +82507,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -82186,7 +82534,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -82209,7 +82557,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -82255,7 +82603,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -82292,7 +82640,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -82307,11 +82655,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -84307,7 +84655,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -84315,7 +84663,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map2) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map2.set("Bun", `${versions.bun} (${osInfo})`);
@@ -110434,7 +110782,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -110474,7 +110822,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -110486,8 +110834,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -113411,7 +113759,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -113690,7 +114038,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -113716,7 +114064,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -113835,7 +114183,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -113854,12 +114202,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -114162,7 +114510,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -114176,7 +114524,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -114187,7 +114535,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -114229,26 +114577,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime334 = __toESM(require_commonjs(), 1);
+var import_runtime335 = __toESM(require_commonjs(), 1);
+var import_runtime336 = __toESM(require_commonjs(), 1);
+var import_runtime337 = __toESM(require_commonjs(), 1);
+var import_runtime338 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime328 = __toESM(require_commonjs(), 1);
 var import_runtime329 = __toESM(require_commonjs(), 1);
 var import_runtime330 = __toESM(require_commonjs(), 1);
 var import_runtime331 = __toESM(require_commonjs(), 1);
+var import_runtime332 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime321 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
 var import_runtime325 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime315 = __toESM(require_commonjs(), 1);
-var import_runtime316 = __toESM(require_commonjs(), 1);
-var import_runtime317 = __toESM(require_commonjs(), 1);
-var import_runtime318 = __toESM(require_commonjs(), 1);
-var import_runtime319 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime319.MessageType {
+var import_runtime326 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime326.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -114272,9 +114620,9 @@ var CacheScope$Type = class extends import_runtime319.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime317.reflectionMergePartial)(this, message, value);
+      (0, import_runtime324.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114296,26 +114644,26 @@ var CacheScope$Type = class extends import_runtime319.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime322.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime322.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime325.MessageType {
+var CacheMetadata$Type = class extends import_runtime332.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -114333,9 +114681,9 @@ var CacheMetadata$Type = class extends import_runtime325.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime331.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime323.reflectionMergePartial)(this, message, value);
+      (0, import_runtime330.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114357,27 +114705,27 @@ var CacheMetadata$Type = class extends import_runtime325.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime329.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime328.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime328.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime329.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -114402,9 +114750,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114430,27 +114778,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime334.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -114481,9 +114829,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114509,26 +114857,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime334.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -114560,9 +114908,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114592,29 +114940,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime334.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime334.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime334.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -114645,9 +114993,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114673,26 +115021,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime334.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime334.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -114725,9 +115073,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114757,29 +115105,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime334.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime334.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -114810,9 +115158,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -114838,21 +115186,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime334.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -115124,7 +115472,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs3 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -115200,16 +115548,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type2) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -115259,7 +115607,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -115268,7 +115616,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -115284,7 +115632,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -115293,7 +115641,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -115336,7 +115684,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs3.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs3.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -115462,7 +115810,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -115533,7 +115881,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -115599,7 +115947,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -115674,7 +116022,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -115750,380 +116098,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob2 = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type2, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type2 === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type: type2,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type2, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type: type2, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type: type2,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/dataflow-deploy/dist/index.cjs
+++ b/dataflow-deploy/dist/index.cjs
@@ -61487,16 +61487,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61605,13 +61605,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61641,7 +61641,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61667,7 +61667,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61689,7 +61689,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61700,7 +61700,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61721,7 +61721,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92500,6 +92500,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92515,7 +92524,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92529,6 +92538,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92568,7 +92582,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/dataflow-deploy/dist/index.cjs
+++ b/dataflow-deploy/dist/index.cjs
@@ -92500,13 +92500,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -92526,6 +92533,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -92542,7 +92550,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/dataflow-deploy/dist/index.cjs
+++ b/dataflow-deploy/dist/index.cjs
@@ -92500,18 +92500,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -92532,6 +92538,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -92550,7 +92557,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/dataflow-deploy/dist/index.cjs
+++ b/dataflow-deploy/dist/index.cjs
@@ -57843,15 +57843,318 @@ var getTribeProject = /* @__PURE__ */ __name(async (projectId) => {
   return tribeProject;
 }, "getTribeProject");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -57889,10 +58192,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -57900,7 +58203,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -57940,7 +58243,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -57978,10 +58281,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -58052,13 +58355,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -58075,12 +58378,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -58099,8 +58402,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -58111,12 +58414,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -58152,7 +58455,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -58177,8 +58480,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -58216,10 +58519,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -58462,7 +58765,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -58486,7 +58789,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -58496,7 +58799,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -58532,7 +58835,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -58544,10 +58847,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -58603,8 +58906,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -58704,16 +59007,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -58731,7 +59034,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -58754,7 +59057,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -58800,7 +59103,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -58837,7 +59140,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -58852,11 +59155,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -60852,7 +61155,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -60860,7 +61163,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -86978,7 +87281,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -87018,7 +87321,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -87030,8 +87333,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -89955,7 +90258,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -90234,7 +90537,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -90260,7 +90563,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -90379,7 +90682,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -90398,12 +90701,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -90706,7 +91009,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -90720,7 +91023,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -90731,7 +91034,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -90773,26 +91076,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime322 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+var import_runtime332 = __toESM(require_commonjs(), 1);
+var import_runtime333 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
 var import_runtime325 = __toESM(require_commonjs(), 1);
 var import_runtime326 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime316 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
 var import_runtime319 = __toESM(require_commonjs(), 1);
 var import_runtime320 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var import_runtime313 = __toESM(require_commonjs(), 1);
-var import_runtime314 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime314.MessageType {
+var import_runtime321 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime321.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -90816,9 +91119,9 @@ var CacheScope$Type = class extends import_runtime314.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime313.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime320.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime312.reflectionMergePartial)(this, message, value);
+      (0, import_runtime319.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90840,26 +91143,26 @@ var CacheScope$Type = class extends import_runtime314.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime311.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime318.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime310.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime317.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime310.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime317.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime311.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime318.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime320.MessageType {
+var CacheMetadata$Type = class extends import_runtime327.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -90877,9 +91180,9 @@ var CacheMetadata$Type = class extends import_runtime320.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime319.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime326.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime318.reflectionMergePartial)(this, message, value);
+      (0, import_runtime325.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90901,27 +91204,27 @@ var CacheMetadata$Type = class extends import_runtime320.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime317.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime324.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime316.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime323.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime316.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime323.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime317.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime324.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime326.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -90946,9 +91249,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime326.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90974,27 +91277,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime326.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime322.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime329.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime326.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -91025,9 +91328,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime326.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91053,26 +91356,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime326.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime322.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime329.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime326.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -91104,9 +91407,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime326.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91136,29 +91439,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime326.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime322.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime329.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime322.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime329.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime322.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime329.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime326.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -91189,9 +91492,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime326.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91217,26 +91520,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime326.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime322.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime329.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime322.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime329.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime326.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -91269,9 +91572,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime326.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91301,29 +91604,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime326.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime322.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime329.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime322.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime329.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime326.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -91354,9 +91657,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime326.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91382,21 +91685,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime326.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime322.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime329.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -91668,7 +91971,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -91744,16 +92047,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -91803,7 +92106,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -91812,7 +92115,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -91828,7 +92131,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -91837,7 +92140,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -91880,7 +92183,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -92006,7 +92309,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -92077,7 +92380,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -92143,7 +92446,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92218,7 +92521,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92294,335 +92597,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/dataflow-template-build/dist/index.cjs
+++ b/dataflow-template-build/dist/index.cjs
@@ -92444,18 +92444,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -92476,6 +92482,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -92494,7 +92501,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/dataflow-template-build/dist/index.cjs
+++ b/dataflow-template-build/dist/index.cjs
@@ -61431,16 +61431,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61549,13 +61549,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61585,7 +61585,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61611,7 +61611,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61633,7 +61633,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61644,7 +61644,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61665,7 +61665,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92444,6 +92444,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92459,7 +92468,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92473,6 +92482,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92512,7 +92526,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/dataflow-template-build/dist/index.cjs
+++ b/dataflow-template-build/dist/index.cjs
@@ -92444,13 +92444,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -92470,6 +92477,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -92486,7 +92494,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/dataflow-template-build/dist/index.cjs
+++ b/dataflow-template-build/dist/index.cjs
@@ -57787,15 +57787,318 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -57833,10 +58136,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -57844,7 +58147,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -57884,7 +58187,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -57922,10 +58225,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -57996,13 +58299,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -58019,12 +58322,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -58043,8 +58346,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -58055,12 +58358,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -58096,7 +58399,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -58121,8 +58424,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -58160,10 +58463,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -58406,7 +58709,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -58430,7 +58733,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -58440,7 +58743,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -58476,7 +58779,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -58488,10 +58791,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -58547,8 +58850,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -58648,16 +58951,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -58675,7 +58978,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -58698,7 +59001,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -58744,7 +59047,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -58781,7 +59084,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -58796,11 +59099,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -60796,7 +61099,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -60804,7 +61107,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -86922,7 +87225,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -86962,7 +87265,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -86974,8 +87277,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -89899,7 +90202,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -90178,7 +90481,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -90204,7 +90507,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -90323,7 +90626,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -90342,12 +90645,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -90650,7 +90953,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -90664,7 +90967,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -90675,7 +90978,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -90717,26 +91020,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -90760,9 +91063,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90784,26 +91087,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -90821,9 +91124,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90845,27 +91148,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -90890,9 +91193,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90918,27 +91221,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -90969,9 +91272,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90997,26 +91300,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -91048,9 +91351,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91080,29 +91383,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -91133,9 +91436,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91161,26 +91464,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -91213,9 +91516,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91245,29 +91548,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -91298,9 +91601,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91326,21 +91629,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -91612,7 +91915,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -91688,16 +91991,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -91747,7 +92050,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -91756,7 +92059,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -91772,7 +92075,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -91781,7 +92084,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -91824,7 +92127,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -91950,7 +92253,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -92021,7 +92324,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -92087,7 +92390,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92162,7 +92465,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92238,335 +92541,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/external-events/dist/index.cjs
+++ b/external-events/dist/index.cjs
@@ -82050,16 +82050,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -82168,13 +82168,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -82204,7 +82204,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -82230,7 +82230,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -82252,7 +82252,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -82263,7 +82263,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -82284,7 +82284,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -113074,6 +113074,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -113089,7 +113098,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -113103,6 +113112,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -113150,7 +113164,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -113176,11 +113190,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -113198,7 +113212,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -113418,7 +113432,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/external-events/dist/index.cjs
+++ b/external-events/dist/index.cjs
@@ -113074,18 +113074,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type2, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type2 === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -113106,6 +113112,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type: type2,
   projectId,
   email,
   credentialsFilePath,
@@ -113124,7 +113131,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type2, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/external-events/dist/index.cjs
+++ b/external-events/dist/index.cjs
@@ -113074,13 +113074,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -113100,6 +113107,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -113116,7 +113124,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -113197,6 +113205,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/external-events/dist/index.cjs
+++ b/external-events/dist/index.cjs
@@ -78406,15 +78406,363 @@ __name(camelcaseKeys, "camelcaseKeys");
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type: type2, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type: type2,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -78452,10 +78800,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -78463,7 +78811,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -78503,7 +78851,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -78541,10 +78889,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -78615,13 +78963,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -78638,12 +78986,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -78662,8 +79010,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -78674,12 +79022,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -78715,7 +79063,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -78740,8 +79088,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -78779,10 +79127,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -79025,7 +79373,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -79049,7 +79397,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -79059,7 +79407,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -79095,7 +79443,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -79107,10 +79455,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -79166,8 +79514,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -79267,16 +79615,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -79294,7 +79642,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -79317,7 +79665,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -79363,7 +79711,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -79400,7 +79748,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -79415,11 +79763,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -81415,7 +81763,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -81423,7 +81771,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map2) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map2.set("Bun", `${versions.bun} (${osInfo})`);
@@ -107542,7 +107890,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -107582,7 +107930,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -107594,8 +107942,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -110519,7 +110867,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -110798,7 +111146,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -110824,7 +111172,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -110943,7 +111291,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -110962,12 +111310,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -111270,7 +111618,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -111284,7 +111632,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -111295,7 +111643,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -111337,26 +111685,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+var import_runtime332 = __toESM(require_commonjs(), 1);
+var import_runtime333 = __toESM(require_commonjs(), 1);
+var import_runtime334 = __toESM(require_commonjs(), 1);
+var import_runtime335 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime325 = __toESM(require_commonjs(), 1);
 var import_runtime326 = __toESM(require_commonjs(), 1);
 var import_runtime327 = __toESM(require_commonjs(), 1);
 var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime318 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime319 = __toESM(require_commonjs(), 1);
 var import_runtime320 = __toESM(require_commonjs(), 1);
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var import_runtime313 = __toESM(require_commonjs(), 1);
-var import_runtime314 = __toESM(require_commonjs(), 1);
-var import_runtime315 = __toESM(require_commonjs(), 1);
-var import_runtime316 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime316.MessageType {
+var import_runtime323 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime323.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -111380,9 +111728,9 @@ var CacheScope$Type = class extends import_runtime316.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime315.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime322.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime314.reflectionMergePartial)(this, message, value);
+      (0, import_runtime321.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111404,26 +111752,26 @@ var CacheScope$Type = class extends import_runtime316.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime313.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime320.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime312.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime319.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime312.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime319.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime313.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime320.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime322.MessageType {
+var CacheMetadata$Type = class extends import_runtime329.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -111441,9 +111789,9 @@ var CacheMetadata$Type = class extends import_runtime322.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime321.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime328.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime320.reflectionMergePartial)(this, message, value);
+      (0, import_runtime327.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111465,27 +111813,27 @@ var CacheMetadata$Type = class extends import_runtime322.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime319.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime326.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime318.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime325.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime318.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime325.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime319.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime326.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime328.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -111510,9 +111858,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime328.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111538,27 +111886,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime328.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime324.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime331.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime328.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -111589,9 +111937,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime328.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111617,26 +111965,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime328.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime324.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime331.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime328.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -111668,9 +112016,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime328.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111700,29 +112048,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime328.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime324.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime331.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime324.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime331.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime324.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime331.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime328.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -111753,9 +112101,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime328.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111781,26 +112129,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime328.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime324.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime331.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime324.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime331.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime328.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -111833,9 +112181,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime328.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111865,29 +112213,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime328.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime324.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime331.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime324.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime331.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime328.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -111918,9 +112266,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime328.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -111946,21 +112294,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime328.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime324.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime331.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -112232,7 +112580,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -112308,16 +112656,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type2) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -112367,7 +112715,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -112376,7 +112724,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -112392,7 +112740,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -112401,7 +112749,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -112444,7 +112792,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -112570,7 +112918,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -112641,7 +112989,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -112707,7 +113055,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -112782,7 +113130,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -112858,380 +113206,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type2, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type2 === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type: type2,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type2, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type: type2, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type: type2,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/gcp-secret-manager/dist/index.cjs
+++ b/gcp-secret-manager/dist/index.cjs
@@ -100012,13 +100012,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100038,6 +100045,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100054,7 +100062,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100135,6 +100143,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/gcp-secret-manager/dist/index.cjs
+++ b/gcp-secret-manager/dist/index.cjs
@@ -65345,15 +65345,363 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65391,10 +65739,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65402,7 +65750,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65442,7 +65790,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65480,10 +65828,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65554,13 +65902,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65577,12 +65925,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65601,8 +65949,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65613,12 +65961,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65654,7 +66002,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65679,8 +66027,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65718,10 +66066,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -65964,7 +66312,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -65988,7 +66336,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -65998,7 +66346,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66034,7 +66382,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66046,10 +66394,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66105,8 +66453,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66206,16 +66554,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66233,7 +66581,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66256,7 +66604,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66302,7 +66650,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66339,7 +66687,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66354,11 +66702,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68354,7 +68702,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68362,7 +68710,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94480,7 +94828,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94520,7 +94868,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94532,8 +94880,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97457,7 +97805,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97736,7 +98084,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97762,7 +98110,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97881,7 +98229,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -97900,12 +98248,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98208,7 +98556,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98222,7 +98570,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98233,7 +98581,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98275,26 +98623,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98318,9 +98666,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98342,26 +98690,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98379,9 +98727,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98403,27 +98751,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98448,9 +98796,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98476,27 +98824,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98527,9 +98875,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98555,26 +98903,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98606,9 +98954,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98638,29 +98986,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98691,9 +99039,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98719,26 +99067,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98771,9 +99119,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98803,29 +99151,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98856,9 +99204,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98884,21 +99232,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99170,7 +99518,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99246,16 +99594,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99305,7 +99653,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99314,7 +99662,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99330,7 +99678,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99339,7 +99687,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99382,7 +99730,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99508,7 +99856,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99579,7 +99927,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99645,7 +99993,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99720,7 +100068,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99796,380 +100144,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/gcp-secret-manager/dist/index.cjs
+++ b/gcp-secret-manager/dist/index.cjs
@@ -68989,16 +68989,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69107,13 +69107,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69143,7 +69143,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69169,7 +69169,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69191,7 +69191,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69202,7 +69202,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69223,7 +69223,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100012,6 +100012,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100027,7 +100036,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100041,6 +100050,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100088,7 +100102,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -100114,11 +100128,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -100136,7 +100150,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100356,7 +100370,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/gcp-secret-manager/dist/index.cjs
+++ b/gcp-secret-manager/dist/index.cjs
@@ -100012,18 +100012,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100044,6 +100050,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100062,7 +100069,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/iam-test-token/dist/index.cjs
+++ b/iam-test-token/dist/index.cjs
@@ -100012,13 +100012,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100038,6 +100045,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100054,7 +100062,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100135,6 +100143,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/iam-test-token/dist/index.cjs
+++ b/iam-test-token/dist/index.cjs
@@ -65345,15 +65345,363 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65391,10 +65739,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65402,7 +65750,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65442,7 +65790,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65480,10 +65828,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65554,13 +65902,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65577,12 +65925,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65601,8 +65949,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65613,12 +65961,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65654,7 +66002,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65679,8 +66027,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65718,10 +66066,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -65964,7 +66312,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -65988,7 +66336,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -65998,7 +66346,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66034,7 +66382,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66046,10 +66394,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66105,8 +66453,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66206,16 +66554,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66233,7 +66581,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66256,7 +66604,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66302,7 +66650,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66339,7 +66687,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66354,11 +66702,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68354,7 +68702,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68362,7 +68710,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94480,7 +94828,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94520,7 +94868,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94532,8 +94880,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97457,7 +97805,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97736,7 +98084,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97762,7 +98110,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97881,7 +98229,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -97900,12 +98248,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98208,7 +98556,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98222,7 +98570,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98233,7 +98581,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98275,26 +98623,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98318,9 +98666,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98342,26 +98690,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98379,9 +98727,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98403,27 +98751,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98448,9 +98796,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98476,27 +98824,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98527,9 +98875,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98555,26 +98903,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98606,9 +98954,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98638,29 +98986,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98691,9 +99039,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98719,26 +99067,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98771,9 +99119,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98803,29 +99151,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98856,9 +99204,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98884,21 +99232,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99170,7 +99518,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99246,16 +99594,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99305,7 +99653,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99314,7 +99662,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99330,7 +99678,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99339,7 +99687,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99382,7 +99730,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99508,7 +99856,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99579,7 +99927,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99645,7 +99993,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99720,7 +100068,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99796,380 +100144,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/iam-test-token/dist/index.cjs
+++ b/iam-test-token/dist/index.cjs
@@ -68989,16 +68989,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69107,13 +69107,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69143,7 +69143,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69169,7 +69169,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69191,7 +69191,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69202,7 +69202,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69223,7 +69223,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100012,6 +100012,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100027,7 +100036,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100041,6 +100050,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100088,7 +100102,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -100114,11 +100128,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -100136,7 +100150,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100356,7 +100370,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/iam-test-token/dist/index.cjs
+++ b/iam-test-token/dist/index.cjs
@@ -100012,18 +100012,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100044,6 +100050,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100062,7 +100069,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/iam/dist/index.cjs
+++ b/iam/dist/index.cjs
@@ -101390,18 +101390,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -101422,6 +101428,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -101440,7 +101447,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/iam/dist/index.cjs
+++ b/iam/dist/index.cjs
@@ -66723,15 +66723,363 @@ var fetchIamToken = /* @__PURE__ */ __name(async (apiKey, apiEmail, apiPassword,
 }), "fetchIamToken");
 var iam_auth_default = fetchIamToken;
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -66769,10 +67117,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -66780,7 +67128,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -66820,7 +67168,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -66858,10 +67206,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -66932,13 +67280,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -66955,12 +67303,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -66979,8 +67327,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -66991,12 +67339,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -67032,7 +67380,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -67057,8 +67405,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -67096,10 +67444,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -67342,7 +67690,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -67366,7 +67714,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -67376,7 +67724,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -67412,7 +67760,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -67424,10 +67772,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -67483,8 +67831,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -67584,16 +67932,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -67611,7 +67959,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -67634,7 +67982,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -67680,7 +68028,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -67717,7 +68065,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -67732,11 +68080,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -69732,7 +70080,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -69740,7 +70088,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -95858,7 +96206,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -95898,7 +96246,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -95910,8 +96258,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -98835,7 +99183,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -99114,7 +99462,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -99140,7 +99488,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -99259,7 +99607,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -99278,12 +99626,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -99586,7 +99934,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -99600,7 +99948,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -99611,7 +99959,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -99653,26 +100001,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime322 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+var import_runtime332 = __toESM(require_commonjs(), 1);
+var import_runtime333 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
 var import_runtime325 = __toESM(require_commonjs(), 1);
 var import_runtime326 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime316 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
 var import_runtime319 = __toESM(require_commonjs(), 1);
 var import_runtime320 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var import_runtime313 = __toESM(require_commonjs(), 1);
-var import_runtime314 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime314.MessageType {
+var import_runtime321 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime321.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -99696,9 +100044,9 @@ var CacheScope$Type = class extends import_runtime314.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime313.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime320.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime312.reflectionMergePartial)(this, message, value);
+      (0, import_runtime319.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99720,26 +100068,26 @@ var CacheScope$Type = class extends import_runtime314.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime311.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime318.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime310.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime317.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime310.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime317.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime311.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime318.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime320.MessageType {
+var CacheMetadata$Type = class extends import_runtime327.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -99757,9 +100105,9 @@ var CacheMetadata$Type = class extends import_runtime320.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime319.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime326.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime318.reflectionMergePartial)(this, message, value);
+      (0, import_runtime325.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99781,27 +100129,27 @@ var CacheMetadata$Type = class extends import_runtime320.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime317.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime324.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime316.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime323.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime316.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime323.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime317.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime324.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime326.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -99826,9 +100174,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime326.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99854,27 +100202,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime326.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime322.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime329.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime326.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -99905,9 +100253,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime326.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99933,26 +100281,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime326.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime322.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime329.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime326.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -99984,9 +100332,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime326.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100016,29 +100364,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime326.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime322.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime329.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime322.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime329.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime322.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime329.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime326.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -100069,9 +100417,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime326.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100097,26 +100445,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime326.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime322.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime329.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime322.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime329.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime326.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -100149,9 +100497,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime326.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100181,29 +100529,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime326.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime322.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime329.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime322.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime329.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime326.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime333.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -100234,9 +100582,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime326.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime332.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime324.reflectionMergePartial)(this, message, value);
+      (0, import_runtime331.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100262,21 +100610,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime326.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime330.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime322.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime329.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime322.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime329.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime322.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime329.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime330.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -100548,7 +100896,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -100624,16 +100972,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -100683,7 +101031,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -100692,7 +101040,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -100708,7 +101056,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -100717,7 +101065,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -100760,7 +101108,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -100886,7 +101234,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -100957,7 +101305,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -101023,7 +101371,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101098,7 +101446,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101174,380 +101522,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);
@@ -101778,7 +101752,7 @@ async function getIdToken(audience) {
     throw new Error("No authenticated service account");
   }
   const args = ["auth", "print-identity-token", `--audiences=${audience}`];
-  if (account.type === "wid_federation") {
+  if (account.type === authType.widFederation) {
     args.push(
       `--impersonate-service-account=${account.email}`,
       "--include-email"

--- a/iam/dist/index.cjs
+++ b/iam/dist/index.cjs
@@ -70367,16 +70367,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70485,13 +70485,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70521,7 +70521,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70547,7 +70547,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70569,7 +70569,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70580,7 +70580,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70601,7 +70601,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101390,6 +101390,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101405,7 +101414,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101419,6 +101428,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101466,7 +101480,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -101492,11 +101506,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -101514,7 +101528,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -101734,7 +101748,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/iam/dist/index.cjs
+++ b/iam/dist/index.cjs
@@ -101390,13 +101390,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -101416,6 +101423,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -101432,7 +101440,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101513,6 +101521,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/identity-token/dist/index.cjs
+++ b/identity-token/dist/index.cjs
@@ -92444,18 +92444,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -92476,6 +92482,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -92494,7 +92501,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/identity-token/dist/index.cjs
+++ b/identity-token/dist/index.cjs
@@ -61431,16 +61431,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61549,13 +61549,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61585,7 +61585,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61611,7 +61611,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61633,7 +61633,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61644,7 +61644,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61665,7 +61665,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92444,6 +92444,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92459,7 +92468,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92473,6 +92482,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92512,7 +92526,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/identity-token/dist/index.cjs
+++ b/identity-token/dist/index.cjs
@@ -92444,13 +92444,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -92470,6 +92477,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -92486,7 +92494,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/identity-token/dist/index.cjs
+++ b/identity-token/dist/index.cjs
@@ -57787,15 +57787,318 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -57833,10 +58136,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -57844,7 +58147,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -57884,7 +58187,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -57922,10 +58225,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -57996,13 +58299,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -58019,12 +58322,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -58043,8 +58346,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -58055,12 +58358,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -58096,7 +58399,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -58121,8 +58424,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -58160,10 +58463,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -58406,7 +58709,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -58430,7 +58733,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -58440,7 +58743,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -58476,7 +58779,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -58488,10 +58791,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -58547,8 +58850,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -58648,16 +58951,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -58675,7 +58978,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -58698,7 +59001,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -58744,7 +59047,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -58781,7 +59084,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -58796,11 +59099,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -60796,7 +61099,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -60804,7 +61107,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -86922,7 +87225,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -86962,7 +87265,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -86974,8 +87277,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -89899,7 +90202,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -90178,7 +90481,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -90204,7 +90507,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -90323,7 +90626,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -90342,12 +90645,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -90650,7 +90953,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -90664,7 +90967,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -90675,7 +90978,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -90717,26 +91020,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -90760,9 +91063,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90784,26 +91087,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -90821,9 +91124,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90845,27 +91148,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -90890,9 +91193,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90918,27 +91221,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -90969,9 +91272,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90997,26 +91300,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -91048,9 +91351,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91080,29 +91383,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -91133,9 +91436,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91161,26 +91464,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -91213,9 +91516,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91245,29 +91548,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -91298,9 +91601,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91326,21 +91629,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -91612,7 +91915,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -91688,16 +91991,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -91747,7 +92050,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -91756,7 +92059,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -91772,7 +92075,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -91781,7 +92084,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -91824,7 +92127,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -91950,7 +92253,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -92021,7 +92324,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -92087,7 +92390,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92162,7 +92465,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92238,335 +92541,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/kubernetes/dist/index.cjs
+++ b/kubernetes/dist/index.cjs
@@ -101793,13 +101793,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -101819,6 +101826,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -101835,7 +101843,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/kubernetes/dist/index.cjs
+++ b/kubernetes/dist/index.cjs
@@ -70780,16 +70780,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70898,13 +70898,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70934,7 +70934,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70960,7 +70960,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70982,7 +70982,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70993,7 +70993,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -71014,7 +71014,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101793,6 +101793,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101808,7 +101817,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101822,6 +101831,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101861,7 +101875,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/kubernetes/dist/index.cjs
+++ b/kubernetes/dist/index.cjs
@@ -101793,18 +101793,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -101825,6 +101831,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -101843,7 +101850,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/kubernetes/dist/index.cjs
+++ b/kubernetes/dist/index.cjs
@@ -67136,15 +67136,318 @@ var authenticateKubeCtl = /* @__PURE__ */ __name(async ({ cluster, clusterLocati
 ]), "authenticateKubeCtl");
 var kubectl_auth_default = authenticateKubeCtl;
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs3.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs5 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
+    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs7 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs6 = __toESM(require("fs"), 1);
+var fs9 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -67182,10 +67485,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -67193,7 +67496,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -67233,7 +67536,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -67271,10 +67574,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -67345,13 +67648,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -67368,12 +67671,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -67392,8 +67695,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -67404,12 +67707,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -67445,7 +67748,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -67470,8 +67773,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -67509,10 +67812,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -67755,7 +68058,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs6.promises.lstat(searchPath));
+          yield __await(fs9.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -67779,7 +68082,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -67789,7 +68092,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs6.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs9.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -67825,7 +68128,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs6.promises.stat(item.path);
+          stats = yield fs9.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -67837,10 +68140,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs6.promises.lstat(item.path);
+        stats = yield fs9.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs6.promises.realpath(item.path);
+        const realPath = yield fs9.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -67896,8 +68199,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs7 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs10 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -67997,16 +68300,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs7.statSync(filePath).size;
+  return fs10.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -68024,7 +68327,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -68047,7 +68350,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs7.unlink)(filePath);
+    return util4.promisify(fs10.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -68093,7 +68396,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs7.existsSync(GnuTarPathOnWindows)) {
+    if (fs10.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -68130,7 +68433,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs10 = __toESM(require("fs"), 1);
+var fs13 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -68145,11 +68448,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -70145,7 +70448,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -70153,7 +70456,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -96271,7 +96574,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -96311,7 +96614,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs3.default.createWriteStream(file);
+    const ws = import_node_fs6.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -96323,8 +96626,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs3.default.stat);
-var fsCreateReadStream = import_node_fs3.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs6.default.stat);
+var fsCreateReadStream = import_node_fs6.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -99248,7 +99551,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -99527,7 +99830,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs9.createWriteStream(archivePath);
+    const writeStream = fs12.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -99553,7 +99856,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs9.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs12.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -99672,7 +99975,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs9.openSync(archivePath, "w");
+      const fd = fs12.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -99691,12 +99994,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs9.writeFileSync(fd, result);
+            fs12.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs9.closeSync(fd);
+        fs12.closeSync(fd);
       }
     }
   });
@@ -99999,7 +100302,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs10.openSync(archivePath, "r");
+    const fd = fs13.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -100013,7 +100316,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs10.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs13.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -100024,7 +100327,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs10.closeSync(fd);
+      fs13.closeSync(fd);
     }
     return;
   });
@@ -100066,26 +100369,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+var import_runtime332 = __toESM(require_commonjs(), 1);
+var import_runtime333 = __toESM(require_commonjs(), 1);
+var import_runtime334 = __toESM(require_commonjs(), 1);
+var import_runtime335 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime325 = __toESM(require_commonjs(), 1);
 var import_runtime326 = __toESM(require_commonjs(), 1);
 var import_runtime327 = __toESM(require_commonjs(), 1);
 var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime318 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime319 = __toESM(require_commonjs(), 1);
 var import_runtime320 = __toESM(require_commonjs(), 1);
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var import_runtime313 = __toESM(require_commonjs(), 1);
-var import_runtime314 = __toESM(require_commonjs(), 1);
-var import_runtime315 = __toESM(require_commonjs(), 1);
-var import_runtime316 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime316.MessageType {
+var import_runtime323 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime323.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -100109,9 +100412,9 @@ var CacheScope$Type = class extends import_runtime316.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime315.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime322.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime314.reflectionMergePartial)(this, message, value);
+      (0, import_runtime321.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100133,26 +100436,26 @@ var CacheScope$Type = class extends import_runtime316.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime313.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime320.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime312.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime319.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime312.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime319.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime313.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime320.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime322.MessageType {
+var CacheMetadata$Type = class extends import_runtime329.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -100170,9 +100473,9 @@ var CacheMetadata$Type = class extends import_runtime322.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime321.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime328.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime320.reflectionMergePartial)(this, message, value);
+      (0, import_runtime327.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100194,27 +100497,27 @@ var CacheMetadata$Type = class extends import_runtime322.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime319.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime326.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime318.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime325.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime318.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime325.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime319.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime326.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime328.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -100239,9 +100542,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime328.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100267,27 +100570,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime328.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime324.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime331.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime328.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -100318,9 +100621,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime328.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100346,26 +100649,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime328.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime324.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime331.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime328.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -100397,9 +100700,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime328.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100429,29 +100732,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime328.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime324.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime331.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime324.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime331.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime324.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime331.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime328.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -100482,9 +100785,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime328.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100510,26 +100813,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime328.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime324.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime331.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime324.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime331.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime328.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -100562,9 +100865,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime328.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100594,29 +100897,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime328.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime324.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime331.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime324.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime331.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime328.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime335.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -100647,9 +100950,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime328.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime327.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime334.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime326.reflectionMergePartial)(this, message, value);
+      (0, import_runtime333.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100675,21 +100978,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime328.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime325.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime332.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime324.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime331.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime324.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime331.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime324.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime331.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime325.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime332.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -100961,7 +101264,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -101037,16 +101340,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -101096,7 +101399,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -101105,7 +101408,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -101121,7 +101424,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -101130,7 +101433,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -101173,7 +101476,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -101299,7 +101602,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -101370,7 +101673,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -101436,7 +101739,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101511,7 +101814,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101587,335 +101890,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs4.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs4.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs4.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs4.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs6 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs5.default.existsSync(jobScopedDir)) {
-    import_node_fs5.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs5.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs6.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/nexus-auth-npm/dist/index.cjs
+++ b/nexus-auth-npm/dist/index.cjs
@@ -100024,18 +100024,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100056,6 +100062,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100074,7 +100081,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/nexus-auth-npm/dist/index.cjs
+++ b/nexus-auth-npm/dist/index.cjs
@@ -100024,13 +100024,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100050,6 +100057,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100066,7 +100074,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100147,6 +100155,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/nexus-auth-npm/dist/index.cjs
+++ b/nexus-auth-npm/dist/index.cjs
@@ -65357,15 +65357,363 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65403,10 +65751,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65414,7 +65762,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65454,7 +65802,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65492,10 +65840,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65566,13 +65914,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65589,12 +65937,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65613,8 +65961,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65625,12 +65973,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65666,7 +66014,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65691,8 +66039,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65730,10 +66078,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -65976,7 +66324,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -66000,7 +66348,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -66010,7 +66358,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66046,7 +66394,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66058,10 +66406,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66117,8 +66465,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66218,16 +66566,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66245,7 +66593,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66268,7 +66616,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66314,7 +66662,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66351,7 +66699,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66366,11 +66714,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68366,7 +68714,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68374,7 +68722,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94492,7 +94840,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94532,7 +94880,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94544,8 +94892,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97469,7 +97817,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97748,7 +98096,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97774,7 +98122,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97893,7 +98241,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -97912,12 +98260,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98220,7 +98568,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98234,7 +98582,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98245,7 +98593,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98287,26 +98635,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98330,9 +98678,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98354,26 +98702,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98391,9 +98739,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98415,27 +98763,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98460,9 +98808,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98488,27 +98836,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98539,9 +98887,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98567,26 +98915,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98618,9 +98966,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98650,29 +98998,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98703,9 +99051,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98731,26 +99079,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98783,9 +99131,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98815,29 +99163,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98868,9 +99216,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98896,21 +99244,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99182,7 +99530,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99258,16 +99606,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99317,7 +99665,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99326,7 +99674,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99342,7 +99690,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99351,7 +99699,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99394,7 +99742,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99520,7 +99868,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99591,7 +99939,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99657,7 +100005,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99732,7 +100080,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99808,380 +100156,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/nexus-auth-npm/dist/index.cjs
+++ b/nexus-auth-npm/dist/index.cjs
@@ -69001,16 +69001,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69119,13 +69119,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69155,7 +69155,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69181,7 +69181,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69203,7 +69203,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69214,7 +69214,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69235,7 +69235,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100024,6 +100024,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100039,7 +100048,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100053,6 +100062,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100100,7 +100114,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -100126,11 +100140,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -100148,7 +100162,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100368,7 +100382,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -68990,16 +68990,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69108,13 +69108,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69144,7 +69144,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69170,7 +69170,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69192,7 +69192,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69203,7 +69203,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69224,7 +69224,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100003,6 +100003,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100018,7 +100027,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100032,6 +100041,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100071,7 +100085,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -100003,18 +100003,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100035,6 +100041,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100053,7 +100060,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -100003,13 +100003,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100029,6 +100036,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100045,7 +100053,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -65346,15 +65346,318 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
 var import_node_fs10 = __toESM(require("node:fs"), 1);
 var import_node_path8 = __toESM(require("node:path"), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65392,10 +65695,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65403,7 +65706,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65443,7 +65746,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65481,10 +65784,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65555,13 +65858,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65578,12 +65881,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65602,8 +65905,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65614,12 +65917,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65655,7 +65958,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65680,8 +65983,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65719,10 +66022,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -65965,7 +66268,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -65989,7 +66292,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -65999,7 +66302,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66035,7 +66338,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66047,10 +66350,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66106,8 +66409,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66207,16 +66510,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66234,7 +66537,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66257,7 +66560,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66303,7 +66606,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66340,7 +66643,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66355,11 +66658,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68355,7 +68658,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68363,7 +68666,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94481,7 +94784,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94521,7 +94824,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94533,8 +94836,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97458,7 +97761,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97737,7 +98040,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97763,7 +98066,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97882,7 +98185,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -97901,12 +98204,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98209,7 +98512,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98223,7 +98526,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98234,7 +98537,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98276,26 +98579,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98319,9 +98622,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98343,26 +98646,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98380,9 +98683,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98404,27 +98707,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98449,9 +98752,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98477,27 +98780,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98528,9 +98831,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98556,26 +98859,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98607,9 +98910,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98639,29 +98942,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98692,9 +98995,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98720,26 +99023,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98772,9 +99075,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98804,29 +99107,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98857,9 +99160,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98885,21 +99188,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99171,7 +99474,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99247,16 +99550,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99306,7 +99609,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99315,7 +99618,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99331,7 +99634,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99340,7 +99643,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99383,7 +99686,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99509,7 +99812,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99580,7 +99883,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99646,7 +99949,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99721,7 +100024,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99797,335 +100100,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/repository-dispatch/dist/index.cjs
+++ b/repository-dispatch/dist/index.cjs
@@ -104774,13 +104774,20 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -104800,6 +104807,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -104816,7 +104824,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -104897,6 +104905,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/repository-dispatch/dist/index.cjs
+++ b/repository-dispatch/dist/index.cjs
@@ -104774,18 +104774,24 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -104806,6 +104812,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -104824,7 +104831,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/repository-dispatch/dist/index.cjs
+++ b/repository-dispatch/dist/index.cjs
@@ -73748,16 +73748,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -73866,13 +73866,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -73902,7 +73902,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -73928,7 +73928,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -73950,7 +73950,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -73961,7 +73961,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -73982,7 +73982,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -104774,6 +104774,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -104789,7 +104798,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -104803,6 +104812,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -104850,7 +104864,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -104876,11 +104890,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -104898,7 +104912,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -105118,7 +105132,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/repository-dispatch/dist/index.cjs
+++ b/repository-dispatch/dist/index.cjs
@@ -70104,15 +70104,363 @@ __name(getOctokit, "getOctokit");
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth2, current) {
+  if (current) {
+    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -70150,10 +70498,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -70161,7 +70509,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -70201,7 +70549,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -70239,10 +70587,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -70313,13 +70661,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -70336,12 +70684,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -70360,8 +70708,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -70372,12 +70720,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -70413,7 +70761,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -70438,8 +70786,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -70477,10 +70825,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -70723,7 +71071,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -70747,7 +71095,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -70757,7 +71105,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -70793,7 +71141,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -70805,10 +71153,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -70864,8 +71212,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -70965,16 +71313,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -70992,7 +71340,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -71015,7 +71363,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter15(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -71061,7 +71409,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter15(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -71098,7 +71446,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -71113,11 +71461,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -73113,7 +73461,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -73121,7 +73469,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -99242,7 +99590,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -99282,7 +99630,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -99294,8 +99642,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -102219,7 +102567,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -102498,7 +102846,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter18(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient2 = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter18(this, void 0, void 0, function* () {
       return httpClient2.get(archiveLocation);
@@ -102524,7 +102872,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient2 = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -102643,7 +102991,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -102662,12 +103010,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -102970,7 +103318,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
   return __awaiter19(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -102984,7 +103332,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient2, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient2, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -102995,7 +103343,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -103037,26 +103385,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime339 = __toESM(require_commonjs(), 1);
+var import_runtime346 = __toESM(require_commonjs(), 1);
+var import_runtime347 = __toESM(require_commonjs(), 1);
+var import_runtime348 = __toESM(require_commonjs(), 1);
+var import_runtime349 = __toESM(require_commonjs(), 1);
+var import_runtime350 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime340 = __toESM(require_commonjs(), 1);
 var import_runtime341 = __toESM(require_commonjs(), 1);
 var import_runtime342 = __toESM(require_commonjs(), 1);
 var import_runtime343 = __toESM(require_commonjs(), 1);
+var import_runtime344 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime333 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime334 = __toESM(require_commonjs(), 1);
 var import_runtime335 = __toESM(require_commonjs(), 1);
 var import_runtime336 = __toESM(require_commonjs(), 1);
 var import_runtime337 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime327 = __toESM(require_commonjs(), 1);
-var import_runtime328 = __toESM(require_commonjs(), 1);
-var import_runtime329 = __toESM(require_commonjs(), 1);
-var import_runtime330 = __toESM(require_commonjs(), 1);
-var import_runtime331 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime331.MessageType {
+var import_runtime338 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -103080,9 +103428,9 @@ var CacheScope$Type = class extends import_runtime331.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103104,26 +103452,26 @@ var CacheScope$Type = class extends import_runtime331.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime327.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime334.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime327.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime334.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime337.MessageType {
+var CacheMetadata$Type = class extends import_runtime344.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -103141,9 +103489,9 @@ var CacheMetadata$Type = class extends import_runtime337.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime343.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime335.reflectionMergePartial)(this, message, value);
+      (0, import_runtime342.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103165,27 +103513,27 @@ var CacheMetadata$Type = class extends import_runtime337.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime341.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime333.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime340.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime333.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime340.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime341.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime343.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -103210,9 +103558,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime343.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103238,27 +103586,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime343.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime339.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime346.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime343.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -103289,9 +103637,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime343.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103317,26 +103665,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime343.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime339.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime346.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime343.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -103368,9 +103716,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime343.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103400,29 +103748,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime343.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime339.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime346.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime339.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime346.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime339.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime346.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime343.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -103453,9 +103801,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime343.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103481,26 +103829,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime343.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime339.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime346.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime339.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime346.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime343.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -103533,9 +103881,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime343.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103565,29 +103913,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime343.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime339.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime346.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime339.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime346.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime343.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -103618,9 +103966,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime343.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103646,21 +103994,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime343.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime339.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime346.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -103932,7 +104280,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs3 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter21 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -104008,16 +104356,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -104067,7 +104415,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -104076,7 +104424,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -104092,7 +104440,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -104101,7 +104449,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -104144,7 +104492,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter21(this, void 0, void 0, function* () {
-    (0, import_fs3.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs3.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -104270,7 +104618,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -104341,7 +104689,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -104407,7 +104755,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -104482,7 +104830,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -104558,380 +104906,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth2, current) {
-  if (current) {
-    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os5 = __toESM(require("os"), 1);

--- a/setup-gcloud/README.md
+++ b/setup-gcloud/README.md
@@ -121,13 +121,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up gcloud with Workload Identity Federation
-        id: gcloud
         uses: extenda/actions/setup-gcloud@v0
         with:
-          service-account-key: ${{ secrets.GCLOUD_AUTH_WIF }}
+          service-account-key: ${{ secrets.GCLOUD_AUTH_PROD }}
 
       - name: Show active project
         run: gcloud config get-value project
@@ -150,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up gcloud
         id: gcloud
@@ -159,68 +158,13 @@ jobs:
           service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
 
       - name: Configure Docker for Artifact Registry or GCR
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker --quiet eu.gcr.io
 
       - name: Build and push Docker image
         run: |
           IMAGE="gcr.io/${{ steps.gcloud.outputs.project-id }}/${IMAGE_NAME}:${GITHUB_SHA}"
           docker build -t "$IMAGE" .
           docker push "$IMAGE"
-```
-
-### Export default credentials for later steps
-
-Use this when later tools or SDKs should authenticate through environment variables instead of calling `gcloud` directly.
-
-```yaml
-on: push
-
-permissions:
-  contents: read
-  id-token: write
-
-jobs:
-  integration-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up gcloud and export application default credentials
-        id: gcloud
-        uses: extenda/actions/setup-gcloud@v0
-        with:
-          service-account-key: ${{ secrets.GCLOUD_AUTH_WIF }}
-          export-default-credentials: true
-
-      - name: Run tests using exported credentials
-        run: |
-          echo "Project: ${{ steps.gcloud.outputs.project-id }}"
-          test -n "$GOOGLE_APPLICATION_CREDENTIALS"
-```
-
-### Fallback example with a service account JSON key
-
-Use this only when Workload Identity Federation is not available.
-
-```yaml
-on: push
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up gcloud with service account JSON key
-        id: gcloud
-        uses: extenda/actions/setup-gcloud@v0
-        with:
-          service-account-key: ${{ secrets.GCLOUD_AUTH_JSON_KEY }}
-
-      - name: List clusters
-        run: gcloud container clusters list --project "${{ steps.gcloud.outputs.project-id }}"
 ```
 
 ## Notes

--- a/setup-gcloud/action.yml
+++ b/setup-gcloud/action.yml
@@ -12,12 +12,11 @@ inputs:
     required: false
     default: latest
   export-default-credentials:
-    deprecationMessage: |
+    deprecationMessage: >
       This input is deprecated. The future default behavior is to always export credentials. This is
-      required for gcloud interoperability with workload identity federation.
-
-      The post step ensures that exported credentials are cleaned up after the job completes, so there
-      are no security implications to always exporting credentials.
+      required for gcloud interoperability with workload identity federation. The post step ensures
+      that exported credentials are cleaned up after the job completes, so there are no security
+      implications to always exporting credentials.
     description: |
       Export the path to the credentials as `GOOGLE_APPLICATION_CREDENTIALS` to be used in subsequent steps.
       Google Cloud CLIs and APIs will automatically use this environment variable to find credentials.

--- a/setup-gcloud/dist/index.cjs
+++ b/setup-gcloud/dist/index.cjs
@@ -57787,15 +57787,360 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
+// setup-gcloud/src/get-access-token.js
+async function introspectToken(accessToken) {
+  if (isDebug()) {
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
+}
+__name(introspectToken, "introspectToken");
+async function getAccessToken() {
+  const current = getCurrentAccount();
+  if (!current) {
+    return null;
+  }
+  const { type, email } = current;
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true).catch((err) => {
+    warning(
+      "Missing permissions to create a long-lived access token. Short-lived 10 minute tokens will be used."
+    );
+    debug2(err.message);
+    return null;
+  });
+  if (accessToken) {
+    setSecret(accessToken);
+    await introspectToken(accessToken);
+  }
+  return accessToken;
+}
+__name(getAccessToken, "getAccessToken");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -57833,10 +58178,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -57844,7 +58189,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -57884,7 +58229,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -57922,10 +58267,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -57996,13 +58341,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -58019,12 +58364,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -58043,8 +58388,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -58055,12 +58400,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -58096,7 +58441,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -58121,8 +58466,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -58160,10 +58505,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -58406,7 +58751,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -58430,7 +58775,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -58440,7 +58785,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -58476,7 +58821,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -58488,10 +58833,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -58547,8 +58892,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -58648,16 +58993,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -58675,7 +59020,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -58698,7 +59043,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -58744,7 +59089,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -58781,7 +59126,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -58796,11 +59141,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -60796,7 +61141,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -60804,7 +61149,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -86922,7 +87267,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -86962,7 +87307,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -86974,8 +87319,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -89899,7 +90244,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -90178,7 +90523,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -90204,7 +90549,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -90323,7 +90668,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -90342,12 +90687,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -90650,7 +90995,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -90664,7 +91009,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -90675,7 +91020,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -90717,26 +91062,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -90760,9 +91105,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90784,26 +91129,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -90821,9 +91166,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90845,27 +91190,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -90890,9 +91235,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90918,27 +91263,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -90969,9 +91314,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -90997,26 +91342,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -91048,9 +91393,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91080,29 +91425,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -91133,9 +91478,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91161,26 +91506,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -91213,9 +91558,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91245,29 +91590,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -91298,9 +91643,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -91326,21 +91671,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -91612,7 +91957,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -91688,16 +92033,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -91747,7 +92092,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -91756,7 +92101,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -91772,7 +92117,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -91781,7 +92126,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -91824,7 +92169,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -91950,7 +92295,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -92021,7 +92366,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -92087,7 +92432,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92162,7 +92507,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -92238,335 +92583,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);
@@ -92727,6 +92743,11 @@ var action5 = /* @__PURE__ */ __name(async () => {
   const version3 = getInput("version") || "latest";
   const exportCredentials = getInput("export-default-credentials") || "false";
   await setup_gcloud_default(serviceAccountKey, version3, exportCredentials === "true");
+  const accessToken = await getAccessToken();
+  if (accessToken) {
+    info(`Export ${env.accessToken}`);
+    exportVariable(env.accessToken, accessToken);
+  }
 }, "action");
 var src_default = action5;
 

--- a/setup-gcloud/dist/index.cjs
+++ b/setup-gcloud/dist/index.cjs
@@ -92444,18 +92444,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -92476,6 +92482,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -92494,7 +92501,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/setup-gcloud/dist/index.cjs
+++ b/setup-gcloud/dist/index.cjs
@@ -61431,16 +61431,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -61549,13 +61549,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -61585,7 +61585,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -61611,7 +61611,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -61633,7 +61633,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -61644,7 +61644,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -61665,7 +61665,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -92444,6 +92444,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -92459,7 +92468,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -92473,6 +92482,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -92512,7 +92526,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/setup-gcloud/dist/index.cjs
+++ b/setup-gcloud/dist/index.cjs
@@ -92444,13 +92444,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -92470,6 +92477,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -92486,7 +92494,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -29142,18 +29142,24 @@ var env = {
 };
 var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
 tyString");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -29174,6 +29180,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -29192,7 +29199,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -25,6 +25,911 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
+// node_modules/ms/index.js
+var require_ms = __commonJS({
+  "node_modules/ms/index.js"(exports2, module2) {
+    var s = 1e3;
+    var m = s * 60;
+    var h = m * 60;
+    var d = h * 24;
+    var w = d * 7;
+    var y = d * 365.25;
+    module2.exports = function(val, options) {
+      options = options || {};
+      var type = typeof val;
+      if (type === "string" && val.length > 0) {
+        return parse(val);
+      } else if (type === "number" && isFinite(val)) {
+        return options.long ? fmtLong(val) : fmtShort(val);
+      }
+      throw new Error(
+        "val is not a non-empty string or a valid number. val=" + JSON.stringify(val)
+      );
+    };
+    function parse(str) {
+      str = String(str);
+      if (str.length > 100) {
+        return;
+      }
+      var match = /^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.
+      exec(
+        str
+      );
+      if (!match) {
+        return;
+      }
+      var n = parseFloat(match[1]);
+      var type = (match[2] || "ms").toLowerCase();
+      switch (type) {
+        case "years":
+        case "year":
+        case "yrs":
+        case "yr":
+        case "y":
+          return n * y;
+        case "weeks":
+        case "week":
+        case "w":
+          return n * w;
+        case "days":
+        case "day":
+        case "d":
+          return n * d;
+        case "hours":
+        case "hour":
+        case "hrs":
+        case "hr":
+        case "h":
+          return n * h;
+        case "minutes":
+        case "minute":
+        case "mins":
+        case "min":
+        case "m":
+          return n * m;
+        case "seconds":
+        case "second":
+        case "secs":
+        case "sec":
+        case "s":
+          return n * s;
+        case "milliseconds":
+        case "millisecond":
+        case "msecs":
+        case "msec":
+        case "ms":
+          return n;
+        default:
+          return void 0;
+      }
+    }
+    __name(parse, "parse");
+    function fmtShort(ms) {
+      var msAbs = Math.abs(ms);
+      if (msAbs >= d) {
+        return Math.round(ms / d) + "d";
+      }
+      if (msAbs >= h) {
+        return Math.round(ms / h) + "h";
+      }
+      if (msAbs >= m) {
+        return Math.round(ms / m) + "m";
+      }
+      if (msAbs >= s) {
+        return Math.round(ms / s) + "s";
+      }
+      return ms + "ms";
+    }
+    __name(fmtShort, "fmtShort");
+    function fmtLong(ms) {
+      var msAbs = Math.abs(ms);
+      if (msAbs >= d) {
+        return plural(ms, msAbs, d, "day");
+      }
+      if (msAbs >= h) {
+        return plural(ms, msAbs, h, "hour");
+      }
+      if (msAbs >= m) {
+        return plural(ms, msAbs, m, "minute");
+      }
+      if (msAbs >= s) {
+        return plural(ms, msAbs, s, "second");
+      }
+      return ms + " ms";
+    }
+    __name(fmtLong, "fmtLong");
+    function plural(ms, msAbs, n, name) {
+      var isPlural = msAbs >= n * 1.5;
+      return Math.round(ms / n) + " " + name + (isPlural ? "s" : "");
+    }
+    __name(plural, "plural");
+  }
+});
+
+// node_modules/debug/src/common.js
+var require_common = __commonJS({
+  "node_modules/debug/src/common.js"(exports2, module2) {
+    function setup(env2) {
+      createDebug.debug = createDebug;
+      createDebug.default = createDebug;
+      createDebug.coerce = coerce;
+      createDebug.disable = disable;
+      createDebug.enable = enable;
+      createDebug.enabled = enabled;
+      createDebug.humanize = require_ms();
+      createDebug.destroy = destroy;
+      Object.keys(env2).forEach((key) => {
+        createDebug[key] = env2[key];
+      });
+      createDebug.names = [];
+      createDebug.skips = [];
+      createDebug.formatters = {};
+      function selectColor(namespace) {
+        let hash = 0;
+        for (let i = 0; i < namespace.length; i++) {
+          hash = (hash << 5) - hash + namespace.charCodeAt(i);
+          hash |= 0;
+        }
+        return createDebug.colors[Math.abs(hash) % createDebug.colors.length];
+      }
+      __name(selectColor, "selectColor");
+      createDebug.selectColor = selectColor;
+      function createDebug(namespace) {
+        let prevTime;
+        let enableOverride = null;
+        let namespacesCache;
+        let enabledCache;
+        function debug3(...args) {
+          if (!debug3.enabled) {
+            return;
+          }
+          const self = debug3;
+          const curr = Number(/* @__PURE__ */ new Date());
+          const ms = curr - (prevTime || curr);
+          self.diff = ms;
+          self.prev = prevTime;
+          self.curr = curr;
+          prevTime = curr;
+          args[0] = createDebug.coerce(args[0]);
+          if (typeof args[0] !== "string") {
+            args.unshift("%O");
+          }
+          let index = 0;
+          args[0] = args[0].replace(/%([a-zA-Z%])/g, (match, format) => {
+            if (match === "%%") {
+              return "%";
+            }
+            index++;
+            const formatter = createDebug.formatters[format];
+            if (typeof formatter === "function") {
+              const val = args[index];
+              match = formatter.call(self, val);
+              args.splice(index, 1);
+              index--;
+            }
+            return match;
+          });
+          createDebug.formatArgs.call(self, args);
+          const logFn = self.log || createDebug.log;
+          logFn.apply(self, args);
+        }
+        __name(debug3, "debug");
+        debug3.namespace = namespace;
+        debug3.useColors = createDebug.useColors();
+        debug3.color = createDebug.selectColor(namespace);
+        debug3.extend = extend;
+        debug3.destroy = createDebug.destroy;
+        Object.defineProperty(debug3, "enabled", {
+          enumerable: true,
+          configurable: false,
+          get: /* @__PURE__ */ __name(() => {
+            if (enableOverride !== null) {
+              return enableOverride;
+            }
+            if (namespacesCache !== createDebug.namespaces) {
+              namespacesCache = createDebug.namespaces;
+              enabledCache = createDebug.enabled(namespace);
+            }
+            return enabledCache;
+          }, "get"),
+          set: /* @__PURE__ */ __name((v) => {
+            enableOverride = v;
+          }, "set")
+        });
+        if (typeof createDebug.init === "function") {
+          createDebug.init(debug3);
+        }
+        return debug3;
+      }
+      __name(createDebug, "createDebug");
+      function extend(namespace, delimiter2) {
+        const newDebug = createDebug(this.namespace + (typeof delimiter2 === "undefined" ? ":" : delimiter2) + namespace);
+        newDebug.log = this.log;
+        return newDebug;
+      }
+      __name(extend, "extend");
+      function enable(namespaces) {
+        createDebug.save(namespaces);
+        createDebug.namespaces = namespaces;
+        createDebug.names = [];
+        createDebug.skips = [];
+        const split = (typeof namespaces === "string" ? namespaces : "").trim().replace(/\s+/g, ",").split(",").filter(Boolean);
+        for (const ns of split) {
+          if (ns[0] === "-") {
+            createDebug.skips.push(ns.slice(1));
+          } else {
+            createDebug.names.push(ns);
+          }
+        }
+      }
+      __name(enable, "enable");
+      function matchesTemplate(search, template) {
+        let searchIndex = 0;
+        let templateIndex = 0;
+        let starIndex = -1;
+        let matchIndex = 0;
+        while (searchIndex < search.length) {
+          if (templateIndex < template.length && (template[templateIndex] === search[searchIndex] || template[templateIndex] ===
+          "*")) {
+            if (template[templateIndex] === "*") {
+              starIndex = templateIndex;
+              matchIndex = searchIndex;
+              templateIndex++;
+            } else {
+              searchIndex++;
+              templateIndex++;
+            }
+          } else if (starIndex !== -1) {
+            templateIndex = starIndex + 1;
+            matchIndex++;
+            searchIndex = matchIndex;
+          } else {
+            return false;
+          }
+        }
+        while (templateIndex < template.length && template[templateIndex] === "*") {
+          templateIndex++;
+        }
+        return templateIndex === template.length;
+      }
+      __name(matchesTemplate, "matchesTemplate");
+      function disable() {
+        const namespaces = [
+          ...createDebug.names,
+          ...createDebug.skips.map((namespace) => "-" + namespace)
+        ].join(",");
+        createDebug.enable("");
+        return namespaces;
+      }
+      __name(disable, "disable");
+      function enabled(name) {
+        for (const skip of createDebug.skips) {
+          if (matchesTemplate(name, skip)) {
+            return false;
+          }
+        }
+        for (const ns of createDebug.names) {
+          if (matchesTemplate(name, ns)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      __name(enabled, "enabled");
+      function coerce(val) {
+        if (val instanceof Error) {
+          return val.stack || val.message;
+        }
+        return val;
+      }
+      __name(coerce, "coerce");
+      function destroy() {
+        console.warn("Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in\
+ the next major version of `debug`.");
+      }
+      __name(destroy, "destroy");
+      createDebug.enable(createDebug.load());
+      return createDebug;
+    }
+    __name(setup, "setup");
+    module2.exports = setup;
+  }
+});
+
+// node_modules/debug/src/browser.js
+var require_browser = __commonJS({
+  "node_modules/debug/src/browser.js"(exports2, module2) {
+    exports2.formatArgs = formatArgs;
+    exports2.save = save;
+    exports2.load = load;
+    exports2.useColors = useColors;
+    exports2.storage = localstorage();
+    exports2.destroy = /* @__PURE__ */ (() => {
+      let warned = false;
+      return () => {
+        if (!warned) {
+          warned = true;
+          console.warn("Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed \
+in the next major version of `debug`.");
+        }
+      };
+    })();
+    exports2.colors = [
+      "#0000CC",
+      "#0000FF",
+      "#0033CC",
+      "#0033FF",
+      "#0066CC",
+      "#0066FF",
+      "#0099CC",
+      "#0099FF",
+      "#00CC00",
+      "#00CC33",
+      "#00CC66",
+      "#00CC99",
+      "#00CCCC",
+      "#00CCFF",
+      "#3300CC",
+      "#3300FF",
+      "#3333CC",
+      "#3333FF",
+      "#3366CC",
+      "#3366FF",
+      "#3399CC",
+      "#3399FF",
+      "#33CC00",
+      "#33CC33",
+      "#33CC66",
+      "#33CC99",
+      "#33CCCC",
+      "#33CCFF",
+      "#6600CC",
+      "#6600FF",
+      "#6633CC",
+      "#6633FF",
+      "#66CC00",
+      "#66CC33",
+      "#9900CC",
+      "#9900FF",
+      "#9933CC",
+      "#9933FF",
+      "#99CC00",
+      "#99CC33",
+      "#CC0000",
+      "#CC0033",
+      "#CC0066",
+      "#CC0099",
+      "#CC00CC",
+      "#CC00FF",
+      "#CC3300",
+      "#CC3333",
+      "#CC3366",
+      "#CC3399",
+      "#CC33CC",
+      "#CC33FF",
+      "#CC6600",
+      "#CC6633",
+      "#CC9900",
+      "#CC9933",
+      "#CCCC00",
+      "#CCCC33",
+      "#FF0000",
+      "#FF0033",
+      "#FF0066",
+      "#FF0099",
+      "#FF00CC",
+      "#FF00FF",
+      "#FF3300",
+      "#FF3333",
+      "#FF3366",
+      "#FF3399",
+      "#FF33CC",
+      "#FF33FF",
+      "#FF6600",
+      "#FF6633",
+      "#FF9900",
+      "#FF9933",
+      "#FFCC00",
+      "#FFCC33"
+    ];
+    function useColors() {
+      if (typeof window !== "undefined" && window.process && (window.process.type === "renderer" || window.process.__nwjs)) {
+        return true;
+      }
+      if (typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/(edge|trident)\/(\d+)/)) {
+        return false;
+      }
+      let m;
+      return typeof document !== "undefined" && document.documentElement && document.documentElement.style && document.documentElement.
+      style.WebkitAppearance || // Is firebug? http://stackoverflow.com/a/398120/376773
+      typeof window !== "undefined" && window.console && (window.console.firebug || window.console.exception && window.console.
+      table) || // Is firefox >= v31?
+      // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
+      typeof navigator !== "undefined" && navigator.userAgent && (m = navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/)) &&
+      parseInt(m[1], 10) >= 31 || // Double check webkit in userAgent just in case we are in a worker
+      typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/);
+    }
+    __name(useColors, "useColors");
+    function formatArgs(args) {
+      args[0] = (this.useColors ? "%c" : "") + this.namespace + (this.useColors ? " %c" : " ") + args[0] + (this.useColors ?
+      "%c " : " ") + "+" + module2.exports.humanize(this.diff);
+      if (!this.useColors) {
+        return;
+      }
+      const c = "color: " + this.color;
+      args.splice(1, 0, c, "color: inherit");
+      let index = 0;
+      let lastC = 0;
+      args[0].replace(/%[a-zA-Z%]/g, (match) => {
+        if (match === "%%") {
+          return;
+        }
+        index++;
+        if (match === "%c") {
+          lastC = index;
+        }
+      });
+      args.splice(lastC, 0, c);
+    }
+    __name(formatArgs, "formatArgs");
+    exports2.log = console.debug || console.log || (() => {
+    });
+    function save(namespaces) {
+      try {
+        if (namespaces) {
+          exports2.storage.setItem("debug", namespaces);
+        } else {
+          exports2.storage.removeItem("debug");
+        }
+      } catch (error2) {
+      }
+    }
+    __name(save, "save");
+    function load() {
+      let r;
+      try {
+        r = exports2.storage.getItem("debug") || exports2.storage.getItem("DEBUG");
+      } catch (error2) {
+      }
+      if (!r && typeof process !== "undefined" && "env" in process) {
+        r = process.env.DEBUG;
+      }
+      return r;
+    }
+    __name(load, "load");
+    function localstorage() {
+      try {
+        return localStorage;
+      } catch (error2) {
+      }
+    }
+    __name(localstorage, "localstorage");
+    module2.exports = require_common()(exports2);
+    var { formatters } = module2.exports;
+    formatters.j = function(v) {
+      try {
+        return JSON.stringify(v);
+      } catch (error2) {
+        return "[UnexpectedJSONParseError]: " + error2.message;
+      }
+    };
+  }
+});
+
+// node_modules/has-flag/index.js
+var require_has_flag = __commonJS({
+  "node_modules/has-flag/index.js"(exports2, module2) {
+    "use strict";
+    module2.exports = (flag, argv = process.argv) => {
+      const prefix = flag.startsWith("-") ? "" : flag.length === 1 ? "-" : "--";
+      const position = argv.indexOf(prefix + flag);
+      const terminatorPosition = argv.indexOf("--");
+      return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
+    };
+  }
+});
+
+// node_modules/supports-color/index.js
+var require_supports_color = __commonJS({
+  "node_modules/supports-color/index.js"(exports2, module2) {
+    "use strict";
+    var os7 = require("os");
+    var tty = require("tty");
+    var hasFlag = require_has_flag();
+    var { env: env2 } = process;
+    var forceColor;
+    if (hasFlag("no-color") || hasFlag("no-colors") || hasFlag("color=false") || hasFlag("color=never")) {
+      forceColor = 0;
+    } else if (hasFlag("color") || hasFlag("colors") || hasFlag("color=true") || hasFlag("color=always")) {
+      forceColor = 1;
+    }
+    if ("FORCE_COLOR" in env2) {
+      if (env2.FORCE_COLOR === "true") {
+        forceColor = 1;
+      } else if (env2.FORCE_COLOR === "false") {
+        forceColor = 0;
+      } else {
+        forceColor = env2.FORCE_COLOR.length === 0 ? 1 : Math.min(parseInt(env2.FORCE_COLOR, 10), 3);
+      }
+    }
+    function translateLevel(level) {
+      if (level === 0) {
+        return false;
+      }
+      return {
+        level,
+        hasBasic: true,
+        has256: level >= 2,
+        has16m: level >= 3
+      };
+    }
+    __name(translateLevel, "translateLevel");
+    function supportsColor(haveStream, streamIsTTY) {
+      if (forceColor === 0) {
+        return 0;
+      }
+      if (hasFlag("color=16m") || hasFlag("color=full") || hasFlag("color=truecolor")) {
+        return 3;
+      }
+      if (hasFlag("color=256")) {
+        return 2;
+      }
+      if (haveStream && !streamIsTTY && forceColor === void 0) {
+        return 0;
+      }
+      const min = forceColor || 0;
+      if (env2.TERM === "dumb") {
+        return min;
+      }
+      if (process.platform === "win32") {
+        const osRelease = os7.release().split(".");
+        if (Number(osRelease[0]) >= 10 && Number(osRelease[2]) >= 10586) {
+          return Number(osRelease[2]) >= 14931 ? 3 : 2;
+        }
+        return 1;
+      }
+      if ("CI" in env2) {
+        if (["TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "GITHUB_ACTIONS", "BUILDKITE"].some((sign) => sign in env2) ||
+        env2.CI_NAME === "codeship") {
+          return 1;
+        }
+        return min;
+      }
+      if ("TEAMCITY_VERSION" in env2) {
+        return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env2.TEAMCITY_VERSION) ? 1 : 0;
+      }
+      if (env2.COLORTERM === "truecolor") {
+        return 3;
+      }
+      if ("TERM_PROGRAM" in env2) {
+        const version = parseInt((env2.TERM_PROGRAM_VERSION || "").split(".")[0], 10);
+        switch (env2.TERM_PROGRAM) {
+          case "iTerm.app":
+            return version >= 3 ? 3 : 2;
+          case "Apple_Terminal":
+            return 2;
+        }
+      }
+      if (/-256(color)?$/i.test(env2.TERM)) {
+        return 2;
+      }
+      if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env2.TERM)) {
+        return 1;
+      }
+      if ("COLORTERM" in env2) {
+        return 1;
+      }
+      return min;
+    }
+    __name(supportsColor, "supportsColor");
+    function getSupportLevel(stream) {
+      const level = supportsColor(stream, stream && stream.isTTY);
+      return translateLevel(level);
+    }
+    __name(getSupportLevel, "getSupportLevel");
+    module2.exports = {
+      supportsColor: getSupportLevel,
+      stdout: translateLevel(supportsColor(true, tty.isatty(1))),
+      stderr: translateLevel(supportsColor(true, tty.isatty(2)))
+    };
+  }
+});
+
+// node_modules/debug/src/node.js
+var require_node = __commonJS({
+  "node_modules/debug/src/node.js"(exports2, module2) {
+    var tty = require("tty");
+    var util = require("util");
+    exports2.init = init;
+    exports2.log = log;
+    exports2.formatArgs = formatArgs;
+    exports2.save = save;
+    exports2.load = load;
+    exports2.useColors = useColors;
+    exports2.destroy = util.deprecate(
+      () => {
+      },
+      "Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major\
+ version of `debug`."
+    );
+    exports2.colors = [6, 2, 3, 4, 5, 1];
+    try {
+      const supportsColor = require_supports_color();
+      if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
+        exports2.colors = [
+          20,
+          21,
+          26,
+          27,
+          32,
+          33,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          56,
+          57,
+          62,
+          63,
+          68,
+          69,
+          74,
+          75,
+          76,
+          77,
+          78,
+          79,
+          80,
+          81,
+          92,
+          93,
+          98,
+          99,
+          112,
+          113,
+          128,
+          129,
+          134,
+          135,
+          148,
+          149,
+          160,
+          161,
+          162,
+          163,
+          164,
+          165,
+          166,
+          167,
+          168,
+          169,
+          170,
+          171,
+          172,
+          173,
+          178,
+          179,
+          184,
+          185,
+          196,
+          197,
+          198,
+          199,
+          200,
+          201,
+          202,
+          203,
+          204,
+          205,
+          206,
+          207,
+          208,
+          209,
+          214,
+          215,
+          220,
+          221
+        ];
+      }
+    } catch (error2) {
+    }
+    exports2.inspectOpts = Object.keys(process.env).filter((key) => {
+      return /^debug_/i.test(key);
+    }).reduce((obj, key) => {
+      const prop = key.substring(6).toLowerCase().replace(/_([a-z])/g, (_, k) => {
+        return k.toUpperCase();
+      });
+      let val = process.env[key];
+      if (/^(yes|on|true|enabled)$/i.test(val)) {
+        val = true;
+      } else if (/^(no|off|false|disabled)$/i.test(val)) {
+        val = false;
+      } else if (val === "null") {
+        val = null;
+      } else {
+        val = Number(val);
+      }
+      obj[prop] = val;
+      return obj;
+    }, {});
+    function useColors() {
+      return "colors" in exports2.inspectOpts ? Boolean(exports2.inspectOpts.colors) : tty.isatty(process.stderr.fd);
+    }
+    __name(useColors, "useColors");
+    function formatArgs(args) {
+      const { namespace: name, useColors: useColors2 } = this;
+      if (useColors2) {
+        const c = this.color;
+        const colorCode = "\x1B[3" + (c < 8 ? c : "8;5;" + c);
+        const prefix = `  ${colorCode};1m${name} \x1B[0m`;
+        args[0] = prefix + args[0].split("\n").join("\n" + prefix);
+        args.push(colorCode + "m+" + module2.exports.humanize(this.diff) + "\x1B[0m");
+      } else {
+        args[0] = getDate() + name + " " + args[0];
+      }
+    }
+    __name(formatArgs, "formatArgs");
+    function getDate() {
+      if (exports2.inspectOpts.hideDate) {
+        return "";
+      }
+      return (/* @__PURE__ */ new Date()).toISOString() + " ";
+    }
+    __name(getDate, "getDate");
+    function log(...args) {
+      return process.stderr.write(util.formatWithOptions(exports2.inspectOpts, ...args) + "\n");
+    }
+    __name(log, "log");
+    function save(namespaces) {
+      if (namespaces) {
+        process.env.DEBUG = namespaces;
+      } else {
+        delete process.env.DEBUG;
+      }
+    }
+    __name(save, "save");
+    function load() {
+      return process.env.DEBUG;
+    }
+    __name(load, "load");
+    function init(debug3) {
+      debug3.inspectOpts = {};
+      const keys = Object.keys(exports2.inspectOpts);
+      for (let i = 0; i < keys.length; i++) {
+        debug3.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
+      }
+    }
+    __name(init, "init");
+    module2.exports = require_common()(exports2);
+    var { formatters } = module2.exports;
+    formatters.o = function(v) {
+      this.inspectOpts.colors = this.useColors;
+      return util.inspect(v, this.inspectOpts).split("\n").map((str) => str.trim()).join(" ");
+    };
+    formatters.O = function(v) {
+      this.inspectOpts.colors = this.useColors;
+      return util.inspect(v, this.inspectOpts);
+    };
+  }
+});
+
+// node_modules/debug/src/index.js
+var require_src = __commonJS({
+  "node_modules/debug/src/index.js"(exports2, module2) {
+    if (typeof process === "undefined" || process.type === "renderer" || process.browser === true || process.__nwjs) {
+      module2.exports = require_browser();
+    } else {
+      module2.exports = require_node();
+    }
+  }
+});
+
+// node_modules/@kwsites/file-exists/dist/src/index.js
+var require_src2 = __commonJS({
+  "node_modules/@kwsites/file-exists/dist/src/index.js"(exports2) {
+    "use strict";
+    var __importDefault = exports2 && exports2.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var fs_1 = require("fs");
+    var debug_1 = __importDefault(require_src());
+    var log = debug_1.default("@kwsites/file-exists");
+    function check(path5, isFile, isDirectory2) {
+      log(`checking %s`, path5);
+      try {
+        const stat2 = fs_1.statSync(path5);
+        if (stat2.isFile() && isFile) {
+          log(`[OK] path represents a file`);
+          return true;
+        }
+        if (stat2.isDirectory() && isDirectory2) {
+          log(`[OK] path represents a directory`);
+          return true;
+        }
+        log(`[FAIL] path represents something other than a file or directory`);
+        return false;
+      } catch (e) {
+        if (e.code === "ENOENT") {
+          log(`[FAIL] path is not accessible: %o`, e);
+          return false;
+        }
+        log(`[FATAL] %o`, e);
+        throw e;
+      }
+    }
+    __name(check, "check");
+    function exists3(path5, type = exports2.READABLE) {
+      return check(path5, (type & exports2.FILE) > 0, (type & exports2.FOLDER) > 0);
+    }
+    __name(exists3, "exists");
+    exports2.exists = exists3;
+    exports2.FILE = 1;
+    exports2.FOLDER = 2;
+    exports2.READABLE = exports2.FILE + exports2.FOLDER;
+  }
+});
+
+// node_modules/@kwsites/file-exists/dist/index.js
+var require_dist = __commonJS({
+  "node_modules/@kwsites/file-exists/dist/index.js"(exports2) {
+    "use strict";
+    function __export2(m) {
+      for (var p in m) if (!exports2.hasOwnProperty(p)) exports2[p] = m[p];
+    }
+    __name(__export2, "__export");
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    __export2(require_src2());
+  }
+});
+
+// node_modules/@kwsites/promise-deferred/dist/index.js
+var require_dist2 = __commonJS({
+  "node_modules/@kwsites/promise-deferred/dist/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.createDeferred = exports2.deferred = void 0;
+    function deferred2() {
+      let done;
+      let fail;
+      let status = "pending";
+      const promise = new Promise((_done, _fail) => {
+        done = _done;
+        fail = _fail;
+      });
+      return {
+        promise,
+        done(result) {
+          if (status === "pending") {
+            status = "resolved";
+            done(result);
+          }
+        },
+        fail(error2) {
+          if (status === "pending") {
+            status = "rejected";
+            fail(error2);
+          }
+        },
+        get fulfilled() {
+          return status !== "pending";
+        },
+        get status() {
+          return status;
+        }
+      };
+    }
+    __name(deferred2, "deferred");
+    exports2.deferred = deferred2;
+    exports2.createDeferred = deferred2;
+    exports2.default = deferred2;
+  }
+});
+
 // node_modules/tunnel/lib/tunnel.js
 var require_tunnel = __commonJS({
   "node_modules/tunnel/lib/tunnel.js"(exports2) {
@@ -33,7 +938,7 @@ var require_tunnel = __commonJS({
     var tls = require("tls");
     var http = require("http");
     var https = require("https");
-    var events = require("events");
+    var events2 = require("events");
     var assert = require("assert");
     var util = require("util");
     exports2.httpOverHttp = httpOverHttp2;
@@ -90,7 +995,7 @@ var require_tunnel = __commonJS({
       }, "onFree"));
     }
     __name(TunnelingAgent, "TunnelingAgent");
-    util.inherits(TunnelingAgent, events.EventEmitter);
+    util.inherits(TunnelingAgent, events2.EventEmitter);
     TunnelingAgent.prototype.addRequest = /* @__PURE__ */ __name(function addRequest(req, host, port, localAddress) {
       var self = this;
       var options = mergeOptions({ request: req }, self.options, toOptions(host, port, localAddress));
@@ -135,13 +1040,13 @@ var require_tunnel = __commonJS({
         connectOptions.headers = connectOptions.headers || {};
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
-      debug2("making CONNECT request");
+      debug3("making CONNECT request");
       var connectReq = self.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
       connectReq.once("upgrade", onUpgrade);
       connectReq.once("connect", onConnect);
-      connectReq.once("error", onError);
+      connectReq.once("error", onError2);
       connectReq.end();
       function onResponse(res) {
         res.upgrade = true;
@@ -157,44 +1062,44 @@ var require_tunnel = __commonJS({
         connectReq.removeAllListeners();
         socket.removeAllListeners();
         if (res.statusCode !== 200) {
-          debug2(
+          debug3(
             "tunneling socket could not be established, statusCode=%d",
             res.statusCode
           );
           socket.destroy();
-          var error = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
-          debug2("got illegal response body from proxy");
+          debug3("got illegal response body from proxy");
           socket.destroy();
-          var error = new Error("got illegal response body from proxy");
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("got illegal response body from proxy");
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
-        debug2("tunneling connection has established");
+        debug3("tunneling connection has established");
         self.sockets[self.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       __name(onConnect, "onConnect");
-      function onError(cause) {
+      function onError2(cause) {
         connectReq.removeAllListeners();
-        debug2(
+        debug3(
           "tunneling socket could not be established, cause=%s\n",
           cause.message,
           cause.stack
         );
-        var error = new Error("tunneling socket could not be established, cause=" + cause.message);
-        error.code = "ECONNRESET";
-        options.request.emit("error", error);
+        var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
+        error2.code = "ECONNRESET";
+        options.request.emit("error", error2);
         self.removeSocket(placeholder);
       }
-      __name(onError, "onError");
+      __name(onError2, "onError");
     }, "createSocket");
     TunnelingAgent.prototype.removeSocket = /* @__PURE__ */ __name(function removeSocket(socket) {
       var pos = this.sockets.indexOf(socket);
@@ -250,9 +1155,9 @@ var require_tunnel = __commonJS({
       return target;
     }
     __name(mergeOptions, "mergeOptions");
-    var debug2;
+    var debug3;
     if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-      debug2 = /* @__PURE__ */ __name(function() {
+      debug3 = /* @__PURE__ */ __name(function() {
         var args = Array.prototype.slice.call(arguments);
         if (typeof args[0] === "string") {
           args[0] = "TUNNEL: " + args[0];
@@ -262,10 +1167,10 @@ var require_tunnel = __commonJS({
         console.error.apply(console, args);
       }, "debug");
     } else {
-      debug2 = /* @__PURE__ */ __name(function() {
+      debug3 = /* @__PURE__ */ __name(function() {
       }, "debug");
     }
-    exports2.debug = debug2;
+    exports2.debug = debug3;
   }
 });
 
@@ -1171,14 +2076,14 @@ eger.");
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path5 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path && path[0] !== "/") {
-          path = `/${path}`;
+        if (path5 && path5[0] !== "/") {
+          path5 = `/${path5}`;
         }
-        return new URL(`${origin}${path}`);
+        return new URL(`${origin}${path5}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1657,52 +2562,52 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
         const {
           connectParams: { version, protocol, port, host },
-          error
+          error: error2
         } = evt;
         debuglog(
           "connection to %s using %s%s errored - %s",
           `${host}${port ? `:${port}` : ""}`,
           protocol,
           version,
-          error.message
+          error2.message
         );
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path, origin }
+          request: { method, path: path5, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path);
+        debuglog("sending request to %s %s/%s", method, origin, path5);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path, origin },
+          request: { method, path: path5, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path,
+          path5,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path, origin }
+          request: { method, path: path5, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path);
+        debuglog("trailers received from %s %s/%s", method, origin, path5);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path, origin },
-          error
+          request: { method, path: path5, origin },
+          error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path,
-          error.message
+          path5,
+          error2.message
         );
       });
       isClientSet = true;
@@ -1737,7 +2642,7 @@ var require_diagnostics = __commonJS({
         diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
           const {
             connectParams: { version, protocol, port, host },
-            error
+            error: error2
           } = evt;
           debuglog(
             "connection to %s%s using %s%s errored - %s",
@@ -1745,14 +2650,14 @@ var require_diagnostics = __commonJS({
             port ? `:${port}` : "",
             protocol,
             version,
-            error.message
+            error2.message
           );
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path, origin }
+            request: { method, path: path5, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path);
+          debuglog("sending request to %s %s/%s", method, origin, path5);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1818,7 +2723,7 @@ var require_request = __commonJS({
         __name(this, "Request");
       }
       constructor(origin, {
-        path,
+        path: path5,
         method,
         body,
         headers,
@@ -1833,12 +2738,12 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path !== "string") {
+        if (typeof path5 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path[0] !== "/" && !(path.startsWith("http://") || path.startsWith("https://")) && method !== "CONNEC\
-T") {
+        } else if (path5[0] !== "/" && !(path5.startsWith("http://") || path5.startsWith("https://")) && method !== "CON\
+NECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path)) {
+        } else if (invalidPathRegex.test(path5)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -1905,7 +2810,7 @@ terable");
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path, query) : path;
+        this.path = query ? buildURL(path5, query) : path5;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -2020,16 +2925,16 @@ terable");
           this.onError(err);
         }
       }
-      onError(error) {
+      onError(error2) {
         this.onFinally();
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       onFinally() {
         if (this.errorHandler) {
@@ -2129,8 +3034,8 @@ terable");
 var require_dispatcher = __commonJS({
   "node_modules/undici/lib/dispatcher/dispatcher.js"(exports2, module2) {
     "use strict";
-    var EventEmitter = require("node:events");
-    var Dispatcher = class extends EventEmitter {
+    var EventEmitter2 = require("node:events");
+    var Dispatcher = class extends EventEmitter2 {
       static {
         __name(this, "Dispatcher");
       }
@@ -2233,9 +3138,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback) {
         if (callback === void 0) {
-          return new Promise((resolve, reject) => {
+          return new Promise((resolve2, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve(data);
+              return err ? reject(err) : resolve2(data);
             });
           });
         }
@@ -2273,12 +3178,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback === void 0) {
-          return new Promise((resolve, reject) => {
+          return new Promise((resolve2, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve(data);
+              ) : resolve2(data);
             });
           });
         }
@@ -2458,9 +3363,9 @@ var require_timers = __commonJS({
        * before the specified function or code is executed.
        * @param {*} arg
        */
-      constructor(callback, delay, arg) {
+      constructor(callback, delay2, arg) {
         this._onTimeout = callback;
-        this._idleTimeout = delay;
+        this._idleTimeout = delay2;
         this._timerArg = arg;
         this.refresh();
       }
@@ -2505,8 +3410,8 @@ var require_timers = __commonJS({
        * when the timer expires.
        * @returns {NodeJS.Timeout|FastTimer}
        */
-      setTimeout(callback, delay, arg) {
-        return delay <= RESOLUTION_MS ? setTimeout(callback, delay, arg) : new FastTimer(callback, delay, arg);
+      setTimeout(callback, delay2, arg) {
+        return delay2 <= RESOLUTION_MS ? setTimeout(callback, delay2, arg) : new FastTimer(callback, delay2, arg);
       },
       /**
        * The clearTimeout method cancels an instantiated Timer previously created
@@ -2532,8 +3437,8 @@ var require_timers = __commonJS({
        * when the timer expires.
        * @returns {FastTimer}
        */
-      setFastTimeout(callback, delay, arg) {
-        return new FastTimer(callback, delay, arg);
+      setFastTimeout(callback, delay2, arg) {
+        return new FastTimer(callback, delay2, arg);
       },
       /**
        * The clearTimeout method cancels an instantiated FastTimer previously
@@ -2559,8 +3464,8 @@ var require_timers = __commonJS({
        * @deprecated
        * @param {number} [delay=0] The delay in milliseconds to add to the now value.
        */
-      tick(delay = 0) {
-        fastNow += delay - RESOLUTION_MS + 1;
+      tick(delay2 = 0) {
+        fastNow += delay2 - RESOLUTION_MS + 1;
         onTick();
         onTick();
       },
@@ -3126,8 +4031,8 @@ var require_constants2 = __commonJS({
 var require_llhttp_wasm = __commonJS({
   "node_modules/undici/lib/llhttp/llhttp-wasm.js"(exports2, module2) {
     "use strict";
-    var { Buffer: Buffer2 } = require("node:buffer");
-    module2.exports = Buffer2.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
+    var { Buffer: Buffer3 } = require("node:buffer");
+    module2.exports = Buffer3.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
 b25faGVhZGVyc19jb21wbGV0ZQAEA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNl\
 bnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2Fn\
 ZV9jb21wbGV0ZQAAAy0sBQYAAAIAAAAAAAACAQIAAgICAAADAAAAAAMDAwMBAQEBAQEBAQEAAAIAAAAEBQFwARISBQMBAAIGCAF/AUGA1AQLB9EFIgZtZW1v\
@@ -3675,8 +4580,8 @@ RUJTQ1JJQkVBUkRPV05BQ0VJTkROS0NLVUJTQ1JJQkVIVFRQL0FEVFAv", "base64");
 var require_llhttp_simd_wasm = __commonJS({
   "node_modules/undici/lib/llhttp/llhttp_simd-wasm.js"(exports2, module2) {
     "use strict";
-    var { Buffer: Buffer2 } = require("node:buffer");
-    module2.exports = Buffer2.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
+    var { Buffer: Buffer3 } = require("node:buffer");
+    module2.exports = Buffer3.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
 b25faGVhZGVyc19jb21wbGV0ZQAEA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNl\
 bnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2Fn\
 ZV9jb21wbGV0ZQAAAy0sBQYAAAIAAAAAAAACAQIAAgICAAADAAAAAAMDAwMBAQEBAQEBAQEAAAIAAAAEBQFwARISBQMBAAIGCAF/AUGA1AQLB9EFIgZtZW1v\
@@ -5283,11 +6188,11 @@ var require_util2 = __commonJS({
     var { isUint8Array } = require("node:util/types");
     var { webidl } = require_webidl();
     var supportedHashes = [];
-    var crypto;
+    var crypto2;
     try {
-      crypto = require("node:crypto");
+      crypto2 = require("node:crypto");
       const possibleRelevantHashes = ["sha256", "sha384", "sha512"];
-      supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash));
+      supportedHashes = crypto2.getHashes().filter((hash) => possibleRelevantHashes.includes(hash));
     } catch {
     }
     function responseURL(response) {
@@ -5590,7 +6495,7 @@ ption");
     }
     __name(isURLPotentiallyTrustworthy, "isURLPotentiallyTrustworthy");
     function bytesMatch(bytes, metadataList) {
-      if (crypto === void 0) {
+      if (crypto2 === void 0) {
         return true;
       }
       const parsedMetadata = parseMetadata(metadataList);
@@ -5605,7 +6510,7 @@ ption");
       for (const item of metadata) {
         const algorithm = item.algo;
         const expectedValue = item.hash;
-        let actualValue = crypto.createHash(algorithm).update(bytes).digest("base64");
+        let actualValue = crypto2.createHash(algorithm).update(bytes).digest("base64");
         if (actualValue[actualValue.length - 1] === "=") {
           if (actualValue[actualValue.length - 2] === "=") {
             actualValue = actualValue.slice(0, -2);
@@ -5705,8 +6610,8 @@ ption");
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise = new Promise((resolve, reject) => {
-        res = resolve;
+      const promise = new Promise((resolve2, reject) => {
+        res = resolve2;
         rej = reject;
       });
       return { promise, resolve: res, reject: rej };
@@ -5840,7 +6745,7 @@ ption");
           writable: true,
           enumerable: true,
           configurable: true,
-          value: /* @__PURE__ */ __name(function forEach(callbackfn, thisArg = globalThis) {
+          value: /* @__PURE__ */ __name(function forEach2(callbackfn, thisArg = globalThis) {
             webidl.brandCheck(this, object);
             webidl.argumentLengthCheck(arguments, 1, `${name}.forEach`);
             if (typeof callbackfn !== "function") {
@@ -6479,8 +7384,9 @@ var require_formdata_parser = __commonJS({
         return false;
       }
       for (let i = 0; i < length; ++i) {
-        const cp = boundary.charCodeAt(i);
-        if (!(cp >= 48 && cp <= 57 || cp >= 65 && cp <= 90 || cp >= 97 && cp <= 122 || cp === 39 || cp === 45 || cp === 95)) {
+        const cp2 = boundary.charCodeAt(i);
+        if (!(cp2 >= 48 && cp2 <= 57 || cp2 >= 65 && cp2 <= 90 || cp2 >= 97 && cp2 <= 122 || cp2 === 39 || cp2 === 45 ||
+        cp2 === 95)) {
           return false;
         }
       }
@@ -6734,8 +7640,8 @@ var require_body = __commonJS({
     var { multipartFormDataParser } = require_formdata_parser();
     var random;
     try {
-      const crypto = require("node:crypto");
-      random = /* @__PURE__ */ __name((max) => crypto.randomInt(0, max), "random");
+      const crypto2 = require("node:crypto");
+      random = /* @__PURE__ */ __name((max) => crypto2.randomInt(0, max), "random");
     } catch {
       random = /* @__PURE__ */ __name((max) => Math.floor(Math.random(max)), "random");
     }
@@ -6990,7 +7896,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
       }
       throwIfAborted(object[kState]);
       const promise = createDeferredPromise();
-      const errorSteps = /* @__PURE__ */ __name((error) => promise.reject(error), "errorSteps");
+      const errorSteps = /* @__PURE__ */ __name((error2) => promise.reject(error2), "errorSteps");
       const successSteps = /* @__PURE__ */ __name((data) => {
         try {
           promise.resolve(convertBytesToJSValue(data));
@@ -7186,21 +8092,21 @@ var require_client_h1 = __commonJS({
         this.connection = "";
         this.maxResponseSize = client[kMaxResponseSize];
       }
-      setTimeout(delay, type) {
-        if (delay !== this.timeoutValue || type & USE_FAST_TIMER ^ this.timeoutType & USE_FAST_TIMER) {
+      setTimeout(delay2, type) {
+        if (delay2 !== this.timeoutValue || type & USE_FAST_TIMER ^ this.timeoutType & USE_FAST_TIMER) {
           if (this.timeout) {
             timers.clearTimeout(this.timeout);
             this.timeout = null;
           }
-          if (delay) {
+          if (delay2) {
             if (type & USE_FAST_TIMER) {
-              this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this));
+              this.timeout = timers.setFastTimeout(onParserTimeout, delay2, new WeakRef(this));
             } else {
-              this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this));
+              this.timeout = setTimeout(onParserTimeout, delay2, new WeakRef(this));
               this.timeout.unref();
             }
           }
-          this.timeoutValue = delay;
+          this.timeoutValue = delay2;
         } else if (this.timeout) {
           if (this.timeout.refresh) {
             this.timeout.refresh();
@@ -7519,8 +8425,8 @@ var require_client_h1 = __commonJS({
         }
       }
     };
-    function onParserTimeout(parser) {
-      const { socket, timeoutType, client, paused } = parser.deref();
+    function onParserTimeout(parser4) {
+      const { socket, timeoutType, client, paused } = parser4.deref();
       if (timeoutType === TIMEOUT_HEADERS) {
         if (!socket[kWriting] || socket.writableNeedDrain || client[kRunning] > 1) {
           assert(!paused, "cannot be paused while waiting for headers");
@@ -7549,34 +8455,34 @@ var require_client_h1 = __commonJS({
       socket[kParser] = new Parser(client, socket, llhttpInstance);
       addListener(socket, "error", function(err) {
         assert(err.code !== "ERR_TLS_CERT_ALTNAME_INVALID");
-        const parser = this[kParser];
-        if (err.code === "ECONNRESET" && parser.statusCode && !parser.shouldKeepAlive) {
-          parser.onMessageComplete();
+        const parser4 = this[kParser];
+        if (err.code === "ECONNRESET" && parser4.statusCode && !parser4.shouldKeepAlive) {
+          parser4.onMessageComplete();
           return;
         }
         this[kError] = err;
         this[kClient][kOnError](err);
       });
       addListener(socket, "readable", function() {
-        const parser = this[kParser];
-        if (parser) {
-          parser.readMore();
+        const parser4 = this[kParser];
+        if (parser4) {
+          parser4.readMore();
         }
       });
       addListener(socket, "end", function() {
-        const parser = this[kParser];
-        if (parser.statusCode && !parser.shouldKeepAlive) {
-          parser.onMessageComplete();
+        const parser4 = this[kParser];
+        if (parser4.statusCode && !parser4.shouldKeepAlive) {
+          parser4.onMessageComplete();
           return;
         }
         util.destroy(this, new SocketError("other side closed", util.getSocketInfo(this)));
       });
       addListener(socket, "close", function() {
         const client2 = this[kClient];
-        const parser = this[kParser];
-        if (parser) {
-          if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-            parser.onMessageComplete();
+        const parser4 = this[kParser];
+        if (parser4) {
+          if (!this[kError] && parser4.statusCode && !parser4.shouldKeepAlive) {
+            parser4.onMessageComplete();
           }
           this[kParser].destroy();
           this[kParser] = null;
@@ -7676,7 +8582,7 @@ var require_client_h1 = __commonJS({
     }
     __name(shouldSendContentLength, "shouldSendContentLength");
     function writeH1(client, request) {
-      const { method, path, host, upgrade, blocking, reset } = request;
+      const { method, path: path5, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method ===
       "PROPFIND" || method === "PROPPATCH";
@@ -7744,7 +8650,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path} HTTP/1.1\r
+      let header = `${method} ${path5} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -7936,12 +8842,12 @@ upgrade: ${upgrade}\r
         }
       }
       __name(onDrain, "onDrain");
-      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve, reject) => {
+      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve2, reject) => {
         assert(callback === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback = resolve;
+          callback = resolve2;
         }
       }), "waitForDrain");
       socket.on("close", onDrain).on("drain", onDrain);
@@ -8288,7 +9194,7 @@ var require_client_h2 = __commonJS({
     __name(shouldSendContentLength, "shouldSendContentLength");
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path5, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -8355,7 +9261,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path;
+      headers[HTTP2_HEADER_PATH] = path5;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -8535,8 +9441,8 @@ var require_client_h2 = __commonJS({
         }
         request.onRequestSent();
         client[kResume]();
-      } catch (error) {
-        abort(error);
+      } catch (error2) {
+        abort(error2);
       }
     }
     __name(writeBuffer, "writeBuffer");
@@ -8599,12 +9505,12 @@ var require_client_h2 = __commonJS({
         }
       }
       __name(onDrain, "onDrain");
-      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve, reject) => {
+      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve2, reject) => {
         assert(callback === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback = resolve;
+          callback = resolve2;
         }
       }), "waitForDrain");
       h2stream.on("close", onDrain).on("drain", onDrain);
@@ -8704,8 +9610,8 @@ var require_redirect_handler = __commonJS({
       onUpgrade(statusCode, headers, socket) {
         this.handler.onUpgrade(statusCode, headers, socket);
       }
-      onError(error) {
-        this.handler.onError(error);
+      onError(error2) {
+        this.handler.onError(error2);
       }
       onHeaders(statusCode, headers, resume, statusText) {
         this.location = this.history.length >= this.maxRedirections || util.isDisturbed(this.opts.body) ? null : parseLocation(
@@ -8726,9 +9632,9 @@ var require_redirect_handler = __commonJS({
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.
         path, this.opts.origin)));
-        const path = search ? `${pathname}${search}` : pathname;
+        const path5 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path;
+        this.opts.path = path5;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -9052,7 +9958,7 @@ var require_client = __commonJS({
         this[kRunningIdx] = 0;
         this[kPendingIdx] = 0;
         this[kResume] = (sync) => resume(this, sync);
-        this[kOnError] = (err) => onError(this, err);
+        this[kOnError] = (err) => onError2(this, err);
       }
       get pipelining() {
         return this[kPipelining];
@@ -9100,16 +10006,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve) => {
+        return new Promise((resolve2) => {
           if (this[kSize]) {
-            this[kClosedResolve] = resolve;
+            this[kClosedResolve] = resolve2;
           } else {
-            resolve(null);
+            resolve2(null);
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve) => {
+        return new Promise((resolve2) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i = 0; i < requests.length; i++) {
             const request = requests[i];
@@ -9120,7 +10026,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve(null);
+            resolve2(null);
           }, "callback");
           if (this[kHTTPContext]) {
             this[kHTTPContext].destroy(err, callback);
@@ -9133,7 +10039,7 @@ var require_client = __commonJS({
       }
     };
     var createRedirectInterceptor = require_redirect_interceptor();
-    function onError(client, err) {
+    function onError2(client, err) {
       if (client[kRunning] === 0 && err.code !== "UND_ERR_INFO" && err.code !== "UND_ERR_SOCKET") {
         assert(client[kPendingIdx] === client[kRunningIdx]);
         const requests = client[kQueue].splice(client[kRunningIdx]);
@@ -9144,7 +10050,7 @@ var require_client = __commonJS({
         assert(client[kSize] === 0);
       }
     }
-    __name(onError, "onError");
+    __name(onError2, "onError");
     async function connect(client) {
       assert(!client[kConnecting]);
       assert(!client[kHTTPContext]);
@@ -9172,7 +10078,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve, reject) => {
+        const socket = await new Promise((resolve2, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -9184,7 +10090,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve(socket2);
+              resolve2(socket2);
             }
           });
         });
@@ -9248,7 +10154,7 @@ var require_client = __commonJS({
             util.errorRequest(client, request, err);
           }
         } else {
-          onError(client, err);
+          onError2(client, err);
         }
         client.emit("connectionError", client[kUrl], [client], err);
       }
@@ -9537,8 +10443,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           await Promise.all(this[kClients].map((c) => c.close()));
         } else {
-          await new Promise((resolve) => {
-            this[kClosedResolve] = resolve;
+          await new Promise((resolve2) => {
+            this[kClosedResolve] = resolve2;
           });
         }
       }
@@ -9669,7 +10575,7 @@ var require_pool = __commonJS({
         this[kOptions] = { ...util.deepClone(options), connect, allowH2 };
         this[kOptions].interceptors = options.interceptors ? { ...options.interceptors } : void 0;
         this[kFactory] = factory;
-        this.on("connectionError", (origin2, targets, error) => {
+        this.on("connectionError", (origin2, targets, error2) => {
           for (const target of targets) {
             const idx = this[kClients].indexOf(target);
             if (idx !== -1) {
@@ -10018,10 +10924,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path = "/",
+          path: path5 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path;
+        opts.path = origin + path5;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10806,7 +11712,7 @@ var require_readable = __commonJS({
         if (this._readableState.closeEmitted) {
           return null;
         }
-        return await new Promise((resolve, reject) => {
+        return await new Promise((resolve2, reject) => {
           if (this[kContentLength] > limit) {
             this.destroy(new AbortError());
           }
@@ -10819,7 +11725,7 @@ var require_readable = __commonJS({
             if (signal?.aborted) {
               reject(signal.reason ?? new AbortError());
             } else {
-              resolve(null);
+              resolve2(null);
             }
           }).on("error", noop).on("data", function(chunk) {
             limit -= chunk.length;
@@ -10840,7 +11746,7 @@ var require_readable = __commonJS({
     __name(isUnusable, "isUnusable");
     async function consume(stream, type) {
       assert(!stream[kConsume]);
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve2, reject) => {
         if (isUnusable(stream)) {
           const rState = stream._readableState;
           if (rState.destroyed && rState.closeEmitted === false) {
@@ -10857,7 +11763,7 @@ var require_readable = __commonJS({
             stream[kConsume] = {
               type,
               stream,
-              resolve,
+              resolve: resolve2,
               reject,
               length: 0,
               body: []
@@ -10931,18 +11837,18 @@ var require_readable = __commonJS({
     }
     __name(chunksConcat, "chunksConcat");
     function consumeEnd(consume2) {
-      const { type, body, resolve, stream, length } = consume2;
+      const { type, body, resolve: resolve2, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve(chunksDecode(body, length));
+          resolve2(chunksDecode(body, length));
         } else if (type === "json") {
-          resolve(JSON.parse(chunksDecode(body, length)));
+          resolve2(JSON.parse(chunksDecode(body, length)));
         } else if (type === "arrayBuffer") {
-          resolve(chunksConcat(body, length).buffer);
+          resolve2(chunksConcat(body, length).buffer);
         } else if (type === "blob") {
-          resolve(new Blob(body, { type: stream[kContentType] }));
+          resolve2(new Blob(body, { type: stream[kContentType] }));
         } else if (type === "bytes") {
-          resolve(chunksConcat(body, length));
+          resolve2(chunksConcat(body, length));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -11210,9 +12116,9 @@ var require_api_request = __commonJS({
     };
     function request(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           request.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -11442,9 +12348,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -11743,9 +12649,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -11841,9 +12747,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve2, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve(data);
+            return err ? reject(err) : resolve2(data);
           });
         });
       }
@@ -12017,21 +12923,21 @@ var require_mock_utils = __commonJS({
       return true;
     }
     __name(matchHeaders, "matchHeaders");
-    function safeUrl(path) {
-      if (typeof path !== "string") {
-        return path;
+    function safeUrl(path5) {
+      if (typeof path5 !== "string") {
+        return path5;
       }
-      const pathSegments = path.split("?");
+      const pathSegments = path5.split("?");
       if (pathSegments.length !== 2) {
-        return path;
+        return path5;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
     __name(safeUrl, "safeUrl");
-    function matchKey(mockDispatch2, { path, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path);
+    function matchKey(mockDispatch2, { path: path5, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path5);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -12055,8 +12961,8 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path }) => matchValue(safeUrl(
-      path), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path5 }) => matchValue(
+      safeUrl(path5), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -12098,9 +13004,9 @@ var require_mock_utils = __commonJS({
     }
     __name(deleteMockDispatch, "deleteMockDispatch");
     function buildKey(opts) {
-      const { path, method, body, headers, query } = opts;
+      const { path: path5, method, body, headers, query } = opts;
       return {
-        path,
+        path: path5,
         method,
         body,
         headers,
@@ -12145,19 +13051,19 @@ var require_mock_utils = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay: delay2, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler.onError(error);
+        handler.onError(error2);
         return true;
       }
-      if (typeof delay === "number" && delay > 0) {
+      if (typeof delay2 === "number" && delay2 > 0) {
         setTimeout(() => {
           handleReply(this[kDispatches]);
-        }, delay);
+        }, delay2);
       } else {
         handleReply(this[kDispatches]);
       }
@@ -12192,21 +13098,21 @@ var require_mock_utils = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler);
-          } catch (error) {
-            if (error instanceof MockNotMatchedError) {
+          } catch (error2) {
+            if (error2 instanceof MockNotMatchedError) {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed \
-(net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed\
+ (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed \
-(net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed\
+ (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -12380,11 +13286,11 @@ var require_mock_interceptor = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -12593,10 +13499,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path5, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path,
+            Path: path5,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -13387,12 +14293,12 @@ var require_headers = __commonJS({
       append(name, value, isLowerCase) {
         this[kHeadersSortedMap] = null;
         const lowercaseName = isLowerCase ? name : name.toLowerCase();
-        const exists2 = this[kHeadersMap].get(lowercaseName);
-        if (exists2) {
-          const delimiter = lowercaseName === "cookie" ? "; " : ", ";
+        const exists3 = this[kHeadersMap].get(lowercaseName);
+        if (exists3) {
+          const delimiter2 = lowercaseName === "cookie" ? "; " : ", ";
           this[kHeadersMap].set(lowercaseName, {
-            name: exists2.name,
-            value: `${exists2.value}${delimiter}${value}`
+            name: exists3.name,
+            value: `${exists3.value}${delimiter2}${value}`
           });
         } else {
           this[kHeadersMap].set(lowercaseName, { name, value });
@@ -14288,15 +15194,15 @@ var require_request2 = __commonJS({
           signal = input[kSignal];
         }
         const origin = environmentSettingsObject.settingsObject.origin;
-        let window = "client";
+        let window2 = "client";
         if (request.window?.constructor?.name === "EnvironmentSettingsObject" && sameOrigin(request.window, origin)) {
-          window = request.window;
+          window2 = request.window;
         }
         if (init.window != null) {
-          throw new TypeError(`'window' option '${window}' must be null`);
+          throw new TypeError(`'window' option '${window2}' must be null`);
         }
         if ("window" in init) {
-          window = "no-window";
+          window2 = "no-window";
         }
         request = makeRequest({
           // URL request’s URL.
@@ -14311,7 +15217,7 @@ var require_request2 = __commonJS({
           // client This’s relevant settings object.
           client: environmentSettingsObject.settingsObject,
           // window window.
-          window,
+          window: window2,
           // priority request’s priority.
           priority: request.priority,
           // origin request’s origin. The propagation of the origin is only significant for navigation requests
@@ -14980,17 +15886,17 @@ var require_fetch = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     function handleFetchDone(response) {
@@ -15089,12 +15995,12 @@ var require_fetch = __commonJS({
     }
     __name(finalizeAndReportTiming, "finalizeAndReportTiming");
     var markResourceTiming = performance.markResourceTiming;
-    function abortFetch(p, request, responseObject, error) {
+    function abortFetch(p, request, responseObject, error2) {
       if (p) {
-        p.reject(error);
+        p.reject(error2);
       }
       if (request.body != null && isReadable(request.body?.stream)) {
-        request.body.stream.cancel(error).catch((err) => {
+        request.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -15106,7 +16012,7 @@ var require_fetch = __commonJS({
       }
       const response = responseObject[kState];
       if (response.body != null && isReadable(response.body?.stream)) {
-        response.body.stream.cancel(error).catch((err) => {
+        response.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -15840,7 +16746,7 @@ processBodyError");
       function dispatch({ body }) {
         const url = requestCurrentURL(request);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve, reject) => agent.dispatch(
+        return new Promise((resolve2, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -15916,8 +16822,8 @@ processBodyError");
                   }
                 }
               }
-              const onError = this.onError.bind(this);
-              resolve({
+              const onError2 = this.onError.bind(this);
+              resolve2({
                 status,
                 statusText,
                 headersList,
@@ -15925,7 +16831,7 @@ processBodyError");
                   if (err) {
                     this.onError(err);
                   }
-                }).on("error", onError) : this.body.on("error", onError)
+                }).on("error", onError2) : this.body.on("error", onError2)
               });
               return true;
             },
@@ -15947,13 +16853,13 @@ processBodyError");
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onUpgrade(status, rawHeaders, socket) {
               if (status !== 101) {
@@ -15963,7 +16869,7 @@ processBodyError");
               for (let i = 0; i < rawHeaders.length; i += 2) {
                 headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i]), rawHeaders[i + 1].toString("latin1"), true);
               }
-              resolve({
+              resolve2({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList,
@@ -16374,7 +17280,7 @@ var require_util4 = __commonJS({
     var { getEncoding } = require_encoding();
     var { serializeAMimeType, parseMIMEType } = require_data_url();
     var { types } = require("node:util");
-    var { StringDecoder } = require("string_decoder");
+    var { StringDecoder: StringDecoder2 } = require("string_decoder");
     var { btoa } = require("node:buffer");
     var staticPropertyDescriptors = {
       enumerable: true,
@@ -16422,8 +17328,8 @@ var require_util4 = __commonJS({
                   }
                   fr[kResult] = result;
                   fireAProgressEvent("load", fr);
-                } catch (error) {
-                  fr[kError] = error;
+                } catch (error2) {
+                  fr[kError] = error2;
                   fireAProgressEvent("error", fr);
                 }
                 if (fr[kState] !== "loading") {
@@ -16432,13 +17338,13 @@ var require_util4 = __commonJS({
               });
               break;
             }
-          } catch (error) {
+          } catch (error2) {
             if (fr[kAborted]) {
               return;
             }
             queueMicrotask(() => {
               fr[kState] = "done";
-              fr[kError] = error;
+              fr[kError] = error2;
               fireAProgressEvent("error", fr);
               if (fr[kState] !== "loading") {
                 fireAProgressEvent("loadend", fr);
@@ -16467,7 +17373,7 @@ var require_util4 = __commonJS({
             dataURL += serializeAMimeType(parsed);
           }
           dataURL += ";base64,";
-          const decoder = new StringDecoder("latin1");
+          const decoder = new StringDecoder2("latin1");
           for (const chunk of bytes) {
             dataURL += btoa(decoder.write(chunk));
           }
@@ -16496,7 +17402,7 @@ var require_util4 = __commonJS({
         }
         case "BinaryString": {
           let binaryString = "";
-          const decoder = new StringDecoder("latin1");
+          const decoder = new StringDecoder2("latin1");
           for (const chunk of bytes) {
             binaryString += decoder.write(chunk);
           }
@@ -17192,8 +18098,8 @@ var require_cache = __commonJS({
        * @returns {requestResponseList}
        */
       #batchCacheOperations(operations) {
-        const cache = this.#relevantRequestResponseList;
-        const backupCache = [...cache];
+        const cache2 = this.#relevantRequestResponseList;
+        const backupCache = [...cache2];
         const addedItems = [];
         const resultList = [];
         try {
@@ -17220,9 +18126,9 @@ var require_cache = __commonJS({
                 return [];
               }
               for (const requestResponse of requestResponses) {
-                const idx = cache.indexOf(requestResponse);
+                const idx = cache2.indexOf(requestResponse);
                 assert(idx !== -1);
-                cache.splice(idx, 1);
+                cache2.splice(idx, 1);
               }
             } else if (operation.type === "put") {
               if (operation.response == null) {
@@ -17252,11 +18158,11 @@ var require_cache = __commonJS({
               }
               requestResponses = this.#queryCache(operation.request);
               for (const requestResponse of requestResponses) {
-                const idx = cache.indexOf(requestResponse);
+                const idx = cache2.indexOf(requestResponse);
                 assert(idx !== -1);
-                cache.splice(idx, 1);
+                cache2.splice(idx, 1);
               }
-              cache.push([operation.request, operation.response]);
+              cache2.push([operation.request, operation.response]);
               addedItems.push([operation.request, operation.response]);
             }
             resultList.push([operation.request, operation.response]);
@@ -17433,13 +18339,13 @@ var require_cachestorage = __commonJS({
         if (options.cacheName != null) {
           if (this.#caches.has(options.cacheName)) {
             const cacheList = this.#caches.get(options.cacheName);
-            const cache = new Cache(kConstruct, cacheList);
-            return await cache.match(request, options);
+            const cache2 = new Cache(kConstruct, cacheList);
+            return await cache2.match(request, options);
           }
         } else {
           for (const cacheList of this.#caches.values()) {
-            const cache = new Cache(kConstruct, cacheList);
-            const response = await cache.match(request, options);
+            const cache2 = new Cache(kConstruct, cacheList);
+            const response = await cache2.match(request, options);
             if (response !== void 0) {
               return response;
             }
@@ -17469,12 +18375,12 @@ var require_cachestorage = __commonJS({
         webidl.argumentLengthCheck(arguments, 1, prefix);
         cacheName = webidl.converters.DOMString(cacheName, prefix, "cacheName");
         if (this.#caches.has(cacheName)) {
-          const cache2 = this.#caches.get(cacheName);
-          return new Cache(kConstruct, cache2);
+          const cache3 = this.#caches.get(cacheName);
+          return new Cache(kConstruct, cache3);
         }
-        const cache = [];
-        this.#caches.set(cacheName, cache);
-        return new Cache(kConstruct, cache);
+        const cache2 = [];
+        this.#caches.set(cacheName, cache2);
+        return new Cache(kConstruct, cache2);
       }
       /**
        * @see https://w3c.github.io/ServiceWorker/#cache-storage-delete
@@ -17592,9 +18498,9 @@ var require_util6 = __commonJS({
       }
     }
     __name(validateCookieValue, "validateCookieValue");
-    function validateCookiePath(path) {
-      for (let i = 0; i < path.length; ++i) {
-        const code = path.charCodeAt(i);
+    function validateCookiePath(path5) {
+      for (let i = 0; i < path5.length; ++i) {
+        const code = path5.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18527,13 +19433,13 @@ var require_frame = __commonJS({
     "use strict";
     var { maxUnsigned16Bit } = require_constants5();
     var BUFFER_SIZE = 16386;
-    var crypto;
+    var crypto2;
     var buffer = null;
     var bufIdx = BUFFER_SIZE;
     try {
-      crypto = require("node:crypto");
+      crypto2 = require("node:crypto");
     } catch {
-      crypto = {
+      crypto2 = {
         // not full compatibility, but minimum.
         randomFillSync: /* @__PURE__ */ __name(function randomFillSync(buffer2, _offset, _size) {
           for (let i = 0; i < buffer2.length; ++i) {
@@ -18546,7 +19452,7 @@ var require_frame = __commonJS({
     function generateMask() {
       if (bufIdx === BUFFER_SIZE) {
         bufIdx = 0;
-        crypto.randomFillSync(buffer ??= Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE);
+        crypto2.randomFillSync(buffer ??= Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE);
       }
       return [buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++]];
     }
@@ -18622,9 +19528,9 @@ var require_connection = __commonJS({
     var { Headers: Headers2, getHeadersList } = require_headers();
     var { getDecodeSplit } = require_util2();
     var { WebsocketFrameSend } = require_frame();
-    var crypto;
+    var crypto2;
     try {
-      crypto = require("node:crypto");
+      crypto2 = require("node:crypto");
     } catch {
     }
     function establishWebSocketConnection(url, protocols, client, ws, onEstablish, options) {
@@ -18644,7 +19550,7 @@ var require_connection = __commonJS({
         const headersList = getHeadersList(new Headers2(options.headers));
         request.headersList = headersList;
       }
-      const keyValue = crypto.randomBytes(16).toString("base64");
+      const keyValue = crypto2.randomBytes(16).toString("base64");
       request.headersList.append("sec-websocket-key", keyValue);
       request.headersList.append("sec-websocket-version", "13");
       for (const protocol of protocols) {
@@ -18674,7 +19580,7 @@ var require_connection = __commonJS({
             return;
           }
           const secWSAccept = response.headersList.get("Sec-WebSocket-Accept");
-          const digest = crypto.createHash("sha1").update(keyValue + uid).digest("base64");
+          const digest = crypto2.createHash("sha1").update(keyValue + uid).digest("base64");
           if (secWSAccept !== digest) {
             failWebsocketConnection(ws, "Incorrect hash received in Sec-WebSocket-Accept header.");
             return;
@@ -18776,11 +19682,11 @@ var require_connection = __commonJS({
       }
     }
     __name(onSocketClose, "onSocketClose");
-    function onSocketError(error) {
+    function onSocketError(error2) {
       const { ws } = this;
       ws[kReadyState] = states.CLOSING;
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(error);
+        channels.socketError.publish(error2);
       }
       this.destroy();
     }
@@ -19054,9 +19960,9 @@ var require_receiver = __commonJS({
                 }
                 this.#state = parserStates.INFO;
               } else {
-                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error, data) => {
-                  if (error) {
-                    failWebsocketConnection(this.ws, error.message);
+                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error2, data) => {
+                  if (error2) {
+                    failWebsocketConnection(this.ws, error2.message);
                     return;
                   }
                   this.#fragments.push(data);
@@ -19561,11 +20467,11 @@ ns");
        */
       #onConnectionEstablished(response, parsedExtensions) {
         this[kResponse] = response;
-        const parser = new ByteParser(this, parsedExtensions);
-        parser.on("drain", onParserDrain);
-        parser.on("error", onParserError.bind(this));
+        const parser4 = new ByteParser(this, parsedExtensions);
+        parser4.on("drain", onParserDrain);
+        parser4.on("error", onParserError.bind(this));
         response.socket.ws = this;
-        this[kByteParser] = parser;
+        this[kByteParser] = parser4;
         this.#sendQueue = new SendQueue(response.socket);
         this[kReadyState] = states.OPEN;
         const extensions = response.headersList.get("sec-websocket-extensions");
@@ -19694,16 +20600,16 @@ var require_util8 = __commonJS({
       return true;
     }
     __name(isASCIINumber, "isASCIINumber");
-    function delay(ms) {
-      return new Promise((resolve) => {
-        setTimeout(resolve, ms).unref();
+    function delay2(ms) {
+      return new Promise((resolve2) => {
+        setTimeout(resolve2, ms).unref();
       });
     }
-    __name(delay, "delay");
+    __name(delay2, "delay");
     module2.exports = {
       isValidLastEventId,
       isASCIINumber,
-      delay
+      delay: delay2
     };
   }
 });
@@ -19953,7 +20859,7 @@ var require_eventsource = __commonJS({
     var { parseMIMEType } = require_data_url();
     var { createFastMessageEvent } = require_events();
     var { isNetworkError } = require_response();
-    var { delay } = require_util8();
+    var { delay: delay2 } = require_util8();
     var { kEnumerableProperty } = require_util();
     var { environmentSettingsObject } = require_util2();
     var experimentalWarned = false;
@@ -20109,8 +21015,8 @@ var require_eventsource = __commonJS({
           pipeline(
             response.body.stream,
             eventSourceStream,
-            (error) => {
-              if (error?.aborted === false) {
+            (error2) => {
+              if (error2?.aborted === false) {
                 this.close();
                 this.dispatchEvent(new Event("error"));
               }
@@ -20127,7 +21033,7 @@ var require_eventsource = __commonJS({
         if (this.#readyState === CLOSED) return;
         this.#readyState = CONNECTING;
         this.dispatchEvent(new Event("error"));
-        await delay(this.#state.reconnectionTime);
+        await delay2(this.#state.reconnectionTime);
         if (this.#readyState !== CONNECTING) return;
         if (this.#state.lastEventId.length) {
           this.#request.headersList.set("last-event-id", this.#state.lastEventId, true);
@@ -20308,11 +21214,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path = opts.path;
+          let path5 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path = `/${path}`;
+            path5 = `/${path5}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path);
+          url = new URL(util.parseOrigin(url).origin + path5);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -20384,8 +21290,6401 @@ var require_undici = __commonJS({
   }
 });
 
-// setup-gcloud/src/cleanup.js
-var import_node_fs = __toESM(require("node:fs"), 1);
+// node_modules/semver/internal/constants.js
+var require_constants6 = __commonJS({
+  "node_modules/semver/internal/constants.js"(exports2, module2) {
+    "use strict";
+    var SEMVER_SPEC_VERSION = "2.0.0";
+    var MAX_LENGTH = 256;
+    var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || /* istanbul ignore next */
+    9007199254740991;
+    var MAX_SAFE_COMPONENT_LENGTH = 16;
+    var MAX_SAFE_BUILD_LENGTH = MAX_LENGTH - 6;
+    var RELEASE_TYPES = [
+      "major",
+      "premajor",
+      "minor",
+      "preminor",
+      "patch",
+      "prepatch",
+      "prerelease"
+    ];
+    module2.exports = {
+      MAX_LENGTH,
+      MAX_SAFE_COMPONENT_LENGTH,
+      MAX_SAFE_BUILD_LENGTH,
+      MAX_SAFE_INTEGER,
+      RELEASE_TYPES,
+      SEMVER_SPEC_VERSION,
+      FLAG_INCLUDE_PRERELEASE: 1,
+      FLAG_LOOSE: 2
+    };
+  }
+});
+
+// node_modules/semver/internal/debug.js
+var require_debug = __commonJS({
+  "node_modules/semver/internal/debug.js"(exports2, module2) {
+    "use strict";
+    var debug3 = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.
+    NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
+    };
+    module2.exports = debug3;
+  }
+});
+
+// node_modules/semver/internal/re.js
+var require_re = __commonJS({
+  "node_modules/semver/internal/re.js"(exports2, module2) {
+    "use strict";
+    var {
+      MAX_SAFE_COMPONENT_LENGTH,
+      MAX_SAFE_BUILD_LENGTH,
+      MAX_LENGTH
+    } = require_constants6();
+    var debug3 = require_debug();
+    exports2 = module2.exports = {};
+    var re = exports2.re = [];
+    var safeRe = exports2.safeRe = [];
+    var src = exports2.src = [];
+    var safeSrc = exports2.safeSrc = [];
+    var t = exports2.t = {};
+    var R = 0;
+    var LETTERDASHNUMBER = "[a-zA-Z0-9-]";
+    var safeRegexReplacements = [
+      ["\\s", 1],
+      ["\\d", MAX_LENGTH],
+      [LETTERDASHNUMBER, MAX_SAFE_BUILD_LENGTH]
+    ];
+    var makeSafeRegex = /* @__PURE__ */ __name((value) => {
+      for (const [token, max] of safeRegexReplacements) {
+        value = value.split(`${token}*`).join(`${token}{0,${max}}`).split(`${token}+`).join(`${token}{1,${max}}`);
+      }
+      return value;
+    }, "makeSafeRegex");
+    var createToken = /* @__PURE__ */ __name((name, value, isGlobal) => {
+      const safe = makeSafeRegex(value);
+      const index = R++;
+      debug3(name, index, value);
+      t[name] = index;
+      src[index] = value;
+      safeSrc[index] = safe;
+      re[index] = new RegExp(value, isGlobal ? "g" : void 0);
+      safeRe[index] = new RegExp(safe, isGlobal ? "g" : void 0);
+    }, "createToken");
+    createToken("NUMERICIDENTIFIER", "0|[1-9]\\d*");
+    createToken("NUMERICIDENTIFIERLOOSE", "\\d+");
+    createToken("NONNUMERICIDENTIFIER", `\\d*[a-zA-Z-]${LETTERDASHNUMBER}*`);
+    createToken("MAINVERSION", `(${src[t.NUMERICIDENTIFIER]})\\.(${src[t.NUMERICIDENTIFIER]})\\.(${src[t.NUMERICIDENTIFIER]}\
+)`);
+    createToken("MAINVERSIONLOOSE", `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.(${src[t.NUMERICIDENTIFIERLOOSE]})\\.(${src[t.
+    NUMERICIDENTIFIERLOOSE]})`);
+    createToken("PRERELEASEIDENTIFIER", `(?:${src[t.NONNUMERICIDENTIFIER]}|${src[t.NUMERICIDENTIFIER]})`);
+    createToken("PRERELEASEIDENTIFIERLOOSE", `(?:${src[t.NONNUMERICIDENTIFIER]}|${src[t.NUMERICIDENTIFIERLOOSE]})`);
+    createToken("PRERELEASE", `(?:-(${src[t.PRERELEASEIDENTIFIER]}(?:\\.${src[t.PRERELEASEIDENTIFIER]})*))`);
+    createToken("PRERELEASELOOSE", `(?:-?(${src[t.PRERELEASEIDENTIFIERLOOSE]}(?:\\.${src[t.PRERELEASEIDENTIFIERLOOSE]})*\
+))`);
+    createToken("BUILDIDENTIFIER", `${LETTERDASHNUMBER}+`);
+    createToken("BUILD", `(?:\\+(${src[t.BUILDIDENTIFIER]}(?:\\.${src[t.BUILDIDENTIFIER]})*))`);
+    createToken("FULLPLAIN", `v?${src[t.MAINVERSION]}${src[t.PRERELEASE]}?${src[t.BUILD]}?`);
+    createToken("FULL", `^${src[t.FULLPLAIN]}$`);
+    createToken("LOOSEPLAIN", `[v=\\s]*${src[t.MAINVERSIONLOOSE]}${src[t.PRERELEASELOOSE]}?${src[t.BUILD]}?`);
+    createToken("LOOSE", `^${src[t.LOOSEPLAIN]}$`);
+    createToken("GTLT", "((?:<|>)?=?)");
+    createToken("XRANGEIDENTIFIERLOOSE", `${src[t.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`);
+    createToken("XRANGEIDENTIFIER", `${src[t.NUMERICIDENTIFIER]}|x|X|\\*`);
+    createToken("XRANGEPLAIN", `[v=\\s]*(${src[t.XRANGEIDENTIFIER]})(?:\\.(${src[t.XRANGEIDENTIFIER]})(?:\\.(${src[t.XRANGEIDENTIFIER]}\
+)(?:${src[t.PRERELEASE]})?${src[t.BUILD]}?)?)?`);
+    createToken("XRANGEPLAINLOOSE", `[v=\\s]*(${src[t.XRANGEIDENTIFIERLOOSE]})(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})(?:\
+\\.(${src[t.XRANGEIDENTIFIERLOOSE]})(?:${src[t.PRERELEASELOOSE]})?${src[t.BUILD]}?)?)?`);
+    createToken("XRANGE", `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAIN]}$`);
+    createToken("XRANGELOOSE", `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("COERCEPLAIN", `${"(^|[^\\d])(\\d{1,"}${MAX_SAFE_COMPONENT_LENGTH}})(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}\
+}))?(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?`);
+    createToken("COERCE", `${src[t.COERCEPLAIN]}(?:$|[^\\d])`);
+    createToken("COERCEFULL", src[t.COERCEPLAIN] + `(?:${src[t.PRERELEASE]})?(?:${src[t.BUILD]})?(?:$|[^\\d])`);
+    createToken("COERCERTL", src[t.COERCE], true);
+    createToken("COERCERTLFULL", src[t.COERCEFULL], true);
+    createToken("LONETILDE", "(?:~>?)");
+    createToken("TILDETRIM", `(\\s*)${src[t.LONETILDE]}\\s+`, true);
+    exports2.tildeTrimReplace = "$1~";
+    createToken("TILDE", `^${src[t.LONETILDE]}${src[t.XRANGEPLAIN]}$`);
+    createToken("TILDELOOSE", `^${src[t.LONETILDE]}${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("LONECARET", "(?:\\^)");
+    createToken("CARETTRIM", `(\\s*)${src[t.LONECARET]}\\s+`, true);
+    exports2.caretTrimReplace = "$1^";
+    createToken("CARET", `^${src[t.LONECARET]}${src[t.XRANGEPLAIN]}$`);
+    createToken("CARETLOOSE", `^${src[t.LONECARET]}${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("COMPARATORLOOSE", `^${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]})$|^$`);
+    createToken("COMPARATOR", `^${src[t.GTLT]}\\s*(${src[t.FULLPLAIN]})$|^$`);
+    createToken("COMPARATORTRIM", `(\\s*)${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]}|${src[t.XRANGEPLAIN]})`, true);
+    exports2.comparatorTrimReplace = "$1$2$3";
+    createToken("HYPHENRANGE", `^\\s*(${src[t.XRANGEPLAIN]})\\s+-\\s+(${src[t.XRANGEPLAIN]})\\s*$`);
+    createToken("HYPHENRANGELOOSE", `^\\s*(${src[t.XRANGEPLAINLOOSE]})\\s+-\\s+(${src[t.XRANGEPLAINLOOSE]})\\s*$`);
+    createToken("STAR", "(<|>)?=?\\s*\\*");
+    createToken("GTE0", "^\\s*>=\\s*0\\.0\\.0\\s*$");
+    createToken("GTE0PRE", "^\\s*>=\\s*0\\.0\\.0-0\\s*$");
+  }
+});
+
+// node_modules/semver/internal/parse-options.js
+var require_parse_options = __commonJS({
+  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+    "use strict";
+    var looseOption = Object.freeze({ loose: true });
+    var emptyOpts = Object.freeze({});
+    var parseOptions = /* @__PURE__ */ __name((options) => {
+      if (!options) {
+        return emptyOpts;
+      }
+      if (typeof options !== "object") {
+        return looseOption;
+      }
+      return options;
+    }, "parseOptions");
+    module2.exports = parseOptions;
+  }
+});
+
+// node_modules/semver/internal/identifiers.js
+var require_identifiers = __commonJS({
+  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+    "use strict";
+    var numeric = /^[0-9]+$/;
+    var compareIdentifiers = /* @__PURE__ */ __name((a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
+      const anum = numeric.test(a);
+      const bnum = numeric.test(b);
+      if (anum && bnum) {
+        a = +a;
+        b = +b;
+      }
+      return a === b ? 0 : anum && !bnum ? -1 : bnum && !anum ? 1 : a < b ? -1 : 1;
+    }, "compareIdentifiers");
+    var rcompareIdentifiers = /* @__PURE__ */ __name((a, b) => compareIdentifiers(b, a), "rcompareIdentifiers");
+    module2.exports = {
+      compareIdentifiers,
+      rcompareIdentifiers
+    };
+  }
+});
+
+// node_modules/semver/classes/semver.js
+var require_semver = __commonJS({
+  "node_modules/semver/classes/semver.js"(exports2, module2) {
+    "use strict";
+    var debug3 = require_debug();
+    var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants6();
+    var { safeRe: re, t } = require_re();
+    var parseOptions = require_parse_options();
+    var { compareIdentifiers } = require_identifiers();
+    var SemVer = class _SemVer {
+      static {
+        __name(this, "SemVer");
+      }
+      constructor(version, options) {
+        options = parseOptions(options);
+        if (version instanceof _SemVer) {
+          if (version.loose === !!options.loose && version.includePrerelease === !!options.includePrerelease) {
+            return version;
+          } else {
+            version = version.version;
+          }
+        } else if (typeof version !== "string") {
+          throw new TypeError(`Invalid version. Must be a string. Got type "${typeof version}".`);
+        }
+        if (version.length > MAX_LENGTH) {
+          throw new TypeError(
+            `version is longer than ${MAX_LENGTH} characters`
+          );
+        }
+        debug3("SemVer", version, options);
+        this.options = options;
+        this.loose = !!options.loose;
+        this.includePrerelease = !!options.includePrerelease;
+        const m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL]);
+        if (!m) {
+          throw new TypeError(`Invalid Version: ${version}`);
+        }
+        this.raw = version;
+        this.major = +m[1];
+        this.minor = +m[2];
+        this.patch = +m[3];
+        if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
+          throw new TypeError("Invalid major version");
+        }
+        if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
+          throw new TypeError("Invalid minor version");
+        }
+        if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
+          throw new TypeError("Invalid patch version");
+        }
+        if (!m[4]) {
+          this.prerelease = [];
+        } else {
+          this.prerelease = m[4].split(".").map((id) => {
+            if (/^[0-9]+$/.test(id)) {
+              const num = +id;
+              if (num >= 0 && num < MAX_SAFE_INTEGER) {
+                return num;
+              }
+            }
+            return id;
+          });
+        }
+        this.build = m[5] ? m[5].split(".") : [];
+        this.format();
+      }
+      format() {
+        this.version = `${this.major}.${this.minor}.${this.patch}`;
+        if (this.prerelease.length) {
+          this.version += `-${this.prerelease.join(".")}`;
+        }
+        return this.version;
+      }
+      toString() {
+        return this.version;
+      }
+      compare(other) {
+        debug3("SemVer.compare", this.version, this.options, other);
+        if (!(other instanceof _SemVer)) {
+          if (typeof other === "string" && other === this.version) {
+            return 0;
+          }
+          other = new _SemVer(other, this.options);
+        }
+        if (other.version === this.version) {
+          return 0;
+        }
+        return this.compareMain(other) || this.comparePre(other);
+      }
+      compareMain(other) {
+        if (!(other instanceof _SemVer)) {
+          other = new _SemVer(other, this.options);
+        }
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
+      }
+      comparePre(other) {
+        if (!(other instanceof _SemVer)) {
+          other = new _SemVer(other, this.options);
+        }
+        if (this.prerelease.length && !other.prerelease.length) {
+          return -1;
+        } else if (!this.prerelease.length && other.prerelease.length) {
+          return 1;
+        } else if (!this.prerelease.length && !other.prerelease.length) {
+          return 0;
+        }
+        let i = 0;
+        do {
+          const a = this.prerelease[i];
+          const b = other.prerelease[i];
+          debug3("prerelease compare", i, a, b);
+          if (a === void 0 && b === void 0) {
+            return 0;
+          } else if (b === void 0) {
+            return 1;
+          } else if (a === void 0) {
+            return -1;
+          } else if (a === b) {
+            continue;
+          } else {
+            return compareIdentifiers(a, b);
+          }
+        } while (++i);
+      }
+      compareBuild(other) {
+        if (!(other instanceof _SemVer)) {
+          other = new _SemVer(other, this.options);
+        }
+        let i = 0;
+        do {
+          const a = this.build[i];
+          const b = other.build[i];
+          debug3("build compare", i, a, b);
+          if (a === void 0 && b === void 0) {
+            return 0;
+          } else if (b === void 0) {
+            return 1;
+          } else if (a === void 0) {
+            return -1;
+          } else if (a === b) {
+            continue;
+          } else {
+            return compareIdentifiers(a, b);
+          }
+        } while (++i);
+      }
+      // preminor will bump the version up to the next minor release, and immediately
+      // down to pre-release. premajor and prepatch work the same way.
+      inc(release, identifier, identifierBase) {
+        if (release.startsWith("pre")) {
+          if (!identifier && identifierBase === false) {
+            throw new Error("invalid increment argument: identifier is empty");
+          }
+          if (identifier) {
+            const match = `-${identifier}`.match(this.options.loose ? re[t.PRERELEASELOOSE] : re[t.PRERELEASE]);
+            if (!match || match[1] !== identifier) {
+              throw new Error(`invalid identifier: ${identifier}`);
+            }
+          }
+        }
+        switch (release) {
+          case "premajor":
+            this.prerelease.length = 0;
+            this.patch = 0;
+            this.minor = 0;
+            this.major++;
+            this.inc("pre", identifier, identifierBase);
+            break;
+          case "preminor":
+            this.prerelease.length = 0;
+            this.patch = 0;
+            this.minor++;
+            this.inc("pre", identifier, identifierBase);
+            break;
+          case "prepatch":
+            this.prerelease.length = 0;
+            this.inc("patch", identifier, identifierBase);
+            this.inc("pre", identifier, identifierBase);
+            break;
+          // If the input is a non-prerelease version, this acts the same as
+          // prepatch.
+          case "prerelease":
+            if (this.prerelease.length === 0) {
+              this.inc("patch", identifier, identifierBase);
+            }
+            this.inc("pre", identifier, identifierBase);
+            break;
+          case "release":
+            if (this.prerelease.length === 0) {
+              throw new Error(`version ${this.raw} is not a prerelease`);
+            }
+            this.prerelease.length = 0;
+            break;
+          case "major":
+            if (this.minor !== 0 || this.patch !== 0 || this.prerelease.length === 0) {
+              this.major++;
+            }
+            this.minor = 0;
+            this.patch = 0;
+            this.prerelease = [];
+            break;
+          case "minor":
+            if (this.patch !== 0 || this.prerelease.length === 0) {
+              this.minor++;
+            }
+            this.patch = 0;
+            this.prerelease = [];
+            break;
+          case "patch":
+            if (this.prerelease.length === 0) {
+              this.patch++;
+            }
+            this.prerelease = [];
+            break;
+          // This probably shouldn't be used publicly.
+          // 1.0.0 'pre' would become 1.0.0-0 which is the wrong direction.
+          case "pre": {
+            const base = Number(identifierBase) ? 1 : 0;
+            if (this.prerelease.length === 0) {
+              this.prerelease = [base];
+            } else {
+              let i = this.prerelease.length;
+              while (--i >= 0) {
+                if (typeof this.prerelease[i] === "number") {
+                  this.prerelease[i]++;
+                  i = -2;
+                }
+              }
+              if (i === -1) {
+                if (identifier === this.prerelease.join(".") && identifierBase === false) {
+                  throw new Error("invalid increment argument: identifier already exists");
+                }
+                this.prerelease.push(base);
+              }
+            }
+            if (identifier) {
+              let prerelease = [identifier, base];
+              if (identifierBase === false) {
+                prerelease = [identifier];
+              }
+              if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+                if (isNaN(this.prerelease[1])) {
+                  this.prerelease = prerelease;
+                }
+              } else {
+                this.prerelease = prerelease;
+              }
+            }
+            break;
+          }
+          default:
+            throw new Error(`invalid increment argument: ${release}`);
+        }
+        this.raw = this.format();
+        if (this.build.length) {
+          this.raw += `+${this.build.join(".")}`;
+        }
+        return this;
+      }
+    };
+    module2.exports = SemVer;
+  }
+});
+
+// node_modules/semver/functions/parse.js
+var require_parse2 = __commonJS({
+  "node_modules/semver/functions/parse.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var parse = /* @__PURE__ */ __name((version, options, throwErrors = false) => {
+      if (version instanceof SemVer) {
+        return version;
+      }
+      try {
+        return new SemVer(version, options);
+      } catch (er) {
+        if (!throwErrors) {
+          return null;
+        }
+        throw er;
+      }
+    }, "parse");
+    module2.exports = parse;
+  }
+});
+
+// node_modules/semver/functions/valid.js
+var require_valid = __commonJS({
+  "node_modules/semver/functions/valid.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var valid2 = /* @__PURE__ */ __name((version, options) => {
+      const v = parse(version, options);
+      return v ? v.version : null;
+    }, "valid");
+    module2.exports = valid2;
+  }
+});
+
+// node_modules/semver/functions/clean.js
+var require_clean = __commonJS({
+  "node_modules/semver/functions/clean.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var clean2 = /* @__PURE__ */ __name((version, options) => {
+      const s = parse(version.trim().replace(/^[=v]+/, ""), options);
+      return s ? s.version : null;
+    }, "clean");
+    module2.exports = clean2;
+  }
+});
+
+// node_modules/semver/functions/inc.js
+var require_inc = __commonJS({
+  "node_modules/semver/functions/inc.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var inc = /* @__PURE__ */ __name((version, release, options, identifier, identifierBase) => {
+      if (typeof options === "string") {
+        identifierBase = identifier;
+        identifier = options;
+        options = void 0;
+      }
+      try {
+        return new SemVer(
+          version instanceof SemVer ? version.version : version,
+          options
+        ).inc(release, identifier, identifierBase).version;
+      } catch (er) {
+        return null;
+      }
+    }, "inc");
+    module2.exports = inc;
+  }
+});
+
+// node_modules/semver/functions/diff.js
+var require_diff = __commonJS({
+  "node_modules/semver/functions/diff.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var diff = /* @__PURE__ */ __name((version1, version2) => {
+      const v1 = parse(version1, null, true);
+      const v2 = parse(version2, null, true);
+      const comparison = v1.compare(v2);
+      if (comparison === 0) {
+        return null;
+      }
+      const v1Higher = comparison > 0;
+      const highVersion = v1Higher ? v1 : v2;
+      const lowVersion = v1Higher ? v2 : v1;
+      const highHasPre = !!highVersion.prerelease.length;
+      const lowHasPre = !!lowVersion.prerelease.length;
+      if (lowHasPre && !highHasPre) {
+        if (!lowVersion.patch && !lowVersion.minor) {
+          return "major";
+        }
+        if (lowVersion.compareMain(highVersion) === 0) {
+          if (lowVersion.minor && !lowVersion.patch) {
+            return "minor";
+          }
+          return "patch";
+        }
+      }
+      const prefix = highHasPre ? "pre" : "";
+      if (v1.major !== v2.major) {
+        return prefix + "major";
+      }
+      if (v1.minor !== v2.minor) {
+        return prefix + "minor";
+      }
+      if (v1.patch !== v2.patch) {
+        return prefix + "patch";
+      }
+      return "prerelease";
+    }, "diff");
+    module2.exports = diff;
+  }
+});
+
+// node_modules/semver/functions/major.js
+var require_major = __commonJS({
+  "node_modules/semver/functions/major.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var major = /* @__PURE__ */ __name((a, loose) => new SemVer(a, loose).major, "major");
+    module2.exports = major;
+  }
+});
+
+// node_modules/semver/functions/minor.js
+var require_minor = __commonJS({
+  "node_modules/semver/functions/minor.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var minor = /* @__PURE__ */ __name((a, loose) => new SemVer(a, loose).minor, "minor");
+    module2.exports = minor;
+  }
+});
+
+// node_modules/semver/functions/patch.js
+var require_patch = __commonJS({
+  "node_modules/semver/functions/patch.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var patch = /* @__PURE__ */ __name((a, loose) => new SemVer(a, loose).patch, "patch");
+    module2.exports = patch;
+  }
+});
+
+// node_modules/semver/functions/prerelease.js
+var require_prerelease = __commonJS({
+  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+    "use strict";
+    var parse = require_parse2();
+    var prerelease = /* @__PURE__ */ __name((version, options) => {
+      const parsed = parse(version, options);
+      return parsed && parsed.prerelease.length ? parsed.prerelease : null;
+    }, "prerelease");
+    module2.exports = prerelease;
+  }
+});
+
+// node_modules/semver/functions/compare.js
+var require_compare = __commonJS({
+  "node_modules/semver/functions/compare.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var compare = /* @__PURE__ */ __name((a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose)), "compare");
+    module2.exports = compare;
+  }
+});
+
+// node_modules/semver/functions/rcompare.js
+var require_rcompare = __commonJS({
+  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var rcompare = /* @__PURE__ */ __name((a, b, loose) => compare(b, a, loose), "rcompare");
+    module2.exports = rcompare;
+  }
+});
+
+// node_modules/semver/functions/compare-loose.js
+var require_compare_loose = __commonJS({
+  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var compareLoose = /* @__PURE__ */ __name((a, b) => compare(a, b, true), "compareLoose");
+    module2.exports = compareLoose;
+  }
+});
+
+// node_modules/semver/functions/compare-build.js
+var require_compare_build = __commonJS({
+  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var compareBuild = /* @__PURE__ */ __name((a, b, loose) => {
+      const versionA = new SemVer(a, loose);
+      const versionB = new SemVer(b, loose);
+      return versionA.compare(versionB) || versionA.compareBuild(versionB);
+    }, "compareBuild");
+    module2.exports = compareBuild;
+  }
+});
+
+// node_modules/semver/functions/sort.js
+var require_sort = __commonJS({
+  "node_modules/semver/functions/sort.js"(exports2, module2) {
+    "use strict";
+    var compareBuild = require_compare_build();
+    var sort = /* @__PURE__ */ __name((list, loose) => list.sort((a, b) => compareBuild(a, b, loose)), "sort");
+    module2.exports = sort;
+  }
+});
+
+// node_modules/semver/functions/rsort.js
+var require_rsort = __commonJS({
+  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+    "use strict";
+    var compareBuild = require_compare_build();
+    var rsort = /* @__PURE__ */ __name((list, loose) => list.sort((a, b) => compareBuild(b, a, loose)), "rsort");
+    module2.exports = rsort;
+  }
+});
+
+// node_modules/semver/functions/gt.js
+var require_gt = __commonJS({
+  "node_modules/semver/functions/gt.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var gt2 = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) > 0, "gt");
+    module2.exports = gt2;
+  }
+});
+
+// node_modules/semver/functions/lt.js
+var require_lt = __commonJS({
+  "node_modules/semver/functions/lt.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var lt = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) < 0, "lt");
+    module2.exports = lt;
+  }
+});
+
+// node_modules/semver/functions/eq.js
+var require_eq = __commonJS({
+  "node_modules/semver/functions/eq.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var eq = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) === 0, "eq");
+    module2.exports = eq;
+  }
+});
+
+// node_modules/semver/functions/neq.js
+var require_neq = __commonJS({
+  "node_modules/semver/functions/neq.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var neq = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) !== 0, "neq");
+    module2.exports = neq;
+  }
+});
+
+// node_modules/semver/functions/gte.js
+var require_gte = __commonJS({
+  "node_modules/semver/functions/gte.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var gte = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) >= 0, "gte");
+    module2.exports = gte;
+  }
+});
+
+// node_modules/semver/functions/lte.js
+var require_lte = __commonJS({
+  "node_modules/semver/functions/lte.js"(exports2, module2) {
+    "use strict";
+    var compare = require_compare();
+    var lte = /* @__PURE__ */ __name((a, b, loose) => compare(a, b, loose) <= 0, "lte");
+    module2.exports = lte;
+  }
+});
+
+// node_modules/semver/functions/cmp.js
+var require_cmp = __commonJS({
+  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+    "use strict";
+    var eq = require_eq();
+    var neq = require_neq();
+    var gt2 = require_gt();
+    var gte = require_gte();
+    var lt = require_lt();
+    var lte = require_lte();
+    var cmp = /* @__PURE__ */ __name((a, op, b, loose) => {
+      switch (op) {
+        case "===":
+          if (typeof a === "object") {
+            a = a.version;
+          }
+          if (typeof b === "object") {
+            b = b.version;
+          }
+          return a === b;
+        case "!==":
+          if (typeof a === "object") {
+            a = a.version;
+          }
+          if (typeof b === "object") {
+            b = b.version;
+          }
+          return a !== b;
+        case "":
+        case "=":
+        case "==":
+          return eq(a, b, loose);
+        case "!=":
+          return neq(a, b, loose);
+        case ">":
+          return gt2(a, b, loose);
+        case ">=":
+          return gte(a, b, loose);
+        case "<":
+          return lt(a, b, loose);
+        case "<=":
+          return lte(a, b, loose);
+        default:
+          throw new TypeError(`Invalid operator: ${op}`);
+      }
+    }, "cmp");
+    module2.exports = cmp;
+  }
+});
+
+// node_modules/semver/functions/coerce.js
+var require_coerce = __commonJS({
+  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var parse = require_parse2();
+    var { safeRe: re, t } = require_re();
+    var coerce = /* @__PURE__ */ __name((version, options) => {
+      if (version instanceof SemVer) {
+        return version;
+      }
+      if (typeof version === "number") {
+        version = String(version);
+      }
+      if (typeof version !== "string") {
+        return null;
+      }
+      options = options || {};
+      let match = null;
+      if (!options.rtl) {
+        match = version.match(options.includePrerelease ? re[t.COERCEFULL] : re[t.COERCE]);
+      } else {
+        const coerceRtlRegex = options.includePrerelease ? re[t.COERCERTLFULL] : re[t.COERCERTL];
+        let next;
+        while ((next = coerceRtlRegex.exec(version)) && (!match || match.index + match[0].length !== version.length)) {
+          if (!match || next.index + next[0].length !== match.index + match[0].length) {
+            match = next;
+          }
+          coerceRtlRegex.lastIndex = next.index + next[1].length + next[2].length;
+        }
+        coerceRtlRegex.lastIndex = -1;
+      }
+      if (match === null) {
+        return null;
+      }
+      const major = match[2];
+      const minor = match[3] || "0";
+      const patch = match[4] || "0";
+      const prerelease = options.includePrerelease && match[5] ? `-${match[5]}` : "";
+      const build = options.includePrerelease && match[6] ? `+${match[6]}` : "";
+      return parse(`${major}.${minor}.${patch}${prerelease}${build}`, options);
+    }, "coerce");
+    module2.exports = coerce;
+  }
+});
+
+// node_modules/semver/internal/lrucache.js
+var require_lrucache = __commonJS({
+  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+    "use strict";
+    var LRUCache = class {
+      static {
+        __name(this, "LRUCache");
+      }
+      constructor() {
+        this.max = 1e3;
+        this.map = /* @__PURE__ */ new Map();
+      }
+      get(key) {
+        const value = this.map.get(key);
+        if (value === void 0) {
+          return void 0;
+        } else {
+          this.map.delete(key);
+          this.map.set(key, value);
+          return value;
+        }
+      }
+      delete(key) {
+        return this.map.delete(key);
+      }
+      set(key, value) {
+        const deleted = this.delete(key);
+        if (!deleted && value !== void 0) {
+          if (this.map.size >= this.max) {
+            const firstKey = this.map.keys().next().value;
+            this.delete(firstKey);
+          }
+          this.map.set(key, value);
+        }
+        return this;
+      }
+    };
+    module2.exports = LRUCache;
+  }
+});
+
+// node_modules/semver/classes/range.js
+var require_range = __commonJS({
+  "node_modules/semver/classes/range.js"(exports2, module2) {
+    "use strict";
+    var SPACE_CHARACTERS = /\s+/g;
+    var Range = class _Range {
+      static {
+        __name(this, "Range");
+      }
+      constructor(range, options) {
+        options = parseOptions(options);
+        if (range instanceof _Range) {
+          if (range.loose === !!options.loose && range.includePrerelease === !!options.includePrerelease) {
+            return range;
+          } else {
+            return new _Range(range.raw, options);
+          }
+        }
+        if (range instanceof Comparator) {
+          this.raw = range.value;
+          this.set = [[range]];
+          this.formatted = void 0;
+          return this;
+        }
+        this.options = options;
+        this.loose = !!options.loose;
+        this.includePrerelease = !!options.includePrerelease;
+        this.raw = range.trim().replace(SPACE_CHARACTERS, " ");
+        this.set = this.raw.split("||").map((r) => this.parseRange(r.trim())).filter((c) => c.length);
+        if (!this.set.length) {
+          throw new TypeError(`Invalid SemVer Range: ${this.raw}`);
+        }
+        if (this.set.length > 1) {
+          const first2 = this.set[0];
+          this.set = this.set.filter((c) => !isNullSet(c[0]));
+          if (this.set.length === 0) {
+            this.set = [first2];
+          } else if (this.set.length > 1) {
+            for (const c of this.set) {
+              if (c.length === 1 && isAny(c[0])) {
+                this.set = [c];
+                break;
+              }
+            }
+          }
+        }
+        this.formatted = void 0;
+      }
+      get range() {
+        if (this.formatted === void 0) {
+          this.formatted = "";
+          for (let i = 0; i < this.set.length; i++) {
+            if (i > 0) {
+              this.formatted += "||";
+            }
+            const comps = this.set[i];
+            for (let k = 0; k < comps.length; k++) {
+              if (k > 0) {
+                this.formatted += " ";
+              }
+              this.formatted += comps[k].toString().trim();
+            }
+          }
+        }
+        return this.formatted;
+      }
+      format() {
+        return this.range;
+      }
+      toString() {
+        return this.range;
+      }
+      parseRange(range) {
+        const memoOpts = (this.options.includePrerelease && FLAG_INCLUDE_PRERELEASE) | (this.options.loose && FLAG_LOOSE);
+        const memoKey = memoOpts + ":" + range;
+        const cached = cache2.get(memoKey);
+        if (cached) {
+          return cached;
+        }
+        const loose = this.options.loose;
+        const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
+        range = range.replace(hr, hyphenReplace(this.options.includePrerelease));
+        debug3("hyphen replace", range);
+        range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
+        debug3("comparator trim", range);
+        range = range.replace(re[t.TILDETRIM], tildeTrimReplace);
+        debug3("tilde trim", range);
+        range = range.replace(re[t.CARETTRIM], caretTrimReplace);
+        debug3("caret trim", range);
+        let rangeList = range.split(" ").map((comp) => parseComparator(comp, this.options)).join(" ").split(/\s+/).map((comp) => replaceGTE0(
+        comp, this.options));
+        if (loose) {
+          rangeList = rangeList.filter((comp) => {
+            debug3("loose invalid filter", comp, this.options);
+            return !!comp.match(re[t.COMPARATORLOOSE]);
+          });
+        }
+        debug3("range list", rangeList);
+        const rangeMap = /* @__PURE__ */ new Map();
+        const comparators = rangeList.map((comp) => new Comparator(comp, this.options));
+        for (const comp of comparators) {
+          if (isNullSet(comp)) {
+            return [comp];
+          }
+          rangeMap.set(comp.value, comp);
+        }
+        if (rangeMap.size > 1 && rangeMap.has("")) {
+          rangeMap.delete("");
+        }
+        const result = [...rangeMap.values()];
+        cache2.set(memoKey, result);
+        return result;
+      }
+      intersects(range, options) {
+        if (!(range instanceof _Range)) {
+          throw new TypeError("a Range is required");
+        }
+        return this.set.some((thisComparators) => {
+          return isSatisfiable(thisComparators, options) && range.set.some((rangeComparators) => {
+            return isSatisfiable(rangeComparators, options) && thisComparators.every((thisComparator) => {
+              return rangeComparators.every((rangeComparator) => {
+                return thisComparator.intersects(rangeComparator, options);
+              });
+            });
+          });
+        });
+      }
+      // if ANY of the sets match ALL of its comparators, then pass
+      test(version) {
+        if (!version) {
+          return false;
+        }
+        if (typeof version === "string") {
+          try {
+            version = new SemVer(version, this.options);
+          } catch (er) {
+            return false;
+          }
+        }
+        for (let i = 0; i < this.set.length; i++) {
+          if (testSet(this.set[i], version, this.options)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+    module2.exports = Range;
+    var LRU = require_lrucache();
+    var cache2 = new LRU();
+    var parseOptions = require_parse_options();
+    var Comparator = require_comparator();
+    var debug3 = require_debug();
+    var SemVer = require_semver();
+    var {
+      safeRe: re,
+      t,
+      comparatorTrimReplace,
+      tildeTrimReplace,
+      caretTrimReplace
+    } = require_re();
+    var { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = require_constants6();
+    var isNullSet = /* @__PURE__ */ __name((c) => c.value === "<0.0.0-0", "isNullSet");
+    var isAny = /* @__PURE__ */ __name((c) => c.value === "", "isAny");
+    var isSatisfiable = /* @__PURE__ */ __name((comparators, options) => {
+      let result = true;
+      const remainingComparators = comparators.slice();
+      let testComparator = remainingComparators.pop();
+      while (result && remainingComparators.length) {
+        result = remainingComparators.every((otherComparator) => {
+          return testComparator.intersects(otherComparator, options);
+        });
+        testComparator = remainingComparators.pop();
+      }
+      return result;
+    }, "isSatisfiable");
+    var parseComparator = /* @__PURE__ */ __name((comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
+      debug3("comp", comp, options);
+      comp = replaceCarets(comp, options);
+      debug3("caret", comp);
+      comp = replaceTildes(comp, options);
+      debug3("tildes", comp);
+      comp = replaceXRanges(comp, options);
+      debug3("xrange", comp);
+      comp = replaceStars(comp, options);
+      debug3("stars", comp);
+      return comp;
+    }, "parseComparator");
+    var isX = /* @__PURE__ */ __name((id) => !id || id.toLowerCase() === "x" || id === "*", "isX");
+    var replaceTildes = /* @__PURE__ */ __name((comp, options) => {
+      return comp.trim().split(/\s+/).map((c) => replaceTilde(c, options)).join(" ");
+    }, "replaceTildes");
+    var replaceTilde = /* @__PURE__ */ __name((comp, options) => {
+      const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
+      return comp.replace(r, (_, M, m, p, pr) => {
+        debug3("tilde", comp, _, M, m, p, pr);
+        let ret;
+        if (isX(M)) {
+          ret = "";
+        } else if (isX(m)) {
+          ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
+        } else if (isX(p)) {
+          ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
+        } else if (pr) {
+          debug3("replaceTilde pr", pr);
+          ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
+        } else {
+          ret = `>=${M}.${m}.${p} <${M}.${+m + 1}.0-0`;
+        }
+        debug3("tilde return", ret);
+        return ret;
+      });
+    }, "replaceTilde");
+    var replaceCarets = /* @__PURE__ */ __name((comp, options) => {
+      return comp.trim().split(/\s+/).map((c) => replaceCaret(c, options)).join(" ");
+    }, "replaceCarets");
+    var replaceCaret = /* @__PURE__ */ __name((comp, options) => {
+      debug3("caret", comp, options);
+      const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET];
+      const z = options.includePrerelease ? "-0" : "";
+      return comp.replace(r, (_, M, m, p, pr) => {
+        debug3("caret", comp, _, M, m, p, pr);
+        let ret;
+        if (isX(M)) {
+          ret = "";
+        } else if (isX(m)) {
+          ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
+        } else if (isX(p)) {
+          if (M === "0") {
+            ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
+          } else {
+            ret = `>=${M}.${m}.0${z} <${+M + 1}.0.0-0`;
+          }
+        } else if (pr) {
+          debug3("replaceCaret pr", pr);
+          if (M === "0") {
+            if (m === "0") {
+              ret = `>=${M}.${m}.${p}-${pr} <${M}.${m}.${+p + 1}-0`;
+            } else {
+              ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
+            }
+          } else {
+            ret = `>=${M}.${m}.${p}-${pr} <${+M + 1}.0.0-0`;
+          }
+        } else {
+          debug3("no pr");
+          if (M === "0") {
+            if (m === "0") {
+              ret = `>=${M}.${m}.${p}${z} <${M}.${m}.${+p + 1}-0`;
+            } else {
+              ret = `>=${M}.${m}.${p}${z} <${M}.${+m + 1}.0-0`;
+            }
+          } else {
+            ret = `>=${M}.${m}.${p} <${+M + 1}.0.0-0`;
+          }
+        }
+        debug3("caret return", ret);
+        return ret;
+      });
+    }, "replaceCaret");
+    var replaceXRanges = /* @__PURE__ */ __name((comp, options) => {
+      debug3("replaceXRanges", comp, options);
+      return comp.split(/\s+/).map((c) => replaceXRange(c, options)).join(" ");
+    }, "replaceXRanges");
+    var replaceXRange = /* @__PURE__ */ __name((comp, options) => {
+      comp = comp.trim();
+      const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
+      return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
+        debug3("xRange", comp, ret, gtlt, M, m, p, pr);
+        const xM = isX(M);
+        const xm = xM || isX(m);
+        const xp = xm || isX(p);
+        const anyX = xp;
+        if (gtlt === "=" && anyX) {
+          gtlt = "";
+        }
+        pr = options.includePrerelease ? "-0" : "";
+        if (xM) {
+          if (gtlt === ">" || gtlt === "<") {
+            ret = "<0.0.0-0";
+          } else {
+            ret = "*";
+          }
+        } else if (gtlt && anyX) {
+          if (xm) {
+            m = 0;
+          }
+          p = 0;
+          if (gtlt === ">") {
+            gtlt = ">=";
+            if (xm) {
+              M = +M + 1;
+              m = 0;
+              p = 0;
+            } else {
+              m = +m + 1;
+              p = 0;
+            }
+          } else if (gtlt === "<=") {
+            gtlt = "<";
+            if (xm) {
+              M = +M + 1;
+            } else {
+              m = +m + 1;
+            }
+          }
+          if (gtlt === "<") {
+            pr = "-0";
+          }
+          ret = `${gtlt + M}.${m}.${p}${pr}`;
+        } else if (xm) {
+          ret = `>=${M}.0.0${pr} <${+M + 1}.0.0-0`;
+        } else if (xp) {
+          ret = `>=${M}.${m}.0${pr} <${M}.${+m + 1}.0-0`;
+        }
+        debug3("xRange return", ret);
+        return ret;
+      });
+    }, "replaceXRange");
+    var replaceStars = /* @__PURE__ */ __name((comp, options) => {
+      debug3("replaceStars", comp, options);
+      return comp.trim().replace(re[t.STAR], "");
+    }, "replaceStars");
+    var replaceGTE0 = /* @__PURE__ */ __name((comp, options) => {
+      debug3("replaceGTE0", comp, options);
+      return comp.trim().replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], "");
+    }, "replaceGTE0");
+    var hyphenReplace = /* @__PURE__ */ __name((incPr) => ($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr) => {
+      if (isX(fM)) {
+        from = "";
+      } else if (isX(fm)) {
+        from = `>=${fM}.0.0${incPr ? "-0" : ""}`;
+      } else if (isX(fp)) {
+        from = `>=${fM}.${fm}.0${incPr ? "-0" : ""}`;
+      } else if (fpr) {
+        from = `>=${from}`;
+      } else {
+        from = `>=${from}${incPr ? "-0" : ""}`;
+      }
+      if (isX(tM)) {
+        to = "";
+      } else if (isX(tm)) {
+        to = `<${+tM + 1}.0.0-0`;
+      } else if (isX(tp)) {
+        to = `<${tM}.${+tm + 1}.0-0`;
+      } else if (tpr) {
+        to = `<=${tM}.${tm}.${tp}-${tpr}`;
+      } else if (incPr) {
+        to = `<${tM}.${tm}.${+tp + 1}-0`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }, "hyphenReplace");
+    var testSet = /* @__PURE__ */ __name((set, version, options) => {
+      for (let i = 0; i < set.length; i++) {
+        if (!set[i].test(version)) {
+          return false;
+        }
+      }
+      if (version.prerelease.length && !options.includePrerelease) {
+        for (let i = 0; i < set.length; i++) {
+          debug3(set[i].semver);
+          if (set[i].semver === Comparator.ANY) {
+            continue;
+          }
+          if (set[i].semver.prerelease.length > 0) {
+            const allowed = set[i].semver;
+            if (allowed.major === version.major && allowed.minor === version.minor && allowed.patch === version.patch) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      return true;
+    }, "testSet");
+  }
+});
+
+// node_modules/semver/classes/comparator.js
+var require_comparator = __commonJS({
+  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+    "use strict";
+    var ANY = /* @__PURE__ */ Symbol("SemVer ANY");
+    var Comparator = class _Comparator {
+      static {
+        __name(this, "Comparator");
+      }
+      static get ANY() {
+        return ANY;
+      }
+      constructor(comp, options) {
+        options = parseOptions(options);
+        if (comp instanceof _Comparator) {
+          if (comp.loose === !!options.loose) {
+            return comp;
+          } else {
+            comp = comp.value;
+          }
+        }
+        comp = comp.trim().split(/\s+/).join(" ");
+        debug3("comparator", comp, options);
+        this.options = options;
+        this.loose = !!options.loose;
+        this.parse(comp);
+        if (this.semver === ANY) {
+          this.value = "";
+        } else {
+          this.value = this.operator + this.semver.version;
+        }
+        debug3("comp", this);
+      }
+      parse(comp) {
+        const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
+        const m = comp.match(r);
+        if (!m) {
+          throw new TypeError(`Invalid comparator: ${comp}`);
+        }
+        this.operator = m[1] !== void 0 ? m[1] : "";
+        if (this.operator === "=") {
+          this.operator = "";
+        }
+        if (!m[2]) {
+          this.semver = ANY;
+        } else {
+          this.semver = new SemVer(m[2], this.options.loose);
+        }
+      }
+      toString() {
+        return this.value;
+      }
+      test(version) {
+        debug3("Comparator.test", version, this.options.loose);
+        if (this.semver === ANY || version === ANY) {
+          return true;
+        }
+        if (typeof version === "string") {
+          try {
+            version = new SemVer(version, this.options);
+          } catch (er) {
+            return false;
+          }
+        }
+        return cmp(version, this.operator, this.semver, this.options);
+      }
+      intersects(comp, options) {
+        if (!(comp instanceof _Comparator)) {
+          throw new TypeError("a Comparator is required");
+        }
+        if (this.operator === "") {
+          if (this.value === "") {
+            return true;
+          }
+          return new Range(comp.value, options).test(this.value);
+        } else if (comp.operator === "") {
+          if (comp.value === "") {
+            return true;
+          }
+          return new Range(this.value, options).test(comp.semver);
+        }
+        options = parseOptions(options);
+        if (options.includePrerelease && (this.value === "<0.0.0-0" || comp.value === "<0.0.0-0")) {
+          return false;
+        }
+        if (!options.includePrerelease && (this.value.startsWith("<0.0.0") || comp.value.startsWith("<0.0.0"))) {
+          return false;
+        }
+        if (this.operator.startsWith(">") && comp.operator.startsWith(">")) {
+          return true;
+        }
+        if (this.operator.startsWith("<") && comp.operator.startsWith("<")) {
+          return true;
+        }
+        if (this.semver.version === comp.semver.version && this.operator.includes("=") && comp.operator.includes("=")) {
+          return true;
+        }
+        if (cmp(this.semver, "<", comp.semver, options) && this.operator.startsWith(">") && comp.operator.startsWith("<")) {
+          return true;
+        }
+        if (cmp(this.semver, ">", comp.semver, options) && this.operator.startsWith("<") && comp.operator.startsWith(">")) {
+          return true;
+        }
+        return false;
+      }
+    };
+    module2.exports = Comparator;
+    var parseOptions = require_parse_options();
+    var { safeRe: re, t } = require_re();
+    var cmp = require_cmp();
+    var debug3 = require_debug();
+    var SemVer = require_semver();
+    var Range = require_range();
+  }
+});
+
+// node_modules/semver/functions/satisfies.js
+var require_satisfies = __commonJS({
+  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var satisfies3 = /* @__PURE__ */ __name((version, range, options) => {
+      try {
+        range = new Range(range, options);
+      } catch (er) {
+        return false;
+      }
+      return range.test(version);
+    }, "satisfies");
+    module2.exports = satisfies3;
+  }
+});
+
+// node_modules/semver/ranges/to-comparators.js
+var require_to_comparators = __commonJS({
+  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var toComparators = /* @__PURE__ */ __name((range, options) => new Range(range, options).set.map((comp) => comp.map(
+    (c) => c.value).join(" ").trim().split(" ")), "toComparators");
+    module2.exports = toComparators;
+  }
+});
+
+// node_modules/semver/ranges/max-satisfying.js
+var require_max_satisfying = __commonJS({
+  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Range = require_range();
+    var maxSatisfying = /* @__PURE__ */ __name((versions, range, options) => {
+      let max = null;
+      let maxSV = null;
+      let rangeObj = null;
+      try {
+        rangeObj = new Range(range, options);
+      } catch (er) {
+        return null;
+      }
+      versions.forEach((v) => {
+        if (rangeObj.test(v)) {
+          if (!max || maxSV.compare(v) === -1) {
+            max = v;
+            maxSV = new SemVer(max, options);
+          }
+        }
+      });
+      return max;
+    }, "maxSatisfying");
+    module2.exports = maxSatisfying;
+  }
+});
+
+// node_modules/semver/ranges/min-satisfying.js
+var require_min_satisfying = __commonJS({
+  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Range = require_range();
+    var minSatisfying = /* @__PURE__ */ __name((versions, range, options) => {
+      let min = null;
+      let minSV = null;
+      let rangeObj = null;
+      try {
+        rangeObj = new Range(range, options);
+      } catch (er) {
+        return null;
+      }
+      versions.forEach((v) => {
+        if (rangeObj.test(v)) {
+          if (!min || minSV.compare(v) === 1) {
+            min = v;
+            minSV = new SemVer(min, options);
+          }
+        }
+      });
+      return min;
+    }, "minSatisfying");
+    module2.exports = minSatisfying;
+  }
+});
+
+// node_modules/semver/ranges/min-version.js
+var require_min_version = __commonJS({
+  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Range = require_range();
+    var gt2 = require_gt();
+    var minVersion = /* @__PURE__ */ __name((range, loose) => {
+      range = new Range(range, loose);
+      let minver = new SemVer("0.0.0");
+      if (range.test(minver)) {
+        return minver;
+      }
+      minver = new SemVer("0.0.0-0");
+      if (range.test(minver)) {
+        return minver;
+      }
+      minver = null;
+      for (let i = 0; i < range.set.length; ++i) {
+        const comparators = range.set[i];
+        let setMin = null;
+        comparators.forEach((comparator) => {
+          const compver = new SemVer(comparator.semver.version);
+          switch (comparator.operator) {
+            case ">":
+              if (compver.prerelease.length === 0) {
+                compver.patch++;
+              } else {
+                compver.prerelease.push(0);
+              }
+              compver.raw = compver.format();
+            /* fallthrough */
+            case "":
+            case ">=":
+              if (!setMin || gt2(compver, setMin)) {
+                setMin = compver;
+              }
+              break;
+            case "<":
+            case "<=":
+              break;
+            /* istanbul ignore next */
+            default:
+              throw new Error(`Unexpected operation: ${comparator.operator}`);
+          }
+        });
+        if (setMin && (!minver || gt2(minver, setMin))) {
+          minver = setMin;
+        }
+      }
+      if (minver && range.test(minver)) {
+        return minver;
+      }
+      return null;
+    }, "minVersion");
+    module2.exports = minVersion;
+  }
+});
+
+// node_modules/semver/ranges/valid.js
+var require_valid2 = __commonJS({
+  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var validRange = /* @__PURE__ */ __name((range, options) => {
+      try {
+        return new Range(range, options).range || "*";
+      } catch (er) {
+        return null;
+      }
+    }, "validRange");
+    module2.exports = validRange;
+  }
+});
+
+// node_modules/semver/ranges/outside.js
+var require_outside = __commonJS({
+  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+    "use strict";
+    var SemVer = require_semver();
+    var Comparator = require_comparator();
+    var { ANY } = Comparator;
+    var Range = require_range();
+    var satisfies3 = require_satisfies();
+    var gt2 = require_gt();
+    var lt = require_lt();
+    var lte = require_lte();
+    var gte = require_gte();
+    var outside = /* @__PURE__ */ __name((version, range, hilo, options) => {
+      version = new SemVer(version, options);
+      range = new Range(range, options);
+      let gtfn, ltefn, ltfn, comp, ecomp;
+      switch (hilo) {
+        case ">":
+          gtfn = gt2;
+          ltefn = lte;
+          ltfn = lt;
+          comp = ">";
+          ecomp = ">=";
+          break;
+        case "<":
+          gtfn = lt;
+          ltefn = gte;
+          ltfn = gt2;
+          comp = "<";
+          ecomp = "<=";
+          break;
+        default:
+          throw new TypeError('Must provide a hilo val of "<" or ">"');
+      }
+      if (satisfies3(version, range, options)) {
+        return false;
+      }
+      for (let i = 0; i < range.set.length; ++i) {
+        const comparators = range.set[i];
+        let high = null;
+        let low = null;
+        comparators.forEach((comparator) => {
+          if (comparator.semver === ANY) {
+            comparator = new Comparator(">=0.0.0");
+          }
+          high = high || comparator;
+          low = low || comparator;
+          if (gtfn(comparator.semver, high.semver, options)) {
+            high = comparator;
+          } else if (ltfn(comparator.semver, low.semver, options)) {
+            low = comparator;
+          }
+        });
+        if (high.operator === comp || high.operator === ecomp) {
+          return false;
+        }
+        if ((!low.operator || low.operator === comp) && ltefn(version, low.semver)) {
+          return false;
+        } else if (low.operator === ecomp && ltfn(version, low.semver)) {
+          return false;
+        }
+      }
+      return true;
+    }, "outside");
+    module2.exports = outside;
+  }
+});
+
+// node_modules/semver/ranges/gtr.js
+var require_gtr = __commonJS({
+  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+    "use strict";
+    var outside = require_outside();
+    var gtr = /* @__PURE__ */ __name((version, range, options) => outside(version, range, ">", options), "gtr");
+    module2.exports = gtr;
+  }
+});
+
+// node_modules/semver/ranges/ltr.js
+var require_ltr = __commonJS({
+  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+    "use strict";
+    var outside = require_outside();
+    var ltr = /* @__PURE__ */ __name((version, range, options) => outside(version, range, "<", options), "ltr");
+    module2.exports = ltr;
+  }
+});
+
+// node_modules/semver/ranges/intersects.js
+var require_intersects = __commonJS({
+  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var intersects = /* @__PURE__ */ __name((r1, r2, options) => {
+      r1 = new Range(r1, options);
+      r2 = new Range(r2, options);
+      return r1.intersects(r2, options);
+    }, "intersects");
+    module2.exports = intersects;
+  }
+});
+
+// node_modules/semver/ranges/simplify.js
+var require_simplify = __commonJS({
+  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+    "use strict";
+    var satisfies3 = require_satisfies();
+    var compare = require_compare();
+    module2.exports = (versions, range, options) => {
+      const set = [];
+      let first2 = null;
+      let prev = null;
+      const v = versions.sort((a, b) => compare(a, b, options));
+      for (const version of v) {
+        const included = satisfies3(version, range, options);
+        if (included) {
+          prev = version;
+          if (!first2) {
+            first2 = version;
+          }
+        } else {
+          if (prev) {
+            set.push([first2, prev]);
+          }
+          prev = null;
+          first2 = null;
+        }
+      }
+      if (first2) {
+        set.push([first2, null]);
+      }
+      const ranges = [];
+      for (const [min, max] of set) {
+        if (min === max) {
+          ranges.push(min);
+        } else if (!max && min === v[0]) {
+          ranges.push("*");
+        } else if (!max) {
+          ranges.push(`>=${min}`);
+        } else if (min === v[0]) {
+          ranges.push(`<=${max}`);
+        } else {
+          ranges.push(`${min} - ${max}`);
+        }
+      }
+      const simplified = ranges.join(" || ");
+      const original = typeof range.raw === "string" ? range.raw : String(range);
+      return simplified.length < original.length ? simplified : range;
+    };
+  }
+});
+
+// node_modules/semver/ranges/subset.js
+var require_subset = __commonJS({
+  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+    "use strict";
+    var Range = require_range();
+    var Comparator = require_comparator();
+    var { ANY } = Comparator;
+    var satisfies3 = require_satisfies();
+    var compare = require_compare();
+    var subset = /* @__PURE__ */ __name((sub, dom, options = {}) => {
+      if (sub === dom) {
+        return true;
+      }
+      sub = new Range(sub, options);
+      dom = new Range(dom, options);
+      let sawNonNull = false;
+      OUTER: for (const simpleSub of sub.set) {
+        for (const simpleDom of dom.set) {
+          const isSub = simpleSubset(simpleSub, simpleDom, options);
+          sawNonNull = sawNonNull || isSub !== null;
+          if (isSub) {
+            continue OUTER;
+          }
+        }
+        if (sawNonNull) {
+          return false;
+        }
+      }
+      return true;
+    }, "subset");
+    var minimumVersionWithPreRelease = [new Comparator(">=0.0.0-0")];
+    var minimumVersion = [new Comparator(">=0.0.0")];
+    var simpleSubset = /* @__PURE__ */ __name((sub, dom, options) => {
+      if (sub === dom) {
+        return true;
+      }
+      if (sub.length === 1 && sub[0].semver === ANY) {
+        if (dom.length === 1 && dom[0].semver === ANY) {
+          return true;
+        } else if (options.includePrerelease) {
+          sub = minimumVersionWithPreRelease;
+        } else {
+          sub = minimumVersion;
+        }
+      }
+      if (dom.length === 1 && dom[0].semver === ANY) {
+        if (options.includePrerelease) {
+          return true;
+        } else {
+          dom = minimumVersion;
+        }
+      }
+      const eqSet = /* @__PURE__ */ new Set();
+      let gt2, lt;
+      for (const c of sub) {
+        if (c.operator === ">" || c.operator === ">=") {
+          gt2 = higherGT(gt2, c, options);
+        } else if (c.operator === "<" || c.operator === "<=") {
+          lt = lowerLT(lt, c, options);
+        } else {
+          eqSet.add(c.semver);
+        }
+      }
+      if (eqSet.size > 1) {
+        return null;
+      }
+      let gtltComp;
+      if (gt2 && lt) {
+        gtltComp = compare(gt2.semver, lt.semver, options);
+        if (gtltComp > 0) {
+          return null;
+        } else if (gtltComp === 0 && (gt2.operator !== ">=" || lt.operator !== "<=")) {
+          return null;
+        }
+      }
+      for (const eq of eqSet) {
+        if (gt2 && !satisfies3(eq, String(gt2), options)) {
+          return null;
+        }
+        if (lt && !satisfies3(eq, String(lt), options)) {
+          return null;
+        }
+        for (const c of dom) {
+          if (!satisfies3(eq, String(c), options)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      let higher, lower;
+      let hasDomLT, hasDomGT;
+      let needDomLTPre = lt && !options.includePrerelease && lt.semver.prerelease.length ? lt.semver : false;
+      let needDomGTPre = gt2 && !options.includePrerelease && gt2.semver.prerelease.length ? gt2.semver : false;
+      if (needDomLTPre && needDomLTPre.prerelease.length === 1 && lt.operator === "<" && needDomLTPre.prerelease[0] === 0) {
+        needDomLTPre = false;
+      }
+      for (const c of dom) {
+        hasDomGT = hasDomGT || c.operator === ">" || c.operator === ">=";
+        hasDomLT = hasDomLT || c.operator === "<" || c.operator === "<=";
+        if (gt2) {
+          if (needDomGTPre) {
+            if (c.semver.prerelease && c.semver.prerelease.length && c.semver.major === needDomGTPre.major && c.semver.minor ===
+            needDomGTPre.minor && c.semver.patch === needDomGTPre.patch) {
+              needDomGTPre = false;
+            }
+          }
+          if (c.operator === ">" || c.operator === ">=") {
+            higher = higherGT(gt2, c, options);
+            if (higher === c && higher !== gt2) {
+              return false;
+            }
+          } else if (gt2.operator === ">=" && !satisfies3(gt2.semver, String(c), options)) {
+            return false;
+          }
+        }
+        if (lt) {
+          if (needDomLTPre) {
+            if (c.semver.prerelease && c.semver.prerelease.length && c.semver.major === needDomLTPre.major && c.semver.minor ===
+            needDomLTPre.minor && c.semver.patch === needDomLTPre.patch) {
+              needDomLTPre = false;
+            }
+          }
+          if (c.operator === "<" || c.operator === "<=") {
+            lower = lowerLT(lt, c, options);
+            if (lower === c && lower !== lt) {
+              return false;
+            }
+          } else if (lt.operator === "<=" && !satisfies3(lt.semver, String(c), options)) {
+            return false;
+          }
+        }
+        if (!c.operator && (lt || gt2) && gtltComp !== 0) {
+          return false;
+        }
+      }
+      if (gt2 && hasDomLT && !lt && gtltComp !== 0) {
+        return false;
+      }
+      if (lt && hasDomGT && !gt2 && gtltComp !== 0) {
+        return false;
+      }
+      if (needDomGTPre || needDomLTPre) {
+        return false;
+      }
+      return true;
+    }, "simpleSubset");
+    var higherGT = /* @__PURE__ */ __name((a, b, options) => {
+      if (!a) {
+        return b;
+      }
+      const comp = compare(a.semver, b.semver, options);
+      return comp > 0 ? a : comp < 0 ? b : b.operator === ">" && a.operator === ">=" ? b : a;
+    }, "higherGT");
+    var lowerLT = /* @__PURE__ */ __name((a, b, options) => {
+      if (!a) {
+        return b;
+      }
+      const comp = compare(a.semver, b.semver, options);
+      return comp < 0 ? a : comp > 0 ? b : b.operator === "<" && a.operator === "<=" ? b : a;
+    }, "lowerLT");
+    module2.exports = subset;
+  }
+});
+
+// node_modules/semver/index.js
+var require_semver2 = __commonJS({
+  "node_modules/semver/index.js"(exports2, module2) {
+    "use strict";
+    var internalRe = require_re();
+    var constants3 = require_constants6();
+    var SemVer = require_semver();
+    var identifiers = require_identifiers();
+    var parse = require_parse2();
+    var valid2 = require_valid();
+    var clean2 = require_clean();
+    var inc = require_inc();
+    var diff = require_diff();
+    var major = require_major();
+    var minor = require_minor();
+    var patch = require_patch();
+    var prerelease = require_prerelease();
+    var compare = require_compare();
+    var rcompare = require_rcompare();
+    var compareLoose = require_compare_loose();
+    var compareBuild = require_compare_build();
+    var sort = require_sort();
+    var rsort = require_rsort();
+    var gt2 = require_gt();
+    var lt = require_lt();
+    var eq = require_eq();
+    var neq = require_neq();
+    var gte = require_gte();
+    var lte = require_lte();
+    var cmp = require_cmp();
+    var coerce = require_coerce();
+    var Comparator = require_comparator();
+    var Range = require_range();
+    var satisfies3 = require_satisfies();
+    var toComparators = require_to_comparators();
+    var maxSatisfying = require_max_satisfying();
+    var minSatisfying = require_min_satisfying();
+    var minVersion = require_min_version();
+    var validRange = require_valid2();
+    var outside = require_outside();
+    var gtr = require_gtr();
+    var ltr = require_ltr();
+    var intersects = require_intersects();
+    var simplifyRange = require_simplify();
+    var subset = require_subset();
+    module2.exports = {
+      parse,
+      valid: valid2,
+      clean: clean2,
+      inc,
+      diff,
+      major,
+      minor,
+      patch,
+      prerelease,
+      compare,
+      rcompare,
+      compareLoose,
+      compareBuild,
+      sort,
+      rsort,
+      gt: gt2,
+      lt,
+      eq,
+      neq,
+      gte,
+      lte,
+      cmp,
+      coerce,
+      Comparator,
+      Range,
+      satisfies: satisfies3,
+      toComparators,
+      maxSatisfying,
+      minSatisfying,
+      minVersion,
+      validRange,
+      outside,
+      gtr,
+      ltr,
+      intersects,
+      simplifyRange,
+      subset,
+      SemVer,
+      re: internalRe.re,
+      src: internalRe.src,
+      tokens: internalRe.t,
+      SEMVER_SPEC_VERSION: constants3.SEMVER_SPEC_VERSION,
+      RELEASE_TYPES: constants3.RELEASE_TYPES,
+      compareIdentifiers: identifiers.compareIdentifiers,
+      rcompareIdentifiers: identifiers.rcompareIdentifiers
+    };
+  }
+});
+
+// node_modules/simple-git/dist/esm/index.js
+var import_node_buffer = require("node:buffer");
+var import_file_exists = __toESM(require_dist(), 1);
+var import_debug = __toESM(require_src(), 1);
+var import_child_process = require("child_process");
+var import_promise_deferred = __toESM(require_dist2(), 1);
+var import_node_path = require("node:path");
+var import_promise_deferred2 = __toESM(require_dist2(), 1);
+var __defProp2 = Object.defineProperty;
+var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames2 = Object.getOwnPropertyNames;
+var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+var __esm = /* @__PURE__ */ __name((fn, res) => /* @__PURE__ */ __name(function __init() {
+  return fn && (res = (0, fn[__getOwnPropNames2(fn)[0]])(fn = 0)), res;
+}, "__init"), "__esm");
+var __commonJS2 = /* @__PURE__ */ __name((cb, mod) => /* @__PURE__ */ __name(function __require() {
+  return mod || (0, cb[__getOwnPropNames2(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+}, "__require"), "__commonJS");
+var __export = /* @__PURE__ */ __name((target, all) => {
+  for (var name in all)
+    __defProp2(target, name, { get: all[name], enumerable: true });
+}, "__export");
+var __copyProps2 = /* @__PURE__ */ __name((to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames2(from))
+      if (!__hasOwnProp2.call(to, key) && key !== except)
+        __defProp2(to, key, { get: /* @__PURE__ */ __name(() => from[key], "get"), enumerable: !(desc = __getOwnPropDesc2(
+        from, key)) || desc.enumerable });
+  }
+  return to;
+}, "__copyProps");
+var __toCommonJS = /* @__PURE__ */ __name((mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod), "__\
+toCommonJS");
+function pathspec(...paths) {
+  const key = new String(paths);
+  cache.set(key, paths);
+  return key;
+}
+__name(pathspec, "pathspec");
+function isPathSpec(path5) {
+  return path5 instanceof String && cache.has(path5);
+}
+__name(isPathSpec, "isPathSpec");
+var cache;
+var init_pathspec = __esm({
+  "src/lib/args/pathspec.ts"() {
+    "use strict";
+    cache = /* @__PURE__ */ new WeakMap();
+  }
+});
+var GitError;
+var init_git_error = __esm({
+  "src/lib/errors/git-error.ts"() {
+    "use strict";
+    GitError = class extends Error {
+      static {
+        __name(this, "GitError");
+      }
+      constructor(task, message) {
+        super(message);
+        this.task = task;
+        Object.setPrototypeOf(this, new.target.prototype);
+      }
+    };
+  }
+});
+var GitResponseError;
+var init_git_response_error = __esm({
+  "src/lib/errors/git-response-error.ts"() {
+    "use strict";
+    init_git_error();
+    GitResponseError = class extends GitError {
+      static {
+        __name(this, "GitResponseError");
+      }
+      constructor(git, message) {
+        super(void 0, message || String(git));
+        this.git = git;
+      }
+    };
+  }
+});
+var TaskConfigurationError;
+var init_task_configuration_error = __esm({
+  "src/lib/errors/task-configuration-error.ts"() {
+    "use strict";
+    init_git_error();
+    TaskConfigurationError = class extends GitError {
+      static {
+        __name(this, "TaskConfigurationError");
+      }
+      constructor(message) {
+        super(void 0, message);
+      }
+    };
+  }
+});
+function asFunction(source) {
+  if (typeof source !== "function") {
+    return NOOP;
+  }
+  return source;
+}
+__name(asFunction, "asFunction");
+function isUserFunction(source) {
+  return typeof source === "function" && source !== NOOP;
+}
+__name(isUserFunction, "isUserFunction");
+function splitOn(input, char) {
+  const index = input.indexOf(char);
+  if (index <= 0) {
+    return [input, ""];
+  }
+  return [input.substr(0, index), input.substr(index + 1)];
+}
+__name(splitOn, "splitOn");
+function first(input, offset = 0) {
+  return isArrayLike(input) && input.length > offset ? input[offset] : void 0;
+}
+__name(first, "first");
+function last(input, offset = 0) {
+  if (isArrayLike(input) && input.length > offset) {
+    return input[input.length - 1 - offset];
+  }
+}
+__name(last, "last");
+function isArrayLike(input) {
+  return filterHasLength(input);
+}
+__name(isArrayLike, "isArrayLike");
+function toLinesWithContent(input = "", trimmed2 = true, separator = "\n") {
+  return input.split(separator).reduce((output, line) => {
+    const lineContent = trimmed2 ? line.trim() : line;
+    if (lineContent) {
+      output.push(lineContent);
+    }
+    return output;
+  }, []);
+}
+__name(toLinesWithContent, "toLinesWithContent");
+function forEachLineWithContent(input, callback) {
+  return toLinesWithContent(input, true).map((line) => callback(line));
+}
+__name(forEachLineWithContent, "forEachLineWithContent");
+function folderExists(path5) {
+  return (0, import_file_exists.exists)(path5, import_file_exists.FOLDER);
+}
+__name(folderExists, "folderExists");
+function append(target, item) {
+  if (Array.isArray(target)) {
+    if (!target.includes(item)) {
+      target.push(item);
+    }
+  } else {
+    target.add(item);
+  }
+  return item;
+}
+__name(append, "append");
+function including(target, item) {
+  if (Array.isArray(target) && !target.includes(item)) {
+    target.push(item);
+  }
+  return target;
+}
+__name(including, "including");
+function remove(target, item) {
+  if (Array.isArray(target)) {
+    const index = target.indexOf(item);
+    if (index >= 0) {
+      target.splice(index, 1);
+    }
+  } else {
+    target.delete(item);
+  }
+  return item;
+}
+__name(remove, "remove");
+function asArray(source) {
+  return Array.isArray(source) ? source : [source];
+}
+__name(asArray, "asArray");
+function asCamelCase(str) {
+  return str.replace(/[\s-]+(.)/g, (_all, chr) => {
+    return chr.toUpperCase();
+  });
+}
+__name(asCamelCase, "asCamelCase");
+function asStringArray(source) {
+  return asArray(source).map((item) => {
+    return item instanceof String ? item : String(item);
+  });
+}
+__name(asStringArray, "asStringArray");
+function asNumber(source, onNaN = 0) {
+  if (source == null) {
+    return onNaN;
+  }
+  const num = parseInt(source, 10);
+  return Number.isNaN(num) ? onNaN : num;
+}
+__name(asNumber, "asNumber");
+function prefixedArray(input, prefix) {
+  const output = [];
+  for (let i = 0, max = input.length; i < max; i++) {
+    output.push(prefix, input[i]);
+  }
+  return output;
+}
+__name(prefixedArray, "prefixedArray");
+function bufferToString(input) {
+  return (Array.isArray(input) ? import_node_buffer.Buffer.concat(input) : input).toString("utf-8");
+}
+__name(bufferToString, "bufferToString");
+function pick(source, properties) {
+  const out = {};
+  properties.forEach((key) => {
+    if (source[key] !== void 0) {
+      out[key] = source[key];
+    }
+  });
+  return out;
+}
+__name(pick, "pick");
+function delay(duration = 0) {
+  return new Promise((done) => setTimeout(done, duration));
+}
+__name(delay, "delay");
+function orVoid(input) {
+  if (input === false) {
+    return void 0;
+  }
+  return input;
+}
+__name(orVoid, "orVoid");
+var NULL;
+var NOOP;
+var objectToString;
+var init_util = __esm({
+  "src/lib/utils/util.ts"() {
+    "use strict";
+    init_argument_filters();
+    NULL = "\0";
+    NOOP = /* @__PURE__ */ __name(() => {
+    }, "NOOP");
+    objectToString = Object.prototype.toString.call.bind(Object.prototype.toString);
+  }
+});
+function filterType(input, filter, def) {
+  if (filter(input)) {
+    return input;
+  }
+  return arguments.length > 2 ? def : void 0;
+}
+__name(filterType, "filterType");
+function filterPrimitives(input, omit) {
+  const type = isPathSpec(input) ? "string" : typeof input;
+  return /number|string|boolean/.test(type) && (!omit || !omit.includes(type));
+}
+__name(filterPrimitives, "filterPrimitives");
+function filterPlainObject(input) {
+  return !!input && objectToString(input) === "[object Object]";
+}
+__name(filterPlainObject, "filterPlainObject");
+function filterFunction(input) {
+  return typeof input === "function";
+}
+__name(filterFunction, "filterFunction");
+var filterArray;
+var filterNumber;
+var filterString;
+var filterStringOrStringArray;
+var filterHasLength;
+var init_argument_filters = __esm({
+  "src/lib/utils/argument-filters.ts"() {
+    "use strict";
+    init_pathspec();
+    init_util();
+    filterArray = /* @__PURE__ */ __name((input) => {
+      return Array.isArray(input);
+    }, "filterArray");
+    filterNumber = /* @__PURE__ */ __name((input) => {
+      return typeof input === "number";
+    }, "filterNumber");
+    filterString = /* @__PURE__ */ __name((input) => {
+      return typeof input === "string" || isPathSpec(input);
+    }, "filterString");
+    filterStringOrStringArray = /* @__PURE__ */ __name((input) => {
+      return filterString(input) || Array.isArray(input) && input.every(filterString);
+    }, "filterStringOrStringArray");
+    filterHasLength = /* @__PURE__ */ __name((input) => {
+      if (input == null || "number|boolean|function".includes(typeof input)) {
+        return false;
+      }
+      return typeof input.length === "number";
+    }, "filterHasLength");
+  }
+});
+var ExitCodes;
+var init_exit_codes = __esm({
+  "src/lib/utils/exit-codes.ts"() {
+    "use strict";
+    ExitCodes = /* @__PURE__ */ ((ExitCodes2) => {
+      ExitCodes2[ExitCodes2["SUCCESS"] = 0] = "SUCCESS";
+      ExitCodes2[ExitCodes2["ERROR"] = 1] = "ERROR";
+      ExitCodes2[ExitCodes2["NOT_FOUND"] = -2] = "NOT_FOUND";
+      ExitCodes2[ExitCodes2["UNCLEAN"] = 128] = "UNCLEAN";
+      return ExitCodes2;
+    })(ExitCodes || {});
+  }
+});
+var GitOutputStreams;
+var init_git_output_streams = __esm({
+  "src/lib/utils/git-output-streams.ts"() {
+    "use strict";
+    GitOutputStreams = class _GitOutputStreams {
+      static {
+        __name(this, "_GitOutputStreams");
+      }
+      constructor(stdOut, stdErr) {
+        this.stdOut = stdOut;
+        this.stdErr = stdErr;
+      }
+      asStrings() {
+        return new _GitOutputStreams(this.stdOut.toString("utf8"), this.stdErr.toString("utf8"));
+      }
+    };
+  }
+});
+function useMatchesDefault() {
+  throw new Error(`LineParser:useMatches not implemented`);
+}
+__name(useMatchesDefault, "useMatchesDefault");
+var LineParser;
+var RemoteLineParser;
+var init_line_parser = __esm({
+  "src/lib/utils/line-parser.ts"() {
+    "use strict";
+    LineParser = class {
+      static {
+        __name(this, "LineParser");
+      }
+      constructor(regExp, useMatches) {
+        this.matches = [];
+        this.useMatches = useMatchesDefault;
+        this.parse = (line, target) => {
+          this.resetMatches();
+          if (!this._regExp.every((reg, index) => this.addMatch(reg, index, line(index)))) {
+            return false;
+          }
+          return this.useMatches(target, this.prepareMatches()) !== false;
+        };
+        this._regExp = Array.isArray(regExp) ? regExp : [regExp];
+        if (useMatches) {
+          this.useMatches = useMatches;
+        }
+      }
+      resetMatches() {
+        this.matches.length = 0;
+      }
+      prepareMatches() {
+        return this.matches;
+      }
+      addMatch(reg, index, line) {
+        const matched = line && reg.exec(line);
+        if (matched) {
+          this.pushMatch(index, matched);
+        }
+        return !!matched;
+      }
+      pushMatch(_index, matched) {
+        this.matches.push(...matched.slice(1));
+      }
+    };
+    RemoteLineParser = class extends LineParser {
+      static {
+        __name(this, "RemoteLineParser");
+      }
+      addMatch(reg, index, line) {
+        return /^remote:\s/.test(String(line)) && super.addMatch(reg, index, line);
+      }
+      pushMatch(index, matched) {
+        if (index > 0 || matched.length > 1) {
+          super.pushMatch(index, matched);
+        }
+      }
+    };
+  }
+});
+function createInstanceConfig(...options) {
+  const baseDir = process.cwd();
+  const config = Object.assign(
+    { baseDir, ...defaultOptions },
+    ...options.filter((o) => typeof o === "object" && o)
+  );
+  config.baseDir = config.baseDir || baseDir;
+  config.trimmed = config.trimmed === true;
+  return config;
+}
+__name(createInstanceConfig, "createInstanceConfig");
+var defaultOptions;
+var init_simple_git_options = __esm({
+  "src/lib/utils/simple-git-options.ts"() {
+    "use strict";
+    defaultOptions = {
+      binary: "git",
+      maxConcurrentProcesses: 5,
+      config: [],
+      trimmed: false
+    };
+  }
+});
+function appendTaskOptions(options, commands = []) {
+  if (!filterPlainObject(options)) {
+    return commands;
+  }
+  return Object.keys(options).reduce((commands2, key) => {
+    const value = options[key];
+    if (isPathSpec(value)) {
+      commands2.push(value);
+    } else if (filterPrimitives(value, ["boolean"])) {
+      commands2.push(key + "=" + value);
+    } else if (Array.isArray(value)) {
+      for (const v of value) {
+        if (!filterPrimitives(v, ["string", "number"])) {
+          commands2.push(key + "=" + v);
+        }
+      }
+    } else {
+      commands2.push(key);
+    }
+    return commands2;
+  }, commands);
+}
+__name(appendTaskOptions, "appendTaskOptions");
+function getTrailingOptions(args, initialPrimitive = 0, objectOnly = false) {
+  const command = [];
+  for (let i = 0, max = initialPrimitive < 0 ? args.length : initialPrimitive; i < max; i++) {
+    if ("string|number".includes(typeof args[i])) {
+      command.push(String(args[i]));
+    }
+  }
+  appendTaskOptions(trailingOptionsArgument(args), command);
+  if (!objectOnly) {
+    command.push(...trailingArrayArgument(args));
+  }
+  return command;
+}
+__name(getTrailingOptions, "getTrailingOptions");
+function trailingArrayArgument(args) {
+  const hasTrailingCallback = typeof last(args) === "function";
+  return asStringArray(filterType(last(args, hasTrailingCallback ? 1 : 0), filterArray, []));
+}
+__name(trailingArrayArgument, "trailingArrayArgument");
+function trailingOptionsArgument(args) {
+  const hasTrailingCallback = filterFunction(last(args));
+  return filterType(last(args, hasTrailingCallback ? 1 : 0), filterPlainObject);
+}
+__name(trailingOptionsArgument, "trailingOptionsArgument");
+function trailingFunctionArgument(args, includeNoop = true) {
+  const callback = asFunction(last(args));
+  return includeNoop || isUserFunction(callback) ? callback : void 0;
+}
+__name(trailingFunctionArgument, "trailingFunctionArgument");
+var init_task_options = __esm({
+  "src/lib/utils/task-options.ts"() {
+    "use strict";
+    init_argument_filters();
+    init_util();
+    init_pathspec();
+  }
+});
+function callTaskParser(parser4, streams) {
+  return parser4(streams.stdOut, streams.stdErr);
+}
+__name(callTaskParser, "callTaskParser");
+function parseStringResponse(result, parsers12, texts, trim = true) {
+  asArray(texts).forEach((text) => {
+    for (let lines = toLinesWithContent(text, trim), i = 0, max = lines.length; i < max; i++) {
+      const line = /* @__PURE__ */ __name((offset = 0) => {
+        if (i + offset >= max) {
+          return;
+        }
+        return lines[i + offset];
+      }, "line");
+      parsers12.some(({ parse }) => parse(line, result));
+    }
+  });
+  return result;
+}
+__name(parseStringResponse, "parseStringResponse");
+var init_task_parser = __esm({
+  "src/lib/utils/task-parser.ts"() {
+    "use strict";
+    init_util();
+  }
+});
+var utils_exports = {};
+__export(utils_exports, {
+  ExitCodes: /* @__PURE__ */ __name(() => ExitCodes, "ExitCodes"),
+  GitOutputStreams: /* @__PURE__ */ __name(() => GitOutputStreams, "GitOutputStreams"),
+  LineParser: /* @__PURE__ */ __name(() => LineParser, "LineParser"),
+  NOOP: /* @__PURE__ */ __name(() => NOOP, "NOOP"),
+  NULL: /* @__PURE__ */ __name(() => NULL, "NULL"),
+  RemoteLineParser: /* @__PURE__ */ __name(() => RemoteLineParser, "RemoteLineParser"),
+  append: /* @__PURE__ */ __name(() => append, "append"),
+  appendTaskOptions: /* @__PURE__ */ __name(() => appendTaskOptions, "appendTaskOptions"),
+  asArray: /* @__PURE__ */ __name(() => asArray, "asArray"),
+  asCamelCase: /* @__PURE__ */ __name(() => asCamelCase, "asCamelCase"),
+  asFunction: /* @__PURE__ */ __name(() => asFunction, "asFunction"),
+  asNumber: /* @__PURE__ */ __name(() => asNumber, "asNumber"),
+  asStringArray: /* @__PURE__ */ __name(() => asStringArray, "asStringArray"),
+  bufferToString: /* @__PURE__ */ __name(() => bufferToString, "bufferToString"),
+  callTaskParser: /* @__PURE__ */ __name(() => callTaskParser, "callTaskParser"),
+  createInstanceConfig: /* @__PURE__ */ __name(() => createInstanceConfig, "createInstanceConfig"),
+  delay: /* @__PURE__ */ __name(() => delay, "delay"),
+  filterArray: /* @__PURE__ */ __name(() => filterArray, "filterArray"),
+  filterFunction: /* @__PURE__ */ __name(() => filterFunction, "filterFunction"),
+  filterHasLength: /* @__PURE__ */ __name(() => filterHasLength, "filterHasLength"),
+  filterNumber: /* @__PURE__ */ __name(() => filterNumber, "filterNumber"),
+  filterPlainObject: /* @__PURE__ */ __name(() => filterPlainObject, "filterPlainObject"),
+  filterPrimitives: /* @__PURE__ */ __name(() => filterPrimitives, "filterPrimitives"),
+  filterString: /* @__PURE__ */ __name(() => filterString, "filterString"),
+  filterStringOrStringArray: /* @__PURE__ */ __name(() => filterStringOrStringArray, "filterStringOrStringArray"),
+  filterType: /* @__PURE__ */ __name(() => filterType, "filterType"),
+  first: /* @__PURE__ */ __name(() => first, "first"),
+  folderExists: /* @__PURE__ */ __name(() => folderExists, "folderExists"),
+  forEachLineWithContent: /* @__PURE__ */ __name(() => forEachLineWithContent, "forEachLineWithContent"),
+  getTrailingOptions: /* @__PURE__ */ __name(() => getTrailingOptions, "getTrailingOptions"),
+  including: /* @__PURE__ */ __name(() => including, "including"),
+  isUserFunction: /* @__PURE__ */ __name(() => isUserFunction, "isUserFunction"),
+  last: /* @__PURE__ */ __name(() => last, "last"),
+  objectToString: /* @__PURE__ */ __name(() => objectToString, "objectToString"),
+  orVoid: /* @__PURE__ */ __name(() => orVoid, "orVoid"),
+  parseStringResponse: /* @__PURE__ */ __name(() => parseStringResponse, "parseStringResponse"),
+  pick: /* @__PURE__ */ __name(() => pick, "pick"),
+  prefixedArray: /* @__PURE__ */ __name(() => prefixedArray, "prefixedArray"),
+  remove: /* @__PURE__ */ __name(() => remove, "remove"),
+  splitOn: /* @__PURE__ */ __name(() => splitOn, "splitOn"),
+  toLinesWithContent: /* @__PURE__ */ __name(() => toLinesWithContent, "toLinesWithContent"),
+  trailingFunctionArgument: /* @__PURE__ */ __name(() => trailingFunctionArgument, "trailingFunctionArgument"),
+  trailingOptionsArgument: /* @__PURE__ */ __name(() => trailingOptionsArgument, "trailingOptionsArgument")
+});
+var init_utils = __esm({
+  "src/lib/utils/index.ts"() {
+    "use strict";
+    init_argument_filters();
+    init_exit_codes();
+    init_git_output_streams();
+    init_line_parser();
+    init_simple_git_options();
+    init_task_options();
+    init_task_parser();
+    init_util();
+  }
+});
+var check_is_repo_exports = {};
+__export(check_is_repo_exports, {
+  CheckRepoActions: /* @__PURE__ */ __name(() => CheckRepoActions, "CheckRepoActions"),
+  checkIsBareRepoTask: /* @__PURE__ */ __name(() => checkIsBareRepoTask, "checkIsBareRepoTask"),
+  checkIsRepoRootTask: /* @__PURE__ */ __name(() => checkIsRepoRootTask, "checkIsRepoRootTask"),
+  checkIsRepoTask: /* @__PURE__ */ __name(() => checkIsRepoTask, "checkIsRepoTask")
+});
+function checkIsRepoTask(action) {
+  switch (action) {
+    case "bare":
+      return checkIsBareRepoTask();
+    case "root":
+      return checkIsRepoRootTask();
+  }
+  const commands = ["rev-parse", "--is-inside-work-tree"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser
+  };
+}
+__name(checkIsRepoTask, "checkIsRepoTask");
+function checkIsRepoRootTask() {
+  const commands = ["rev-parse", "--git-dir"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser(path5) {
+      return /^\.(git)?$/.test(path5.trim());
+    }
+  };
+}
+__name(checkIsRepoRootTask, "checkIsRepoRootTask");
+function checkIsBareRepoTask() {
+  const commands = ["rev-parse", "--is-bare-repository"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser
+  };
+}
+__name(checkIsBareRepoTask, "checkIsBareRepoTask");
+function isNotRepoMessage(error2) {
+  return /(Not a git repository|Kein Git-Repository)/i.test(String(error2));
+}
+__name(isNotRepoMessage, "isNotRepoMessage");
+var CheckRepoActions;
+var onError;
+var parser;
+var init_check_is_repo = __esm({
+  "src/lib/tasks/check-is-repo.ts"() {
+    "use strict";
+    init_utils();
+    CheckRepoActions = /* @__PURE__ */ ((CheckRepoActions2) => {
+      CheckRepoActions2["BARE"] = "bare";
+      CheckRepoActions2["IN_TREE"] = "tree";
+      CheckRepoActions2["IS_REPO_ROOT"] = "root";
+      return CheckRepoActions2;
+    })(CheckRepoActions || {});
+    onError = /* @__PURE__ */ __name(({ exitCode }, error2, done, fail) => {
+      if (exitCode === 128 && isNotRepoMessage(error2)) {
+        return done(Buffer.from("false"));
+      }
+      fail(error2);
+    }, "onError");
+    parser = /* @__PURE__ */ __name((text) => {
+      return text.trim() === "true";
+    }, "parser");
+  }
+});
+function cleanSummaryParser(dryRun, text) {
+  const summary2 = new CleanResponse(dryRun);
+  const regexp = dryRun ? dryRunRemovalRegexp : removalRegexp;
+  toLinesWithContent(text).forEach((line) => {
+    const removed = line.replace(regexp, "");
+    summary2.paths.push(removed);
+    (isFolderRegexp.test(removed) ? summary2.folders : summary2.files).push(removed);
+  });
+  return summary2;
+}
+__name(cleanSummaryParser, "cleanSummaryParser");
+var CleanResponse;
+var removalRegexp;
+var dryRunRemovalRegexp;
+var isFolderRegexp;
+var init_CleanSummary = __esm({
+  "src/lib/responses/CleanSummary.ts"() {
+    "use strict";
+    init_utils();
+    CleanResponse = class {
+      static {
+        __name(this, "CleanResponse");
+      }
+      constructor(dryRun) {
+        this.dryRun = dryRun;
+        this.paths = [];
+        this.files = [];
+        this.folders = [];
+      }
+    };
+    removalRegexp = /^[a-z]+\s*/i;
+    dryRunRemovalRegexp = /^[a-z]+\s+[a-z]+\s*/i;
+    isFolderRegexp = /\/$/;
+  }
+});
+var task_exports = {};
+__export(task_exports, {
+  EMPTY_COMMANDS: /* @__PURE__ */ __name(() => EMPTY_COMMANDS, "EMPTY_COMMANDS"),
+  adhocExecTask: /* @__PURE__ */ __name(() => adhocExecTask, "adhocExecTask"),
+  configurationErrorTask: /* @__PURE__ */ __name(() => configurationErrorTask, "configurationErrorTask"),
+  isBufferTask: /* @__PURE__ */ __name(() => isBufferTask, "isBufferTask"),
+  isEmptyTask: /* @__PURE__ */ __name(() => isEmptyTask, "isEmptyTask"),
+  straightThroughBufferTask: /* @__PURE__ */ __name(() => straightThroughBufferTask, "straightThroughBufferTask"),
+  straightThroughStringTask: /* @__PURE__ */ __name(() => straightThroughStringTask, "straightThroughStringTask")
+});
+function adhocExecTask(parser4) {
+  return {
+    commands: EMPTY_COMMANDS,
+    format: "empty",
+    parser: parser4
+  };
+}
+__name(adhocExecTask, "adhocExecTask");
+function configurationErrorTask(error2) {
+  return {
+    commands: EMPTY_COMMANDS,
+    format: "empty",
+    parser() {
+      throw typeof error2 === "string" ? new TaskConfigurationError(error2) : error2;
+    }
+  };
+}
+__name(configurationErrorTask, "configurationErrorTask");
+function straightThroughStringTask(commands, trimmed2 = false) {
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return trimmed2 ? String(text).trim() : text;
+    }
+  };
+}
+__name(straightThroughStringTask, "straightThroughStringTask");
+function straightThroughBufferTask(commands) {
+  return {
+    commands,
+    format: "buffer",
+    parser(buffer) {
+      return buffer;
+    }
+  };
+}
+__name(straightThroughBufferTask, "straightThroughBufferTask");
+function isBufferTask(task) {
+  return task.format === "buffer";
+}
+__name(isBufferTask, "isBufferTask");
+function isEmptyTask(task) {
+  return task.format === "empty" || !task.commands.length;
+}
+__name(isEmptyTask, "isEmptyTask");
+var EMPTY_COMMANDS;
+var init_task = __esm({
+  "src/lib/tasks/task.ts"() {
+    "use strict";
+    init_task_configuration_error();
+    EMPTY_COMMANDS = [];
+  }
+});
+var clean_exports = {};
+__export(clean_exports, {
+  CONFIG_ERROR_INTERACTIVE_MODE: /* @__PURE__ */ __name(() => CONFIG_ERROR_INTERACTIVE_MODE, "CONFIG_ERROR_INTERACTIVE_M\
+ODE"),
+  CONFIG_ERROR_MODE_REQUIRED: /* @__PURE__ */ __name(() => CONFIG_ERROR_MODE_REQUIRED, "CONFIG_ERROR_MODE_REQUIRED"),
+  CONFIG_ERROR_UNKNOWN_OPTION: /* @__PURE__ */ __name(() => CONFIG_ERROR_UNKNOWN_OPTION, "CONFIG_ERROR_UNKNOWN_OPTION"),
+  CleanOptions: /* @__PURE__ */ __name(() => CleanOptions, "CleanOptions"),
+  cleanTask: /* @__PURE__ */ __name(() => cleanTask, "cleanTask"),
+  cleanWithOptionsTask: /* @__PURE__ */ __name(() => cleanWithOptionsTask, "cleanWithOptionsTask"),
+  isCleanOptionsArray: /* @__PURE__ */ __name(() => isCleanOptionsArray, "isCleanOptionsArray")
+});
+function cleanWithOptionsTask(mode, customArgs) {
+  const { cleanMode, options, valid: valid2 } = getCleanOptions(mode);
+  if (!cleanMode) {
+    return configurationErrorTask(CONFIG_ERROR_MODE_REQUIRED);
+  }
+  if (!valid2.options) {
+    return configurationErrorTask(CONFIG_ERROR_UNKNOWN_OPTION + JSON.stringify(mode));
+  }
+  options.push(...customArgs);
+  if (options.some(isInteractiveMode)) {
+    return configurationErrorTask(CONFIG_ERROR_INTERACTIVE_MODE);
+  }
+  return cleanTask(cleanMode, options);
+}
+__name(cleanWithOptionsTask, "cleanWithOptionsTask");
+function cleanTask(mode, customArgs) {
+  const commands = ["clean", `-${mode}`, ...customArgs];
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return cleanSummaryParser(mode === "n", text);
+    }
+  };
+}
+__name(cleanTask, "cleanTask");
+function isCleanOptionsArray(input) {
+  return Array.isArray(input) && input.every((test) => CleanOptionValues.has(test));
+}
+__name(isCleanOptionsArray, "isCleanOptionsArray");
+function getCleanOptions(input) {
+  let cleanMode;
+  let options = [];
+  let valid2 = { cleanMode: false, options: true };
+  input.replace(/[^a-z]i/g, "").split("").forEach((char) => {
+    if (isCleanMode(char)) {
+      cleanMode = char;
+      valid2.cleanMode = true;
+    } else {
+      valid2.options = valid2.options && isKnownOption(options[options.length] = `-${char}`);
+    }
+  });
+  return {
+    cleanMode,
+    options,
+    valid: valid2
+  };
+}
+__name(getCleanOptions, "getCleanOptions");
+function isCleanMode(cleanMode) {
+  return cleanMode === "f" || cleanMode === "n";
+}
+__name(isCleanMode, "isCleanMode");
+function isKnownOption(option) {
+  return /^-[a-z]$/i.test(option) && CleanOptionValues.has(option.charAt(1));
+}
+__name(isKnownOption, "isKnownOption");
+function isInteractiveMode(option) {
+  if (/^-[^\-]/.test(option)) {
+    return option.indexOf("i") > 0;
+  }
+  return option === "--interactive";
+}
+__name(isInteractiveMode, "isInteractiveMode");
+var CONFIG_ERROR_INTERACTIVE_MODE;
+var CONFIG_ERROR_MODE_REQUIRED;
+var CONFIG_ERROR_UNKNOWN_OPTION;
+var CleanOptions;
+var CleanOptionValues;
+var init_clean = __esm({
+  "src/lib/tasks/clean.ts"() {
+    "use strict";
+    init_CleanSummary();
+    init_utils();
+    init_task();
+    CONFIG_ERROR_INTERACTIVE_MODE = "Git clean interactive mode is not supported";
+    CONFIG_ERROR_MODE_REQUIRED = 'Git clean mode parameter ("n" or "f") is required';
+    CONFIG_ERROR_UNKNOWN_OPTION = "Git clean unknown option found in: ";
+    CleanOptions = /* @__PURE__ */ ((CleanOptions2) => {
+      CleanOptions2["DRY_RUN"] = "n";
+      CleanOptions2["FORCE"] = "f";
+      CleanOptions2["IGNORED_INCLUDED"] = "x";
+      CleanOptions2["IGNORED_ONLY"] = "X";
+      CleanOptions2["EXCLUDING"] = "e";
+      CleanOptions2["QUIET"] = "q";
+      CleanOptions2["RECURSIVE"] = "d";
+      return CleanOptions2;
+    })(CleanOptions || {});
+    CleanOptionValues = /* @__PURE__ */ new Set([
+      "i",
+      ...asStringArray(Object.values(CleanOptions))
+    ]);
+  }
+});
+function configListParser(text) {
+  const config = new ConfigList();
+  for (const item of configParser(text)) {
+    config.addValue(item.file, String(item.key), item.value);
+  }
+  return config;
+}
+__name(configListParser, "configListParser");
+function configGetParser(text, key) {
+  let value = null;
+  const values = [];
+  const scopes = /* @__PURE__ */ new Map();
+  for (const item of configParser(text, key)) {
+    if (item.key !== key) {
+      continue;
+    }
+    values.push(value = item.value);
+    if (!scopes.has(item.file)) {
+      scopes.set(item.file, []);
+    }
+    scopes.get(item.file).push(value);
+  }
+  return {
+    key,
+    paths: Array.from(scopes.keys()),
+    scopes,
+    value,
+    values
+  };
+}
+__name(configGetParser, "configGetParser");
+function configFilePath(filePath) {
+  return filePath.replace(/^(file):/, "");
+}
+__name(configFilePath, "configFilePath");
+function* configParser(text, requestedKey = null) {
+  const lines = text.split("\0");
+  for (let i = 0, max = lines.length - 1; i < max; ) {
+    const file = configFilePath(lines[i++]);
+    let value = lines[i++];
+    let key = requestedKey;
+    if (value.includes("\n")) {
+      const line = splitOn(value, "\n");
+      key = line[0];
+      value = line[1];
+    }
+    yield { file, key, value };
+  }
+}
+__name(configParser, "configParser");
+var ConfigList;
+var init_ConfigList = __esm({
+  "src/lib/responses/ConfigList.ts"() {
+    "use strict";
+    init_utils();
+    ConfigList = class {
+      static {
+        __name(this, "ConfigList");
+      }
+      constructor() {
+        this.files = [];
+        this.values = /* @__PURE__ */ Object.create(null);
+      }
+      get all() {
+        if (!this._all) {
+          this._all = this.files.reduce((all, file) => {
+            return Object.assign(all, this.values[file]);
+          }, {});
+        }
+        return this._all;
+      }
+      addFile(file) {
+        if (!(file in this.values)) {
+          const latest = last(this.files);
+          this.values[file] = latest ? Object.create(this.values[latest]) : {};
+          this.files.push(file);
+        }
+        return this.values[file];
+      }
+      addValue(file, key, value) {
+        const values = this.addFile(file);
+        if (!Object.hasOwn(values, key)) {
+          values[key] = value;
+        } else if (Array.isArray(values[key])) {
+          values[key].push(value);
+        } else {
+          values[key] = [values[key], value];
+        }
+        this._all = void 0;
+      }
+    };
+  }
+});
+function asConfigScope(scope, fallback) {
+  if (typeof scope === "string" && Object.hasOwn(GitConfigScope, scope)) {
+    return scope;
+  }
+  return fallback;
+}
+__name(asConfigScope, "asConfigScope");
+function addConfigTask(key, value, append2, scope) {
+  const commands = ["config", `--${scope}`];
+  if (append2) {
+    commands.push("--add");
+  }
+  commands.push(key, value);
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return text;
+    }
+  };
+}
+__name(addConfigTask, "addConfigTask");
+function getConfigTask(key, scope) {
+  const commands = ["config", "--null", "--show-origin", "--get-all", key];
+  if (scope) {
+    commands.splice(1, 0, `--${scope}`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return configGetParser(text, key);
+    }
+  };
+}
+__name(getConfigTask, "getConfigTask");
+function listConfigTask(scope) {
+  const commands = ["config", "--list", "--show-origin", "--null"];
+  if (scope) {
+    commands.push(`--${scope}`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return configListParser(text);
+    }
+  };
+}
+__name(listConfigTask, "listConfigTask");
+function config_default() {
+  return {
+    addConfig(key, value, ...rest) {
+      return this._runTask(
+        addConfigTask(
+          key,
+          value,
+          rest[0] === true,
+          asConfigScope(
+            rest[1],
+            "local"
+            /* local */
+          )
+        ),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    getConfig(key, scope) {
+      return this._runTask(
+        getConfigTask(key, asConfigScope(scope, void 0)),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    listConfig(...rest) {
+      return this._runTask(
+        listConfigTask(asConfigScope(rest[0], void 0)),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(config_default, "config_default");
+var GitConfigScope;
+var init_config = __esm({
+  "src/lib/tasks/config.ts"() {
+    "use strict";
+    init_ConfigList();
+    init_utils();
+    GitConfigScope = /* @__PURE__ */ ((GitConfigScope2) => {
+      GitConfigScope2["system"] = "system";
+      GitConfigScope2["global"] = "global";
+      GitConfigScope2["local"] = "local";
+      GitConfigScope2["worktree"] = "worktree";
+      return GitConfigScope2;
+    })(GitConfigScope || {});
+  }
+});
+function isDiffNameStatus(input) {
+  return diffNameStatus.has(input);
+}
+__name(isDiffNameStatus, "isDiffNameStatus");
+var DiffNameStatus;
+var diffNameStatus;
+var init_diff_name_status = __esm({
+  "src/lib/tasks/diff-name-status.ts"() {
+    "use strict";
+    DiffNameStatus = /* @__PURE__ */ ((DiffNameStatus2) => {
+      DiffNameStatus2["ADDED"] = "A";
+      DiffNameStatus2["COPIED"] = "C";
+      DiffNameStatus2["DELETED"] = "D";
+      DiffNameStatus2["MODIFIED"] = "M";
+      DiffNameStatus2["RENAMED"] = "R";
+      DiffNameStatus2["CHANGED"] = "T";
+      DiffNameStatus2["UNMERGED"] = "U";
+      DiffNameStatus2["UNKNOWN"] = "X";
+      DiffNameStatus2["BROKEN"] = "B";
+      return DiffNameStatus2;
+    })(DiffNameStatus || {});
+    diffNameStatus = new Set(Object.values(DiffNameStatus));
+  }
+});
+function grepQueryBuilder(...params) {
+  return new GrepQuery().param(...params);
+}
+__name(grepQueryBuilder, "grepQueryBuilder");
+function parseGrep(grep) {
+  const paths = /* @__PURE__ */ new Set();
+  const results = {};
+  forEachLineWithContent(grep, (input) => {
+    const [path5, line, preview] = input.split(NULL);
+    paths.add(path5);
+    (results[path5] = results[path5] || []).push({
+      line: asNumber(line),
+      path: path5,
+      preview
+    });
+  });
+  return {
+    paths,
+    results
+  };
+}
+__name(parseGrep, "parseGrep");
+function grep_default() {
+  return {
+    grep(searchTerm) {
+      const then = trailingFunctionArgument(arguments);
+      const options = getTrailingOptions(arguments);
+      for (const option of disallowedOptions) {
+        if (options.includes(option)) {
+          return this._runTask(
+            configurationErrorTask(`git.grep: use of "${option}" is not supported.`),
+            then
+          );
+        }
+      }
+      if (typeof searchTerm === "string") {
+        searchTerm = grepQueryBuilder().param(searchTerm);
+      }
+      const commands = ["grep", "--null", "-n", "--full-name", ...options, ...searchTerm];
+      return this._runTask(
+        {
+          commands,
+          format: "utf-8",
+          parser(stdOut) {
+            return parseGrep(stdOut);
+          }
+        },
+        then
+      );
+    }
+  };
+}
+__name(grep_default, "grep_default");
+var disallowedOptions;
+var Query;
+var _a;
+var GrepQuery;
+var init_grep = __esm({
+  "src/lib/tasks/grep.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+    disallowedOptions = ["-h"];
+    Query = /* @__PURE__ */ Symbol("grepQuery");
+    GrepQuery = class {
+      static {
+        __name(this, "GrepQuery");
+      }
+      constructor() {
+        this[_a] = [];
+      }
+      *[(_a = Query, Symbol.iterator)]() {
+        for (const query of this[Query]) {
+          yield query;
+        }
+      }
+      and(...and) {
+        and.length && this[Query].push("--and", "(", ...prefixedArray(and, "-e"), ")");
+        return this;
+      }
+      param(...param) {
+        this[Query].push(...prefixedArray(param, "-e"));
+        return this;
+      }
+    };
+  }
+});
+var reset_exports = {};
+__export(reset_exports, {
+  ResetMode: /* @__PURE__ */ __name(() => ResetMode, "ResetMode"),
+  getResetMode: /* @__PURE__ */ __name(() => getResetMode, "getResetMode"),
+  resetTask: /* @__PURE__ */ __name(() => resetTask, "resetTask")
+});
+function resetTask(mode, customArgs) {
+  const commands = ["reset"];
+  if (isValidResetMode(mode)) {
+    commands.push(`--${mode}`);
+  }
+  commands.push(...customArgs);
+  return straightThroughStringTask(commands);
+}
+__name(resetTask, "resetTask");
+function getResetMode(mode) {
+  if (isValidResetMode(mode)) {
+    return mode;
+  }
+  switch (typeof mode) {
+    case "string":
+    case "undefined":
+      return "soft";
+  }
+  return;
+}
+__name(getResetMode, "getResetMode");
+function isValidResetMode(mode) {
+  return typeof mode === "string" && validResetModes.includes(mode);
+}
+__name(isValidResetMode, "isValidResetMode");
+var ResetMode;
+var validResetModes;
+var init_reset = __esm({
+  "src/lib/tasks/reset.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+    ResetMode = /* @__PURE__ */ ((ResetMode2) => {
+      ResetMode2["MIXED"] = "mixed";
+      ResetMode2["SOFT"] = "soft";
+      ResetMode2["HARD"] = "hard";
+      ResetMode2["MERGE"] = "merge";
+      ResetMode2["KEEP"] = "keep";
+      return ResetMode2;
+    })(ResetMode || {});
+    validResetModes = asStringArray(Object.values(ResetMode));
+  }
+});
+function createLog() {
+  return (0, import_debug.default)("simple-git");
+}
+__name(createLog, "createLog");
+function prefixedLogger(to, prefix, forward) {
+  if (!prefix || !String(prefix).replace(/\s*/, "")) {
+    return !forward ? to : (message, ...args) => {
+      to(message, ...args);
+      forward(message, ...args);
+    };
+  }
+  return (message, ...args) => {
+    to(`%s ${message}`, prefix, ...args);
+    if (forward) {
+      forward(message, ...args);
+    }
+  };
+}
+__name(prefixedLogger, "prefixedLogger");
+function childLoggerName(name, childDebugger, { namespace: parentNamespace }) {
+  if (typeof name === "string") {
+    return name;
+  }
+  const childNamespace = childDebugger && childDebugger.namespace || "";
+  if (childNamespace.startsWith(parentNamespace)) {
+    return childNamespace.substr(parentNamespace.length + 1);
+  }
+  return childNamespace || parentNamespace;
+}
+__name(childLoggerName, "childLoggerName");
+function createLogger(label, verbose, initialStep, infoDebugger = createLog()) {
+  const labelPrefix = label && `[${label}]` || "";
+  const spawned = [];
+  const debugDebugger = typeof verbose === "string" ? infoDebugger.extend(verbose) : verbose;
+  const key = childLoggerName(filterType(verbose, filterString), debugDebugger, infoDebugger);
+  return step(initialStep);
+  function sibling(name, initial) {
+    return append(
+      spawned,
+      createLogger(label, key.replace(/^[^:]+/, name), initial, infoDebugger)
+    );
+  }
+  __name(sibling, "sibling");
+  function step(phase) {
+    const stepPrefix = phase && `[${phase}]` || "";
+    const debug22 = debugDebugger && prefixedLogger(debugDebugger, stepPrefix) || NOOP;
+    const info2 = prefixedLogger(infoDebugger, `${labelPrefix} ${stepPrefix}`, debug22);
+    return Object.assign(debugDebugger ? debug22 : info2, {
+      label,
+      sibling,
+      info: info2,
+      step
+    });
+  }
+  __name(step, "step");
+}
+__name(createLogger, "createLogger");
+var init_git_logger = __esm({
+  "src/lib/git-logger.ts"() {
+    "use strict";
+    init_utils();
+    import_debug.default.formatters.L = (value) => String(filterHasLength(value) ? value.length : "-");
+    import_debug.default.formatters.B = (value) => {
+      if (Buffer.isBuffer(value)) {
+        return value.toString("utf8");
+      }
+      return objectToString(value);
+    };
+  }
+});
+var TasksPendingQueue;
+var init_tasks_pending_queue = __esm({
+  "src/lib/runners/tasks-pending-queue.ts"() {
+    "use strict";
+    init_git_error();
+    init_git_logger();
+    TasksPendingQueue = class _TasksPendingQueue {
+      static {
+        __name(this, "_TasksPendingQueue");
+      }
+      constructor(logLabel = "GitExecutor") {
+        this.logLabel = logLabel;
+        this._queue = /* @__PURE__ */ new Map();
+      }
+      withProgress(task) {
+        return this._queue.get(task);
+      }
+      createProgress(task) {
+        const name = _TasksPendingQueue.getName(task.commands[0]);
+        const logger = createLogger(this.logLabel, name);
+        return {
+          task,
+          logger,
+          name
+        };
+      }
+      push(task) {
+        const progress = this.createProgress(task);
+        progress.logger("Adding task to the queue, commands = %o", task.commands);
+        this._queue.set(task, progress);
+        return progress;
+      }
+      fatal(err) {
+        for (const [task, { logger }] of Array.from(this._queue.entries())) {
+          if (task === err.task) {
+            logger.info(`Failed %o`, err);
+            logger(
+              `Fatal exception, any as-yet un-started tasks run through this executor will not be attempted`
+            );
+          } else {
+            logger.info(
+              `A fatal exception occurred in a previous task, the queue has been purged: %o`,
+              err.message
+            );
+          }
+          this.complete(task);
+        }
+        if (this._queue.size !== 0) {
+          throw new Error(`Queue size should be zero after fatal: ${this._queue.size}`);
+        }
+      }
+      complete(task) {
+        const progress = this.withProgress(task);
+        if (progress) {
+          this._queue.delete(task);
+        }
+      }
+      attempt(task) {
+        const progress = this.withProgress(task);
+        if (!progress) {
+          throw new GitError(void 0, "TasksPendingQueue: attempt called for an unknown task");
+        }
+        progress.logger("Starting task");
+        return progress;
+      }
+      static getName(name = "empty") {
+        return `task:${name}:${++_TasksPendingQueue.counter}`;
+      }
+      static {
+        this.counter = 0;
+      }
+    };
+  }
+});
+function pluginContext(task, commands) {
+  return {
+    method: first(task.commands) || "",
+    commands
+  };
+}
+__name(pluginContext, "pluginContext");
+function onErrorReceived(target, logger) {
+  return (err) => {
+    logger(`[ERROR] child process exception %o`, err);
+    target.push(Buffer.from(String(err.stack), "ascii"));
+  };
+}
+__name(onErrorReceived, "onErrorReceived");
+function onDataReceived(target, name, logger, output) {
+  return (buffer) => {
+    logger(`%s received %L bytes`, name, buffer);
+    output(`%B`, buffer);
+    target.push(buffer);
+  };
+}
+__name(onDataReceived, "onDataReceived");
+var GitExecutorChain;
+var init_git_executor_chain = __esm({
+  "src/lib/runners/git-executor-chain.ts"() {
+    "use strict";
+    init_git_error();
+    init_task();
+    init_utils();
+    init_tasks_pending_queue();
+    GitExecutorChain = class {
+      static {
+        __name(this, "GitExecutorChain");
+      }
+      constructor(_executor, _scheduler, _plugins) {
+        this._executor = _executor;
+        this._scheduler = _scheduler;
+        this._plugins = _plugins;
+        this._chain = Promise.resolve();
+        this._queue = new TasksPendingQueue();
+      }
+      get cwd() {
+        return this._cwd || this._executor.cwd;
+      }
+      set cwd(cwd) {
+        this._cwd = cwd;
+      }
+      get env() {
+        return this._executor.env;
+      }
+      get outputHandler() {
+        return this._executor.outputHandler;
+      }
+      chain() {
+        return this;
+      }
+      push(task) {
+        this._queue.push(task);
+        return this._chain = this._chain.then(() => this.attemptTask(task));
+      }
+      async attemptTask(task) {
+        const onScheduleComplete = await this._scheduler.next();
+        const onQueueComplete = /* @__PURE__ */ __name(() => this._queue.complete(task), "onQueueComplete");
+        try {
+          const { logger } = this._queue.attempt(task);
+          return await (isEmptyTask(task) ? this.attemptEmptyTask(task, logger) : this.attemptRemoteTask(task, logger));
+        } catch (e) {
+          throw this.onFatalException(task, e);
+        } finally {
+          onQueueComplete();
+          onScheduleComplete();
+        }
+      }
+      onFatalException(task, e) {
+        const gitError = e instanceof GitError ? Object.assign(e, { task }) : new GitError(task, e && String(e));
+        this._chain = Promise.resolve();
+        this._queue.fatal(gitError);
+        return gitError;
+      }
+      async attemptRemoteTask(task, logger) {
+        const binary = this._plugins.exec("spawn.binary", "", pluginContext(task, task.commands));
+        const args = this._plugins.exec(
+          "spawn.args",
+          [...task.commands],
+          pluginContext(task, task.commands)
+        );
+        const raw = await this.gitResponse(
+          task,
+          binary,
+          args,
+          this.outputHandler,
+          logger.step("SPAWN")
+        );
+        const outputStreams = await this.handleTaskData(task, args, raw, logger.step("HANDLE"));
+        logger(`passing response to task's parser as a %s`, task.format);
+        if (isBufferTask(task)) {
+          return callTaskParser(task.parser, outputStreams);
+        }
+        return callTaskParser(task.parser, outputStreams.asStrings());
+      }
+      async attemptEmptyTask(task, logger) {
+        logger(`empty task bypassing child process to call to task's parser`);
+        return task.parser(this);
+      }
+      handleTaskData(task, args, result, logger) {
+        const { exitCode, rejection, stdOut, stdErr } = result;
+        return new Promise((done, fail) => {
+          logger(`Preparing to handle process response exitCode=%d stdOut=`, exitCode);
+          const { error: error2 } = this._plugins.exec(
+            "task.error",
+            { error: rejection },
+            {
+              ...pluginContext(task, args),
+              ...result
+            }
+          );
+          if (error2 && task.onError) {
+            logger.info(`exitCode=%s handling with custom error handler`);
+            return task.onError(
+              result,
+              error2,
+              (newStdOut) => {
+                logger.info(`custom error handler treated as success`);
+                logger(`custom error returned a %s`, objectToString(newStdOut));
+                done(
+                  new GitOutputStreams(
+                    Array.isArray(newStdOut) ? Buffer.concat(newStdOut) : newStdOut,
+                    Buffer.concat(stdErr)
+                  )
+                );
+              },
+              fail
+            );
+          }
+          if (error2) {
+            logger.info(
+              `handling as error: exitCode=%s stdErr=%s rejection=%o`,
+              exitCode,
+              stdErr.length,
+              rejection
+            );
+            return fail(error2);
+          }
+          logger.info(`retrieving task output complete`);
+          done(new GitOutputStreams(Buffer.concat(stdOut), Buffer.concat(stdErr)));
+        });
+      }
+      async gitResponse(task, command, args, outputHandler, logger) {
+        const outputLogger = logger.sibling("output");
+        const spawnOptions = this._plugins.exec(
+          "spawn.options",
+          {
+            cwd: this.cwd,
+            env: this.env,
+            windowsHide: true
+          },
+          pluginContext(task, task.commands)
+        );
+        return new Promise((done) => {
+          const stdOut = [];
+          const stdErr = [];
+          logger.info(`%s %o`, command, args);
+          logger("%O", spawnOptions);
+          let rejection = this._beforeSpawn(task, args);
+          if (rejection) {
+            return done({
+              stdOut,
+              stdErr,
+              exitCode: 9901,
+              rejection
+            });
+          }
+          this._plugins.exec("spawn.before", void 0, {
+            ...pluginContext(task, args),
+            kill(reason) {
+              rejection = reason || rejection;
+            }
+          });
+          const spawned = (0, import_child_process.spawn)(command, args, spawnOptions);
+          spawned.stdout.on(
+            "data",
+            onDataReceived(stdOut, "stdOut", logger, outputLogger.step("stdOut"))
+          );
+          spawned.stderr.on(
+            "data",
+            onDataReceived(stdErr, "stdErr", logger, outputLogger.step("stdErr"))
+          );
+          spawned.on("error", onErrorReceived(stdErr, logger));
+          if (outputHandler) {
+            logger(`Passing child process stdOut/stdErr to custom outputHandler`);
+            outputHandler(command, spawned.stdout, spawned.stderr, [...args]);
+          }
+          this._plugins.exec("spawn.after", void 0, {
+            ...pluginContext(task, args),
+            spawned,
+            close(exitCode, reason) {
+              done({
+                stdOut,
+                stdErr,
+                exitCode,
+                rejection: rejection || reason
+              });
+            },
+            kill(reason) {
+              if (spawned.killed) {
+                return;
+              }
+              rejection = reason;
+              spawned.kill("SIGINT");
+            }
+          });
+        });
+      }
+      _beforeSpawn(task, args) {
+        let rejection;
+        this._plugins.exec("spawn.before", void 0, {
+          ...pluginContext(task, args),
+          kill(reason) {
+            rejection = reason || rejection;
+          }
+        });
+        return rejection;
+      }
+    };
+  }
+});
+var git_executor_exports = {};
+__export(git_executor_exports, {
+  GitExecutor: /* @__PURE__ */ __name(() => GitExecutor, "GitExecutor")
+});
+var GitExecutor;
+var init_git_executor = __esm({
+  "src/lib/runners/git-executor.ts"() {
+    "use strict";
+    init_git_executor_chain();
+    GitExecutor = class {
+      static {
+        __name(this, "GitExecutor");
+      }
+      constructor(cwd, _scheduler, _plugins) {
+        this.cwd = cwd;
+        this._scheduler = _scheduler;
+        this._plugins = _plugins;
+        this._chain = new GitExecutorChain(this, this._scheduler, this._plugins);
+      }
+      chain() {
+        return new GitExecutorChain(this, this._scheduler, this._plugins);
+      }
+      push(task) {
+        return this._chain.push(task);
+      }
+    };
+  }
+});
+function taskCallback(task, response, callback = NOOP) {
+  const onSuccess = /* @__PURE__ */ __name((data) => {
+    callback(null, data);
+  }, "onSuccess");
+  const onError2 = /* @__PURE__ */ __name((err) => {
+    if (err?.task === task) {
+      callback(
+        err instanceof GitResponseError ? addDeprecationNoticeToError(err) : err,
+        void 0
+      );
+    }
+  }, "onError2");
+  response.then(onSuccess, onError2);
+}
+__name(taskCallback, "taskCallback");
+function addDeprecationNoticeToError(err) {
+  let log = /* @__PURE__ */ __name((name) => {
+    console.warn(
+      `simple-git deprecation notice: accessing GitResponseError.${name} should be GitResponseError.git.${name}, this wi\
+ll no longer be available in version 3`
+    );
+    log = NOOP;
+  }, "log");
+  return Object.create(err, Object.getOwnPropertyNames(err.git).reduce(descriptorReducer, {}));
+  function descriptorReducer(all, name) {
+    if (name in err) {
+      return all;
+    }
+    all[name] = {
+      enumerable: false,
+      configurable: false,
+      get() {
+        log(name);
+        return err.git[name];
+      }
+    };
+    return all;
+  }
+  __name(descriptorReducer, "descriptorReducer");
+}
+__name(addDeprecationNoticeToError, "addDeprecationNoticeToError");
+var init_task_callback = __esm({
+  "src/lib/task-callback.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_utils();
+  }
+});
+function changeWorkingDirectoryTask(directory, root) {
+  return adhocExecTask((instance) => {
+    if (!folderExists(directory)) {
+      throw new Error(`Git.cwd: cannot change to non-directory "${directory}"`);
+    }
+    return (root || instance).cwd = directory;
+  });
+}
+__name(changeWorkingDirectoryTask, "changeWorkingDirectoryTask");
+var init_change_working_directory = __esm({
+  "src/lib/tasks/change-working-directory.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+function checkoutTask(args) {
+  const commands = ["checkout", ...args];
+  if (commands[1] === "-b" && commands.includes("-B")) {
+    commands[1] = remove(commands, "-B");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(checkoutTask, "checkoutTask");
+function checkout_default() {
+  return {
+    checkout() {
+      return this._runTask(
+        checkoutTask(getTrailingOptions(arguments, 1)),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    checkoutBranch(branchName, startPoint) {
+      return this._runTask(
+        checkoutTask(["-b", branchName, startPoint, ...getTrailingOptions(arguments)]),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    checkoutLocalBranch(branchName) {
+      return this._runTask(
+        checkoutTask(["-b", branchName, ...getTrailingOptions(arguments)]),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(checkout_default, "checkout_default");
+var init_checkout = __esm({
+  "src/lib/tasks/checkout.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+function countObjectsResponse() {
+  return {
+    count: 0,
+    garbage: 0,
+    inPack: 0,
+    packs: 0,
+    prunePackable: 0,
+    size: 0,
+    sizeGarbage: 0,
+    sizePack: 0
+  };
+}
+__name(countObjectsResponse, "countObjectsResponse");
+function count_objects_default() {
+  return {
+    countObjects() {
+      return this._runTask({
+        commands: ["count-objects", "--verbose"],
+        format: "utf-8",
+        parser(stdOut) {
+          return parseStringResponse(countObjectsResponse(), [parser2], stdOut);
+        }
+      });
+    }
+  };
+}
+__name(count_objects_default, "count_objects_default");
+var parser2;
+var init_count_objects = __esm({
+  "src/lib/tasks/count-objects.ts"() {
+    "use strict";
+    init_utils();
+    parser2 = new LineParser(
+      /([a-z-]+): (\d+)$/,
+      (result, [key, value]) => {
+        const property = asCamelCase(key);
+        if (Object.hasOwn(result, property)) {
+          result[property] = asNumber(value);
+        }
+      }
+    );
+  }
+});
+function parseCommitResult(stdOut) {
+  const result = {
+    author: null,
+    branch: "",
+    commit: "",
+    root: false,
+    summary: {
+      changes: 0,
+      insertions: 0,
+      deletions: 0
+    }
+  };
+  return parseStringResponse(result, parsers, stdOut);
+}
+__name(parseCommitResult, "parseCommitResult");
+var parsers;
+var init_parse_commit = __esm({
+  "src/lib/parsers/parse-commit.ts"() {
+    "use strict";
+    init_utils();
+    parsers = [
+      new LineParser(/^\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
+        result.branch = branch;
+        result.commit = commit;
+        result.root = !!root;
+      }),
+      new LineParser(/\s*Author:\s(.+)/i, (result, [author]) => {
+        const parts = author.split("<");
+        const email = parts.pop();
+        if (!email || !email.includes("@")) {
+          return;
+        }
+        result.author = {
+          email: email.substr(0, email.length - 1),
+          name: parts.join("<").trim()
+        };
+      }),
+      new LineParser(
+        /(\d+)[^,]*(?:,\s*(\d+)[^,]*)(?:,\s*(\d+))/g,
+        (result, [changes, insertions, deletions]) => {
+          result.summary.changes = parseInt(changes, 10) || 0;
+          result.summary.insertions = parseInt(insertions, 10) || 0;
+          result.summary.deletions = parseInt(deletions, 10) || 0;
+        }
+      ),
+      new LineParser(
+        /^(\d+)[^,]*(?:,\s*(\d+)[^(]+\(([+-]))?/,
+        (result, [changes, lines, direction]) => {
+          result.summary.changes = parseInt(changes, 10) || 0;
+          const count = parseInt(lines, 10) || 0;
+          if (direction === "-") {
+            result.summary.deletions = count;
+          } else if (direction === "+") {
+            result.summary.insertions = count;
+          }
+        }
+      )
+    ];
+  }
+});
+function commitTask(message, files, customArgs) {
+  const commands = [
+    "-c",
+    "core.abbrev=40",
+    "commit",
+    ...prefixedArray(message, "-m"),
+    ...files,
+    ...customArgs
+  ];
+  return {
+    commands,
+    format: "utf-8",
+    parser: parseCommitResult
+  };
+}
+__name(commitTask, "commitTask");
+function commit_default() {
+  return {
+    commit(message, ...rest) {
+      const next = trailingFunctionArgument(arguments);
+      const task = rejectDeprecatedSignatures(message) || commitTask(
+        asArray(message),
+        asArray(filterType(rest[0], filterStringOrStringArray, [])),
+        [
+          ...asStringArray(filterType(rest[1], filterArray, [])),
+          ...getTrailingOptions(arguments, 0, true)
+        ]
+      );
+      return this._runTask(task, next);
+    }
+  };
+  function rejectDeprecatedSignatures(message) {
+    return !filterStringOrStringArray(message) && configurationErrorTask(
+      `git.commit: requires the commit message to be supplied as a string/string[]`
+    );
+  }
+  __name(rejectDeprecatedSignatures, "rejectDeprecatedSignatures");
+}
+__name(commit_default, "commit_default");
+var init_commit = __esm({
+  "src/lib/tasks/commit.ts"() {
+    "use strict";
+    init_parse_commit();
+    init_utils();
+    init_task();
+  }
+});
+function first_commit_default() {
+  return {
+    firstCommit() {
+      return this._runTask(
+        straightThroughStringTask(["rev-list", "--max-parents=0", "HEAD"], true),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(first_commit_default, "first_commit_default");
+var init_first_commit = __esm({
+  "src/lib/tasks/first-commit.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+function hashObjectTask(filePath, write) {
+  const commands = ["hash-object", filePath];
+  if (write) {
+    commands.push("-w");
+  }
+  return straightThroughStringTask(commands, true);
+}
+__name(hashObjectTask, "hashObjectTask");
+var init_hash_object = __esm({
+  "src/lib/tasks/hash-object.ts"() {
+    "use strict";
+    init_task();
+  }
+});
+function parseInit(bare, path5, text) {
+  const response = String(text).trim();
+  let result;
+  if (result = initResponseRegex.exec(response)) {
+    return new InitSummary(bare, path5, false, result[1]);
+  }
+  if (result = reInitResponseRegex.exec(response)) {
+    return new InitSummary(bare, path5, true, result[1]);
+  }
+  let gitDir = "";
+  const tokens = response.split(" ");
+  while (tokens.length) {
+    const token = tokens.shift();
+    if (token === "in") {
+      gitDir = tokens.join(" ");
+      break;
+    }
+  }
+  return new InitSummary(bare, path5, /^re/i.test(response), gitDir);
+}
+__name(parseInit, "parseInit");
+var InitSummary;
+var initResponseRegex;
+var reInitResponseRegex;
+var init_InitSummary = __esm({
+  "src/lib/responses/InitSummary.ts"() {
+    "use strict";
+    InitSummary = class {
+      static {
+        __name(this, "InitSummary");
+      }
+      constructor(bare, path5, existing, gitDir) {
+        this.bare = bare;
+        this.path = path5;
+        this.existing = existing;
+        this.gitDir = gitDir;
+      }
+    };
+    initResponseRegex = /^Init.+ repository in (.+)$/;
+    reInitResponseRegex = /^Rein.+ in (.+)$/;
+  }
+});
+function hasBareCommand(command) {
+  return command.includes(bareCommand);
+}
+__name(hasBareCommand, "hasBareCommand");
+function initTask(bare = false, path5, customArgs) {
+  const commands = ["init", ...customArgs];
+  if (bare && !hasBareCommand(commands)) {
+    commands.splice(1, 0, bareCommand);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return parseInit(commands.includes("--bare"), path5, text);
+    }
+  };
+}
+__name(initTask, "initTask");
+var bareCommand;
+var init_init = __esm({
+  "src/lib/tasks/init.ts"() {
+    "use strict";
+    init_InitSummary();
+    bareCommand = "--bare";
+  }
+});
+function logFormatFromCommand(customArgs) {
+  for (let i = 0; i < customArgs.length; i++) {
+    const format = logFormatRegex.exec(customArgs[i]);
+    if (format) {
+      return `--${format[1]}`;
+    }
+  }
+  return "";
+}
+__name(logFormatFromCommand, "logFormatFromCommand");
+function isLogFormat(customArg) {
+  return logFormatRegex.test(customArg);
+}
+__name(isLogFormat, "isLogFormat");
+var logFormatRegex;
+var init_log_format = __esm({
+  "src/lib/args/log-format.ts"() {
+    "use strict";
+    logFormatRegex = /^--(stat|numstat|name-only|name-status)(=|$)/;
+  }
+});
+var DiffSummary;
+var init_DiffSummary = __esm({
+  "src/lib/responses/DiffSummary.ts"() {
+    "use strict";
+    DiffSummary = class {
+      static {
+        __name(this, "DiffSummary");
+      }
+      constructor() {
+        this.changed = 0;
+        this.deletions = 0;
+        this.insertions = 0;
+        this.files = [];
+      }
+    };
+  }
+});
+function getDiffParser(format = "") {
+  const parser4 = diffSummaryParsers[format];
+  return (stdOut) => parseStringResponse(new DiffSummary(), parser4, stdOut, false);
+}
+__name(getDiffParser, "getDiffParser");
+var statParser;
+var numStatParser;
+var nameOnlyParser;
+var nameStatusParser;
+var diffSummaryParsers;
+var init_parse_diff_summary = __esm({
+  "src/lib/parsers/parse-diff-summary.ts"() {
+    "use strict";
+    init_log_format();
+    init_DiffSummary();
+    init_diff_name_status();
+    init_utils();
+    statParser = [
+      new LineParser(
+        /^(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/,
+        (result, [file, changes, alterations = ""]) => {
+          result.files.push({
+            file: file.trim(),
+            changes: asNumber(changes),
+            insertions: alterations.replace(/[^+]/g, "").length,
+            deletions: alterations.replace(/[^-]/g, "").length,
+            binary: false
+          });
+        }
+      ),
+      new LineParser(
+        /^(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/,
+        (result, [file, before, after]) => {
+          result.files.push({
+            file: file.trim(),
+            before: asNumber(before),
+            after: asNumber(after),
+            binary: true
+          });
+        }
+      ),
+      new LineParser(
+        /(\d+) files? changed\s*((?:, \d+ [^,]+){0,2})/,
+        (result, [changed, summary2]) => {
+          const inserted = /(\d+) i/.exec(summary2);
+          const deleted = /(\d+) d/.exec(summary2);
+          result.changed = asNumber(changed);
+          result.insertions = asNumber(inserted?.[1]);
+          result.deletions = asNumber(deleted?.[1]);
+        }
+      )
+    ];
+    numStatParser = [
+      new LineParser(
+        /(\d+)\t(\d+)\t(.+)$/,
+        (result, [changesInsert, changesDelete, file]) => {
+          const insertions = asNumber(changesInsert);
+          const deletions = asNumber(changesDelete);
+          result.changed++;
+          result.insertions += insertions;
+          result.deletions += deletions;
+          result.files.push({
+            file,
+            changes: insertions + deletions,
+            insertions,
+            deletions,
+            binary: false
+          });
+        }
+      ),
+      new LineParser(/-\t-\t(.+)$/, (result, [file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          after: 0,
+          before: 0,
+          binary: true
+        });
+      })
+    ];
+    nameOnlyParser = [
+      new LineParser(/(.+)$/, (result, [file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          changes: 0,
+          insertions: 0,
+          deletions: 0,
+          binary: false
+        });
+      })
+    ];
+    nameStatusParser = [
+      new LineParser(
+        /([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(\t(.[^\t]*))?$/,
+        (result, [status, similarity, from, _to, to]) => {
+          result.changed++;
+          result.files.push({
+            file: to ?? from,
+            changes: 0,
+            insertions: 0,
+            deletions: 0,
+            binary: false,
+            status: orVoid(isDiffNameStatus(status) && status),
+            from: orVoid(!!to && from !== to && from),
+            similarity: asNumber(similarity)
+          });
+        }
+      )
+    ];
+    diffSummaryParsers = {
+      [
+        ""
+        /* NONE */
+      ]: statParser,
+      [
+        "--stat"
+        /* STAT */
+      ]: statParser,
+      [
+        "--numstat"
+        /* NUM_STAT */
+      ]: numStatParser,
+      [
+        "--name-status"
+        /* NAME_STATUS */
+      ]: nameStatusParser,
+      [
+        "--name-only"
+        /* NAME_ONLY */
+      ]: nameOnlyParser
+    };
+  }
+});
+function lineBuilder(tokens, fields) {
+  return fields.reduce(
+    (line, field, index) => {
+      line[field] = tokens[index] || "";
+      return line;
+    },
+    /* @__PURE__ */ Object.create({ diff: null })
+  );
+}
+__name(lineBuilder, "lineBuilder");
+function createListLogSummaryParser(splitter = SPLITTER, fields = defaultFieldNames, logFormat = "") {
+  const parseDiffResult = getDiffParser(logFormat);
+  return function(stdOut) {
+    const all = toLinesWithContent(
+      stdOut.trim(),
+      false,
+      START_BOUNDARY
+    ).map(function(item) {
+      const lineDetail = item.split(COMMIT_BOUNDARY);
+      const listLogLine = lineBuilder(lineDetail[0].split(splitter), fields);
+      if (lineDetail.length > 1 && !!lineDetail[1].trim()) {
+        listLogLine.diff = parseDiffResult(lineDetail[1]);
+      }
+      return listLogLine;
+    });
+    return {
+      all,
+      latest: all.length && all[0] || null,
+      total: all.length
+    };
+  };
+}
+__name(createListLogSummaryParser, "createListLogSummaryParser");
+var START_BOUNDARY;
+var COMMIT_BOUNDARY;
+var SPLITTER;
+var defaultFieldNames;
+var init_parse_list_log_summary = __esm({
+  "src/lib/parsers/parse-list-log-summary.ts"() {
+    "use strict";
+    init_utils();
+    init_parse_diff_summary();
+    init_log_format();
+    START_BOUNDARY = "\xF2\xF2\xF2\xF2\xF2\xF2 ";
+    COMMIT_BOUNDARY = " \xF2\xF2";
+    SPLITTER = " \xF2 ";
+    defaultFieldNames = ["hash", "date", "message", "refs", "author_name", "author_email"];
+  }
+});
+var diff_exports = {};
+__export(diff_exports, {
+  diffSummaryTask: /* @__PURE__ */ __name(() => diffSummaryTask, "diffSummaryTask"),
+  validateLogFormatConfig: /* @__PURE__ */ __name(() => validateLogFormatConfig, "validateLogFormatConfig")
+});
+function diffSummaryTask(customArgs) {
+  let logFormat = logFormatFromCommand(customArgs);
+  const commands = ["diff"];
+  if (logFormat === "") {
+    logFormat = "--stat";
+    commands.push("--stat=4096");
+  }
+  commands.push(...customArgs);
+  return validateLogFormatConfig(commands) || {
+    commands,
+    format: "utf-8",
+    parser: getDiffParser(logFormat)
+  };
+}
+__name(diffSummaryTask, "diffSummaryTask");
+function validateLogFormatConfig(customArgs) {
+  const flags = customArgs.filter(isLogFormat);
+  if (flags.length > 1) {
+    return configurationErrorTask(
+      `Summary flags are mutually exclusive - pick one of ${flags.join(",")}`
+    );
+  }
+  if (flags.length && customArgs.includes("-z")) {
+    return configurationErrorTask(
+      `Summary flag ${flags} parsing is not compatible with null termination option '-z'`
+    );
+  }
+}
+__name(validateLogFormatConfig, "validateLogFormatConfig");
+var init_diff = __esm({
+  "src/lib/tasks/diff.ts"() {
+    "use strict";
+    init_log_format();
+    init_parse_diff_summary();
+    init_task();
+  }
+});
+function prettyFormat(format, splitter) {
+  const fields = [];
+  const formatStr = [];
+  Object.keys(format).forEach((field) => {
+    fields.push(field);
+    formatStr.push(String(format[field]));
+  });
+  return [fields, formatStr.join(splitter)];
+}
+__name(prettyFormat, "prettyFormat");
+function userOptions(input) {
+  return Object.keys(input).reduce((out, key) => {
+    if (!(key in excludeOptions)) {
+      out[key] = input[key];
+    }
+    return out;
+  }, {});
+}
+__name(userOptions, "userOptions");
+function parseLogOptions(opt = {}, customArgs = []) {
+  const splitter = filterType(opt.splitter, filterString, SPLITTER);
+  const format = filterPlainObject(opt.format) ? opt.format : {
+    hash: "%H",
+    date: opt.strictDate === false ? "%ai" : "%aI",
+    message: "%s",
+    refs: "%D",
+    body: opt.multiLine ? "%B" : "%b",
+    author_name: opt.mailMap !== false ? "%aN" : "%an",
+    author_email: opt.mailMap !== false ? "%aE" : "%ae"
+  };
+  const [fields, formatStr] = prettyFormat(format, splitter);
+  const suffix = [];
+  const command = [
+    `--pretty=format:${START_BOUNDARY}${formatStr}${COMMIT_BOUNDARY}`,
+    ...customArgs
+  ];
+  const maxCount = opt.n || opt["max-count"] || opt.maxCount;
+  if (maxCount) {
+    command.push(`--max-count=${maxCount}`);
+  }
+  if (opt.from || opt.to) {
+    const rangeOperator = opt.symmetric !== false ? "..." : "..";
+    suffix.push(`${opt.from || ""}${rangeOperator}${opt.to || ""}`);
+  }
+  if (filterString(opt.file)) {
+    command.push("--follow", pathspec(opt.file));
+  }
+  appendTaskOptions(userOptions(opt), command);
+  return {
+    fields,
+    splitter,
+    commands: [...command, ...suffix]
+  };
+}
+__name(parseLogOptions, "parseLogOptions");
+function logTask(splitter, fields, customArgs) {
+  const parser4 = createListLogSummaryParser(splitter, fields, logFormatFromCommand(customArgs));
+  return {
+    commands: ["log", ...customArgs],
+    format: "utf-8",
+    parser: parser4
+  };
+}
+__name(logTask, "logTask");
+function log_default() {
+  return {
+    log(...rest) {
+      const next = trailingFunctionArgument(arguments);
+      const options = parseLogOptions(
+        trailingOptionsArgument(arguments),
+        asStringArray(filterType(arguments[0], filterArray, []))
+      );
+      const task = rejectDeprecatedSignatures(...rest) || validateLogFormatConfig(options.commands) || createLogTask(options);
+      return this._runTask(task, next);
+    }
+  };
+  function createLogTask(options) {
+    return logTask(options.splitter, options.fields, options.commands);
+  }
+  __name(createLogTask, "createLogTask");
+  function rejectDeprecatedSignatures(from, to) {
+    return filterString(from) && filterString(to) && configurationErrorTask(
+      `git.log(string, string) should be replaced with git.log({ from: string, to: string })`
+    );
+  }
+  __name(rejectDeprecatedSignatures, "rejectDeprecatedSignatures");
+}
+__name(log_default, "log_default");
+var excludeOptions;
+var init_log = __esm({
+  "src/lib/tasks/log.ts"() {
+    "use strict";
+    init_log_format();
+    init_pathspec();
+    init_parse_list_log_summary();
+    init_utils();
+    init_task();
+    init_diff();
+    excludeOptions = /* @__PURE__ */ ((excludeOptions2) => {
+      excludeOptions2[excludeOptions2["--pretty"] = 0] = "--pretty";
+      excludeOptions2[excludeOptions2["max-count"] = 1] = "max-count";
+      excludeOptions2[excludeOptions2["maxCount"] = 2] = "maxCount";
+      excludeOptions2[excludeOptions2["n"] = 3] = "n";
+      excludeOptions2[excludeOptions2["file"] = 4] = "file";
+      excludeOptions2[excludeOptions2["format"] = 5] = "format";
+      excludeOptions2[excludeOptions2["from"] = 6] = "from";
+      excludeOptions2[excludeOptions2["to"] = 7] = "to";
+      excludeOptions2[excludeOptions2["splitter"] = 8] = "splitter";
+      excludeOptions2[excludeOptions2["symmetric"] = 9] = "symmetric";
+      excludeOptions2[excludeOptions2["mailMap"] = 10] = "mailMap";
+      excludeOptions2[excludeOptions2["multiLine"] = 11] = "multiLine";
+      excludeOptions2[excludeOptions2["strictDate"] = 12] = "strictDate";
+      return excludeOptions2;
+    })(excludeOptions || {});
+  }
+});
+var MergeSummaryConflict;
+var MergeSummaryDetail;
+var init_MergeSummary = __esm({
+  "src/lib/responses/MergeSummary.ts"() {
+    "use strict";
+    MergeSummaryConflict = class {
+      static {
+        __name(this, "MergeSummaryConflict");
+      }
+      constructor(reason, file = null, meta) {
+        this.reason = reason;
+        this.file = file;
+        this.meta = meta;
+      }
+      toString() {
+        return `${this.file}:${this.reason}`;
+      }
+    };
+    MergeSummaryDetail = class {
+      static {
+        __name(this, "MergeSummaryDetail");
+      }
+      constructor() {
+        this.conflicts = [];
+        this.merges = [];
+        this.result = "success";
+      }
+      get failed() {
+        return this.conflicts.length > 0;
+      }
+      get reason() {
+        return this.result;
+      }
+      toString() {
+        if (this.conflicts.length) {
+          return `CONFLICTS: ${this.conflicts.join(", ")}`;
+        }
+        return "OK";
+      }
+    };
+  }
+});
+var PullSummary;
+var PullFailedSummary;
+var init_PullSummary = __esm({
+  "src/lib/responses/PullSummary.ts"() {
+    "use strict";
+    PullSummary = class {
+      static {
+        __name(this, "PullSummary");
+      }
+      constructor() {
+        this.remoteMessages = {
+          all: []
+        };
+        this.created = [];
+        this.deleted = [];
+        this.files = [];
+        this.deletions = {};
+        this.insertions = {};
+        this.summary = {
+          changes: 0,
+          deletions: 0,
+          insertions: 0
+        };
+      }
+    };
+    PullFailedSummary = class {
+      static {
+        __name(this, "PullFailedSummary");
+      }
+      constructor() {
+        this.remote = "";
+        this.hash = {
+          local: "",
+          remote: ""
+        };
+        this.branch = {
+          local: "",
+          remote: ""
+        };
+        this.message = "";
+      }
+      toString() {
+        return this.message;
+      }
+    };
+  }
+});
+function objectEnumerationResult(remoteMessages) {
+  return remoteMessages.objects = remoteMessages.objects || {
+    compressing: 0,
+    counting: 0,
+    enumerating: 0,
+    packReused: 0,
+    reused: { count: 0, delta: 0 },
+    total: { count: 0, delta: 0 }
+  };
+}
+__name(objectEnumerationResult, "objectEnumerationResult");
+function asObjectCount(source) {
+  const count = /^\s*(\d+)/.exec(source);
+  const delta = /delta (\d+)/i.exec(source);
+  return {
+    count: asNumber(count && count[1] || "0"),
+    delta: asNumber(delta && delta[1] || "0")
+  };
+}
+__name(asObjectCount, "asObjectCount");
+var remoteMessagesObjectParsers;
+var init_parse_remote_objects = __esm({
+  "src/lib/parsers/parse-remote-objects.ts"() {
+    "use strict";
+    init_utils();
+    remoteMessagesObjectParsers = [
+      new RemoteLineParser(
+        /^remote:\s*(enumerating|counting|compressing) objects: (\d+),/i,
+        (result, [action, count]) => {
+          const key = action.toLowerCase();
+          const enumeration = objectEnumerationResult(result.remoteMessages);
+          Object.assign(enumeration, { [key]: asNumber(count) });
+        }
+      ),
+      new RemoteLineParser(
+        /^remote:\s*(enumerating|counting|compressing) objects: \d+% \(\d+\/(\d+)\),/i,
+        (result, [action, count]) => {
+          const key = action.toLowerCase();
+          const enumeration = objectEnumerationResult(result.remoteMessages);
+          Object.assign(enumeration, { [key]: asNumber(count) });
+        }
+      ),
+      new RemoteLineParser(
+        /total ([^,]+), reused ([^,]+), pack-reused (\d+)/i,
+        (result, [total, reused, packReused]) => {
+          const objects = objectEnumerationResult(result.remoteMessages);
+          objects.total = asObjectCount(total);
+          objects.reused = asObjectCount(reused);
+          objects.packReused = asNumber(packReused);
+        }
+      )
+    ];
+  }
+});
+function parseRemoteMessages(_stdOut, stdErr) {
+  return parseStringResponse({ remoteMessages: new RemoteMessageSummary() }, parsers2, stdErr);
+}
+__name(parseRemoteMessages, "parseRemoteMessages");
+var parsers2;
+var RemoteMessageSummary;
+var init_parse_remote_messages = __esm({
+  "src/lib/parsers/parse-remote-messages.ts"() {
+    "use strict";
+    init_utils();
+    init_parse_remote_objects();
+    parsers2 = [
+      new RemoteLineParser(/^remote:\s*(.+)$/, (result, [text]) => {
+        result.remoteMessages.all.push(text.trim());
+        return false;
+      }),
+      ...remoteMessagesObjectParsers,
+      new RemoteLineParser(
+        [/create a (?:pull|merge) request/i, /\s(https?:\/\/\S+)$/],
+        (result, [pullRequestUrl]) => {
+          result.remoteMessages.pullRequestUrl = pullRequestUrl;
+        }
+      ),
+      new RemoteLineParser(
+        [/found (\d+) vulnerabilities.+\(([^)]+)\)/i, /\s(https?:\/\/\S+)$/],
+        (result, [count, summary2, url]) => {
+          result.remoteMessages.vulnerabilities = {
+            count: asNumber(count),
+            summary: summary2,
+            url
+          };
+        }
+      )
+    ];
+    RemoteMessageSummary = class {
+      static {
+        __name(this, "RemoteMessageSummary");
+      }
+      constructor() {
+        this.all = [];
+      }
+    };
+  }
+});
+function parsePullErrorResult(stdOut, stdErr) {
+  const pullError = parseStringResponse(new PullFailedSummary(), errorParsers, [stdOut, stdErr]);
+  return pullError.message && pullError;
+}
+__name(parsePullErrorResult, "parsePullErrorResult");
+var FILE_UPDATE_REGEX;
+var SUMMARY_REGEX;
+var ACTION_REGEX;
+var parsers3;
+var errorParsers;
+var parsePullDetail;
+var parsePullResult;
+var init_parse_pull = __esm({
+  "src/lib/parsers/parse-pull.ts"() {
+    "use strict";
+    init_PullSummary();
+    init_utils();
+    init_parse_remote_messages();
+    FILE_UPDATE_REGEX = /^\s*(.+?)\s+\|\s+\d+\s*(\+*)(-*)/;
+    SUMMARY_REGEX = /(\d+)\D+((\d+)\D+\(\+\))?(\D+(\d+)\D+\(-\))?/;
+    ACTION_REGEX = /^(create|delete) mode \d+ (.+)/;
+    parsers3 = [
+      new LineParser(FILE_UPDATE_REGEX, (result, [file, insertions, deletions]) => {
+        result.files.push(file);
+        if (insertions) {
+          result.insertions[file] = insertions.length;
+        }
+        if (deletions) {
+          result.deletions[file] = deletions.length;
+        }
+      }),
+      new LineParser(SUMMARY_REGEX, (result, [changes, , insertions, , deletions]) => {
+        if (insertions !== void 0 || deletions !== void 0) {
+          result.summary.changes = +changes || 0;
+          result.summary.insertions = +insertions || 0;
+          result.summary.deletions = +deletions || 0;
+          return true;
+        }
+        return false;
+      }),
+      new LineParser(ACTION_REGEX, (result, [action, file]) => {
+        append(result.files, file);
+        append(action === "create" ? result.created : result.deleted, file);
+      })
+    ];
+    errorParsers = [
+      new LineParser(/^from\s(.+)$/i, (result, [remote]) => void (result.remote = remote)),
+      new LineParser(/^fatal:\s(.+)$/, (result, [message]) => void (result.message = message)),
+      new LineParser(
+        /([a-z0-9]+)\.\.([a-z0-9]+)\s+(\S+)\s+->\s+(\S+)$/,
+        (result, [hashLocal, hashRemote, branchLocal, branchRemote]) => {
+          result.branch.local = branchLocal;
+          result.hash.local = hashLocal;
+          result.branch.remote = branchRemote;
+          result.hash.remote = hashRemote;
+        }
+      )
+    ];
+    parsePullDetail = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return parseStringResponse(new PullSummary(), parsers3, [stdOut, stdErr]);
+    }, "parsePullDetail");
+    parsePullResult = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return Object.assign(
+        new PullSummary(),
+        parsePullDetail(stdOut, stdErr),
+        parseRemoteMessages(stdOut, stdErr)
+      );
+    }, "parsePullResult");
+  }
+});
+var parsers4;
+var parseMergeResult;
+var parseMergeDetail;
+var init_parse_merge = __esm({
+  "src/lib/parsers/parse-merge.ts"() {
+    "use strict";
+    init_MergeSummary();
+    init_utils();
+    init_parse_pull();
+    parsers4 = [
+      new LineParser(/^Auto-merging\s+(.+)$/, (summary2, [autoMerge]) => {
+        summary2.merges.push(autoMerge);
+      }),
+      new LineParser(/^CONFLICT\s+\((.+)\): Merge conflict in (.+)$/, (summary2, [reason, file]) => {
+        summary2.conflicts.push(new MergeSummaryConflict(reason, file));
+      }),
+      new LineParser(
+        /^CONFLICT\s+\((.+\/delete)\): (.+) deleted in (.+) and/,
+        (summary2, [reason, file, deleteRef]) => {
+          summary2.conflicts.push(new MergeSummaryConflict(reason, file, { deleteRef }));
+        }
+      ),
+      new LineParser(/^CONFLICT\s+\((.+)\):/, (summary2, [reason]) => {
+        summary2.conflicts.push(new MergeSummaryConflict(reason, null));
+      }),
+      new LineParser(/^Automatic merge failed;\s+(.+)$/, (summary2, [result]) => {
+        summary2.result = result;
+      })
+    ];
+    parseMergeResult = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return Object.assign(parseMergeDetail(stdOut, stdErr), parsePullResult(stdOut, stdErr));
+    }, "parseMergeResult");
+    parseMergeDetail = /* @__PURE__ */ __name((stdOut) => {
+      return parseStringResponse(new MergeSummaryDetail(), parsers4, stdOut);
+    }, "parseMergeDetail");
+  }
+});
+function mergeTask(customArgs) {
+  if (!customArgs.length) {
+    return configurationErrorTask("Git.merge requires at least one option");
+  }
+  return {
+    commands: ["merge", ...customArgs],
+    format: "utf-8",
+    parser(stdOut, stdErr) {
+      const merge = parseMergeResult(stdOut, stdErr);
+      if (merge.failed) {
+        throw new GitResponseError(merge);
+      }
+      return merge;
+    }
+  };
+}
+__name(mergeTask, "mergeTask");
+var init_merge = __esm({
+  "src/lib/tasks/merge.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_parse_merge();
+    init_task();
+  }
+});
+function pushResultPushedItem(local, remote, status) {
+  const deleted = status.includes("deleted");
+  const tag = status.includes("tag") || /^refs\/tags/.test(local);
+  const alreadyUpdated = !status.includes("new");
+  return {
+    deleted,
+    tag,
+    branch: !tag,
+    new: !alreadyUpdated,
+    alreadyUpdated,
+    local,
+    remote
+  };
+}
+__name(pushResultPushedItem, "pushResultPushedItem");
+var parsers5;
+var parsePushResult;
+var parsePushDetail;
+var init_parse_push = __esm({
+  "src/lib/parsers/parse-push.ts"() {
+    "use strict";
+    init_utils();
+    init_parse_remote_messages();
+    parsers5 = [
+      new LineParser(/^Pushing to (.+)$/, (result, [repo]) => {
+        result.repo = repo;
+      }),
+      new LineParser(/^updating local tracking ref '(.+)'/, (result, [local]) => {
+        result.ref = {
+          ...result.ref || {},
+          local
+        };
+      }),
+      new LineParser(/^[=*-]\s+([^:]+):(\S+)\s+\[(.+)]$/, (result, [local, remote, type]) => {
+        result.pushed.push(pushResultPushedItem(local, remote, type));
+      }),
+      new LineParser(
+        /^Branch '([^']+)' set up to track remote branch '([^']+)' from '([^']+)'/,
+        (result, [local, remote, remoteName]) => {
+          result.branch = {
+            ...result.branch || {},
+            local,
+            remote,
+            remoteName
+          };
+        }
+      ),
+      new LineParser(
+        /^([^:]+):(\S+)\s+([a-z0-9]+)\.\.([a-z0-9]+)$/,
+        (result, [local, remote, from, to]) => {
+          result.update = {
+            head: {
+              local,
+              remote
+            },
+            hash: {
+              from,
+              to
+            }
+          };
+        }
+      )
+    ];
+    parsePushResult = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      const pushDetail = parsePushDetail(stdOut, stdErr);
+      const responseDetail = parseRemoteMessages(stdOut, stdErr);
+      return {
+        ...pushDetail,
+        ...responseDetail
+      };
+    }, "parsePushResult");
+    parsePushDetail = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return parseStringResponse({ pushed: [] }, parsers5, [stdOut, stdErr]);
+    }, "parsePushDetail");
+  }
+});
+var push_exports = {};
+__export(push_exports, {
+  pushTagsTask: /* @__PURE__ */ __name(() => pushTagsTask, "pushTagsTask"),
+  pushTask: /* @__PURE__ */ __name(() => pushTask, "pushTask")
+});
+function pushTagsTask(ref = {}, customArgs) {
+  append(customArgs, "--tags");
+  return pushTask(ref, customArgs);
+}
+__name(pushTagsTask, "pushTagsTask");
+function pushTask(ref = {}, customArgs) {
+  const commands = ["push", ...customArgs];
+  if (ref.branch) {
+    commands.splice(1, 0, ref.branch);
+  }
+  if (ref.remote) {
+    commands.splice(1, 0, ref.remote);
+  }
+  remove(commands, "-v");
+  append(commands, "--verbose");
+  append(commands, "--porcelain");
+  return {
+    commands,
+    format: "utf-8",
+    parser: parsePushResult
+  };
+}
+__name(pushTask, "pushTask");
+var init_push = __esm({
+  "src/lib/tasks/push.ts"() {
+    "use strict";
+    init_parse_push();
+    init_utils();
+  }
+});
+function show_default() {
+  return {
+    showBuffer() {
+      const commands = ["show", ...getTrailingOptions(arguments, 1)];
+      if (!commands.includes("--binary")) {
+        commands.splice(1, 0, "--binary");
+      }
+      return this._runTask(
+        straightThroughBufferTask(commands),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    show() {
+      const commands = ["show", ...getTrailingOptions(arguments, 1)];
+      return this._runTask(
+        straightThroughStringTask(commands),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(show_default, "show_default");
+var init_show = __esm({
+  "src/lib/tasks/show.ts"() {
+    "use strict";
+    init_utils();
+    init_task();
+  }
+});
+var fromPathRegex;
+var FileStatusSummary;
+var init_FileStatusSummary = __esm({
+  "src/lib/responses/FileStatusSummary.ts"() {
+    "use strict";
+    fromPathRegex = /^(.+)\0(.+)$/;
+    FileStatusSummary = class {
+      static {
+        __name(this, "FileStatusSummary");
+      }
+      constructor(path5, index, working_dir) {
+        this.path = path5;
+        this.index = index;
+        this.working_dir = working_dir;
+        if (index === "R" || working_dir === "R") {
+          const detail = fromPathRegex.exec(path5) || [null, path5, path5];
+          this.from = detail[2] || "";
+          this.path = detail[1] || "";
+        }
+      }
+    };
+  }
+});
+function renamedFile(line) {
+  const [to, from] = line.split(NULL);
+  return {
+    from: from || to,
+    to
+  };
+}
+__name(renamedFile, "renamedFile");
+function parser3(indexX, indexY, handler) {
+  return [`${indexX}${indexY}`, handler];
+}
+__name(parser3, "parser3");
+function conflicts(indexX, ...indexY) {
+  return indexY.map((y) => parser3(indexX, y, (result, file) => result.conflicted.push(file)));
+}
+__name(conflicts, "conflicts");
+function splitLine(result, lineStr) {
+  const trimmed2 = lineStr.trim();
+  switch (" ") {
+    case trimmed2.charAt(2):
+      return data(trimmed2.charAt(0), trimmed2.charAt(1), trimmed2.slice(3));
+    case trimmed2.charAt(1):
+      return data(" ", trimmed2.charAt(0), trimmed2.slice(2));
+    default:
+      return;
+  }
+  function data(index, workingDir, path5) {
+    const raw = `${index}${workingDir}`;
+    const handler = parsers6.get(raw);
+    if (handler) {
+      handler(result, path5);
+    }
+    if (raw !== "##" && raw !== "!!") {
+      result.files.push(new FileStatusSummary(path5, index, workingDir));
+    }
+  }
+  __name(data, "data");
+}
+__name(splitLine, "splitLine");
+var StatusSummary;
+var parsers6;
+var parseStatusSummary;
+var init_StatusSummary = __esm({
+  "src/lib/responses/StatusSummary.ts"() {
+    "use strict";
+    init_utils();
+    init_FileStatusSummary();
+    StatusSummary = class {
+      static {
+        __name(this, "StatusSummary");
+      }
+      constructor() {
+        this.not_added = [];
+        this.conflicted = [];
+        this.created = [];
+        this.deleted = [];
+        this.ignored = void 0;
+        this.modified = [];
+        this.renamed = [];
+        this.files = [];
+        this.staged = [];
+        this.ahead = 0;
+        this.behind = 0;
+        this.current = null;
+        this.tracking = null;
+        this.detached = false;
+        this.isClean = () => {
+          return !this.files.length;
+        };
+      }
+    };
+    parsers6 = new Map([
+      parser3(
+        " ",
+        "A",
+        (result, file) => result.created.push(file)
+      ),
+      parser3(
+        " ",
+        "D",
+        (result, file) => result.deleted.push(file)
+      ),
+      parser3(
+        " ",
+        "M",
+        (result, file) => result.modified.push(file)
+      ),
+      parser3("A", " ", (result, file) => {
+        result.created.push(file);
+        result.staged.push(file);
+      }),
+      parser3("A", "M", (result, file) => {
+        result.created.push(file);
+        result.staged.push(file);
+        result.modified.push(file);
+      }),
+      parser3("D", " ", (result, file) => {
+        result.deleted.push(file);
+        result.staged.push(file);
+      }),
+      parser3("M", " ", (result, file) => {
+        result.modified.push(file);
+        result.staged.push(file);
+      }),
+      parser3("M", "M", (result, file) => {
+        result.modified.push(file);
+        result.staged.push(file);
+      }),
+      parser3("R", " ", (result, file) => {
+        result.renamed.push(renamedFile(file));
+      }),
+      parser3("R", "M", (result, file) => {
+        const renamed = renamedFile(file);
+        result.renamed.push(renamed);
+        result.modified.push(renamed.to);
+      }),
+      parser3("!", "!", (_result, _file) => {
+        (_result.ignored = _result.ignored || []).push(_file);
+      }),
+      parser3(
+        "?",
+        "?",
+        (result, file) => result.not_added.push(file)
+      ),
+      ...conflicts(
+        "A",
+        "A",
+        "U"
+        /* UNMERGED */
+      ),
+      ...conflicts(
+        "D",
+        "D",
+        "U"
+        /* UNMERGED */
+      ),
+      ...conflicts(
+        "U",
+        "A",
+        "D",
+        "U"
+        /* UNMERGED */
+      ),
+      [
+        "##",
+        (result, line) => {
+          const aheadReg = /ahead (\d+)/;
+          const behindReg = /behind (\d+)/;
+          const currentReg = /^(.+?(?=(?:\.{3}|\s|$)))/;
+          const trackingReg = /\.{3}(\S*)/;
+          const onEmptyBranchReg = /\son\s(\S+?)(?=\.{3}|$)/;
+          let regexResult = aheadReg.exec(line);
+          result.ahead = regexResult && +regexResult[1] || 0;
+          regexResult = behindReg.exec(line);
+          result.behind = regexResult && +regexResult[1] || 0;
+          regexResult = currentReg.exec(line);
+          result.current = filterType(regexResult?.[1], filterString, null);
+          regexResult = trackingReg.exec(line);
+          result.tracking = filterType(regexResult?.[1], filterString, null);
+          regexResult = onEmptyBranchReg.exec(line);
+          if (regexResult) {
+            result.current = filterType(regexResult?.[1], filterString, result.current);
+          }
+          result.detached = /\(no branch\)/.test(line);
+        }
+      ]
+    ]);
+    parseStatusSummary = /* @__PURE__ */ __name(function(text) {
+      const lines = text.split(NULL);
+      const status = new StatusSummary();
+      for (let i = 0, l = lines.length; i < l; ) {
+        let line = lines[i++].trim();
+        if (!line) {
+          continue;
+        }
+        if (line.charAt(0) === "R") {
+          line += NULL + (lines[i++] || "");
+        }
+        splitLine(status, line);
+      }
+      return status;
+    }, "parseStatusSummary");
+  }
+});
+function statusTask(customArgs) {
+  const commands = [
+    "status",
+    "--porcelain",
+    "-b",
+    "-u",
+    "--null",
+    ...customArgs.filter((arg) => !ignoredOptions.includes(arg))
+  ];
+  return {
+    format: "utf-8",
+    commands,
+    parser(text) {
+      return parseStatusSummary(text);
+    }
+  };
+}
+__name(statusTask, "statusTask");
+var ignoredOptions;
+var init_status = __esm({
+  "src/lib/tasks/status.ts"() {
+    "use strict";
+    init_StatusSummary();
+    ignoredOptions = ["--null", "-z"];
+  }
+});
+function versionResponse(major = 0, minor = 0, patch = 0, agent = "", installed = true) {
+  return Object.defineProperty(
+    {
+      major,
+      minor,
+      patch,
+      agent,
+      installed
+    },
+    "toString",
+    {
+      value() {
+        return `${this.major}.${this.minor}.${this.patch}`;
+      },
+      configurable: false,
+      enumerable: false
+    }
+  );
+}
+__name(versionResponse, "versionResponse");
+function notInstalledResponse() {
+  return versionResponse(0, 0, 0, "", false);
+}
+__name(notInstalledResponse, "notInstalledResponse");
+function version_default() {
+  return {
+    version() {
+      return this._runTask({
+        commands: ["--version"],
+        format: "utf-8",
+        parser: versionParser,
+        onError(result, error2, done, fail) {
+          if (result.exitCode === -2) {
+            return done(Buffer.from(NOT_INSTALLED));
+          }
+          fail(error2);
+        }
+      });
+    }
+  };
+}
+__name(version_default, "version_default");
+function versionParser(stdOut) {
+  if (stdOut === NOT_INSTALLED) {
+    return notInstalledResponse();
+  }
+  return parseStringResponse(versionResponse(0, 0, 0, stdOut), parsers7, stdOut);
+}
+__name(versionParser, "versionParser");
+var NOT_INSTALLED;
+var parsers7;
+var init_version = __esm({
+  "src/lib/tasks/version.ts"() {
+    "use strict";
+    init_utils();
+    NOT_INSTALLED = "installed=false";
+    parsers7 = [
+      new LineParser(
+        /version (\d+)\.(\d+)\.(\d+)(?:\s*\((.+)\))?/,
+        (result, [major, minor, patch, agent = ""]) => {
+          Object.assign(
+            result,
+            versionResponse(asNumber(major), asNumber(minor), asNumber(patch), agent)
+          );
+        }
+      ),
+      new LineParser(
+        /version (\d+)\.(\d+)\.(\D+)(.+)?$/,
+        (result, [major, minor, patch, agent = ""]) => {
+          Object.assign(result, versionResponse(asNumber(major), asNumber(minor), patch, agent));
+        }
+      )
+    ];
+  }
+});
+function createCloneTask(api, task, repoPath, ...args) {
+  if (!filterString(repoPath)) {
+    return configurationErrorTask(`git.${api}() requires a string 'repoPath'`);
+  }
+  return task(repoPath, filterType(args[0], filterString), getTrailingOptions(arguments));
+}
+__name(createCloneTask, "createCloneTask");
+function clone_default() {
+  return {
+    clone(repo, ...rest) {
+      return this._runTask(
+        createCloneTask("clone", cloneTask, filterType(repo, filterString), ...rest),
+        trailingFunctionArgument(arguments)
+      );
+    },
+    mirror(repo, ...rest) {
+      return this._runTask(
+        createCloneTask("mirror", cloneMirrorTask, filterType(repo, filterString), ...rest),
+        trailingFunctionArgument(arguments)
+      );
+    }
+  };
+}
+__name(clone_default, "clone_default");
+var cloneTask;
+var cloneMirrorTask;
+var init_clone = __esm({
+  "src/lib/tasks/clone.ts"() {
+    "use strict";
+    init_task();
+    init_utils();
+    init_pathspec();
+    cloneTask = /* @__PURE__ */ __name((repo, directory, customArgs) => {
+      const commands = ["clone", ...customArgs];
+      filterString(repo) && commands.push(pathspec(repo));
+      filterString(directory) && commands.push(pathspec(directory));
+      return straightThroughStringTask(commands);
+    }, "cloneTask");
+    cloneMirrorTask = /* @__PURE__ */ __name((repo, directory, customArgs) => {
+      append(customArgs, "--mirror");
+      return cloneTask(repo, directory, customArgs);
+    }, "cloneMirrorTask");
+  }
+});
+var simple_git_api_exports = {};
+__export(simple_git_api_exports, {
+  SimpleGitApi: /* @__PURE__ */ __name(() => SimpleGitApi, "SimpleGitApi")
+});
+var SimpleGitApi;
+var init_simple_git_api = __esm({
+  "src/lib/simple-git-api.ts"() {
+    "use strict";
+    init_task_callback();
+    init_change_working_directory();
+    init_checkout();
+    init_count_objects();
+    init_commit();
+    init_config();
+    init_first_commit();
+    init_grep();
+    init_hash_object();
+    init_init();
+    init_log();
+    init_merge();
+    init_push();
+    init_show();
+    init_status();
+    init_task();
+    init_version();
+    init_utils();
+    init_clone();
+    SimpleGitApi = class {
+      static {
+        __name(this, "SimpleGitApi");
+      }
+      constructor(_executor) {
+        this._executor = _executor;
+      }
+      _runTask(task, then) {
+        const chain = this._executor.chain();
+        const promise = chain.push(task);
+        if (then) {
+          taskCallback(task, promise, then);
+        }
+        return Object.create(this, {
+          then: { value: promise.then.bind(promise) },
+          catch: { value: promise.catch.bind(promise) },
+          _executor: { value: chain }
+        });
+      }
+      add(files) {
+        return this._runTask(
+          straightThroughStringTask(["add", ...asArray(files)]),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      cwd(directory) {
+        const next = trailingFunctionArgument(arguments);
+        if (typeof directory === "string") {
+          return this._runTask(changeWorkingDirectoryTask(directory, this._executor), next);
+        }
+        if (typeof directory?.path === "string") {
+          return this._runTask(
+            changeWorkingDirectoryTask(
+              directory.path,
+              directory.root && this._executor || void 0
+            ),
+            next
+          );
+        }
+        return this._runTask(
+          configurationErrorTask("Git.cwd: workingDirectory must be supplied as a string"),
+          next
+        );
+      }
+      hashObject(path5, write) {
+        return this._runTask(
+          hashObjectTask(path5, write === true),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      init(bare) {
+        return this._runTask(
+          initTask(bare === true, this._executor.cwd, getTrailingOptions(arguments)),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      merge() {
+        return this._runTask(
+          mergeTask(getTrailingOptions(arguments)),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      mergeFromTo(remote, branch) {
+        if (!(filterString(remote) && filterString(branch))) {
+          return this._runTask(
+            configurationErrorTask(
+              `Git.mergeFromTo requires that the 'remote' and 'branch' arguments are supplied as strings`
+            )
+          );
+        }
+        return this._runTask(
+          mergeTask([remote, branch, ...getTrailingOptions(arguments)]),
+          trailingFunctionArgument(arguments, false)
+        );
+      }
+      outputHandler(handler) {
+        this._executor.outputHandler = handler;
+        return this;
+      }
+      push() {
+        const task = pushTask(
+          {
+            remote: filterType(arguments[0], filterString),
+            branch: filterType(arguments[1], filterString)
+          },
+          getTrailingOptions(arguments)
+        );
+        return this._runTask(task, trailingFunctionArgument(arguments));
+      }
+      stash() {
+        return this._runTask(
+          straightThroughStringTask(["stash", ...getTrailingOptions(arguments)]),
+          trailingFunctionArgument(arguments)
+        );
+      }
+      status() {
+        return this._runTask(
+          statusTask(getTrailingOptions(arguments)),
+          trailingFunctionArgument(arguments)
+        );
+      }
+    };
+    Object.assign(
+      SimpleGitApi.prototype,
+      checkout_default(),
+      clone_default(),
+      commit_default(),
+      config_default(),
+      count_objects_default(),
+      first_commit_default(),
+      grep_default(),
+      log_default(),
+      show_default(),
+      version_default()
+    );
+  }
+});
+var scheduler_exports = {};
+__export(scheduler_exports, {
+  Scheduler: /* @__PURE__ */ __name(() => Scheduler, "Scheduler")
+});
+var createScheduledTask;
+var Scheduler;
+var init_scheduler = __esm({
+  "src/lib/runners/scheduler.ts"() {
+    "use strict";
+    init_utils();
+    init_git_logger();
+    createScheduledTask = /* @__PURE__ */ (() => {
+      let id = 0;
+      return () => {
+        id++;
+        const { promise, done } = (0, import_promise_deferred.createDeferred)();
+        return {
+          promise,
+          done,
+          id
+        };
+      };
+    })();
+    Scheduler = class {
+      static {
+        __name(this, "Scheduler");
+      }
+      constructor(concurrency = 2) {
+        this.concurrency = concurrency;
+        this.logger = createLogger("", "scheduler");
+        this.pending = [];
+        this.running = [];
+        this.logger(`Constructed, concurrency=%s`, concurrency);
+      }
+      schedule() {
+        if (!this.pending.length || this.running.length >= this.concurrency) {
+          this.logger(
+            `Schedule attempt ignored, pending=%s running=%s concurrency=%s`,
+            this.pending.length,
+            this.running.length,
+            this.concurrency
+          );
+          return;
+        }
+        const task = append(this.running, this.pending.shift());
+        this.logger(`Attempting id=%s`, task.id);
+        task.done(() => {
+          this.logger(`Completing id=`, task.id);
+          remove(this.running, task);
+          this.schedule();
+        });
+      }
+      next() {
+        const { promise, id } = append(this.pending, createScheduledTask());
+        this.logger(`Scheduling id=%s`, id);
+        this.schedule();
+        return promise;
+      }
+    };
+  }
+});
+var apply_patch_exports = {};
+__export(apply_patch_exports, {
+  applyPatchTask: /* @__PURE__ */ __name(() => applyPatchTask, "applyPatchTask")
+});
+function applyPatchTask(patches, customArgs) {
+  return straightThroughStringTask(["apply", ...customArgs, ...patches]);
+}
+__name(applyPatchTask, "applyPatchTask");
+var init_apply_patch = __esm({
+  "src/lib/tasks/apply-patch.ts"() {
+    "use strict";
+    init_task();
+  }
+});
+function branchDeletionSuccess(branch, hash) {
+  return {
+    branch,
+    hash,
+    success: true
+  };
+}
+__name(branchDeletionSuccess, "branchDeletionSuccess");
+function branchDeletionFailure(branch) {
+  return {
+    branch,
+    hash: null,
+    success: false
+  };
+}
+__name(branchDeletionFailure, "branchDeletionFailure");
+var BranchDeletionBatch;
+var init_BranchDeleteSummary = __esm({
+  "src/lib/responses/BranchDeleteSummary.ts"() {
+    "use strict";
+    BranchDeletionBatch = class {
+      static {
+        __name(this, "BranchDeletionBatch");
+      }
+      constructor() {
+        this.all = [];
+        this.branches = {};
+        this.errors = [];
+      }
+      get success() {
+        return !this.errors.length;
+      }
+    };
+  }
+});
+function hasBranchDeletionError(data, processExitCode) {
+  return processExitCode === 1 && deleteErrorRegex.test(data);
+}
+__name(hasBranchDeletionError, "hasBranchDeletionError");
+var deleteSuccessRegex;
+var deleteErrorRegex;
+var parsers8;
+var parseBranchDeletions;
+var init_parse_branch_delete = __esm({
+  "src/lib/parsers/parse-branch-delete.ts"() {
+    "use strict";
+    init_BranchDeleteSummary();
+    init_utils();
+    deleteSuccessRegex = /(\S+)\s+\(\S+\s([^)]+)\)/;
+    deleteErrorRegex = /^error[^']+'([^']+)'/m;
+    parsers8 = [
+      new LineParser(deleteSuccessRegex, (result, [branch, hash]) => {
+        const deletion = branchDeletionSuccess(branch, hash);
+        result.all.push(deletion);
+        result.branches[branch] = deletion;
+      }),
+      new LineParser(deleteErrorRegex, (result, [branch]) => {
+        const deletion = branchDeletionFailure(branch);
+        result.errors.push(deletion);
+        result.all.push(deletion);
+        result.branches[branch] = deletion;
+      })
+    ];
+    parseBranchDeletions = /* @__PURE__ */ __name((stdOut, stdErr) => {
+      return parseStringResponse(new BranchDeletionBatch(), parsers8, [stdOut, stdErr]);
+    }, "parseBranchDeletions");
+  }
+});
+var BranchSummaryResult;
+var init_BranchSummary = __esm({
+  "src/lib/responses/BranchSummary.ts"() {
+    "use strict";
+    BranchSummaryResult = class {
+      static {
+        __name(this, "BranchSummaryResult");
+      }
+      constructor() {
+        this.all = [];
+        this.branches = {};
+        this.current = "";
+        this.detached = false;
+      }
+      push(status, detached, name, commit, label) {
+        if (status === "*") {
+          this.detached = detached;
+          this.current = name;
+        }
+        this.all.push(name);
+        this.branches[name] = {
+          current: status === "*",
+          linkedWorkTree: status === "+",
+          name,
+          commit,
+          label
+        };
+      }
+    };
+  }
+});
+function branchStatus(input) {
+  return input ? input.charAt(0) : "";
+}
+__name(branchStatus, "branchStatus");
+function parseBranchSummary(stdOut, currentOnly = false) {
+  return parseStringResponse(
+    new BranchSummaryResult(),
+    currentOnly ? [currentBranchParser] : parsers9,
+    stdOut
+  );
+}
+__name(parseBranchSummary, "parseBranchSummary");
+var parsers9;
+var currentBranchParser;
+var init_parse_branch = __esm({
+  "src/lib/parsers/parse-branch.ts"() {
+    "use strict";
+    init_BranchSummary();
+    init_utils();
+    parsers9 = [
+      new LineParser(
+        /^([*+]\s)?\((?:HEAD )?detached (?:from|at) (\S+)\)\s+([a-z0-9]+)\s(.*)$/,
+        (result, [current, name, commit, label]) => {
+          result.push(branchStatus(current), true, name, commit, label);
+        }
+      ),
+      new LineParser(
+        /^([*+]\s)?(\S+)\s+([a-z0-9]+)\s?(.*)$/s,
+        (result, [current, name, commit, label]) => {
+          result.push(branchStatus(current), false, name, commit, label);
+        }
+      )
+    ];
+    currentBranchParser = new LineParser(/^(\S+)$/s, (result, [name]) => {
+      result.push("*", false, name, "", "");
+    });
+  }
+});
+var branch_exports = {};
+__export(branch_exports, {
+  branchLocalTask: /* @__PURE__ */ __name(() => branchLocalTask, "branchLocalTask"),
+  branchTask: /* @__PURE__ */ __name(() => branchTask, "branchTask"),
+  containsDeleteBranchCommand: /* @__PURE__ */ __name(() => containsDeleteBranchCommand, "containsDeleteBranchCommand"),
+  deleteBranchTask: /* @__PURE__ */ __name(() => deleteBranchTask, "deleteBranchTask"),
+  deleteBranchesTask: /* @__PURE__ */ __name(() => deleteBranchesTask, "deleteBranchesTask")
+});
+function containsDeleteBranchCommand(commands) {
+  const deleteCommands = ["-d", "-D", "--delete"];
+  return commands.some((command) => deleteCommands.includes(command));
+}
+__name(containsDeleteBranchCommand, "containsDeleteBranchCommand");
+function branchTask(customArgs) {
+  const isDelete = containsDeleteBranchCommand(customArgs);
+  const isCurrentOnly = customArgs.includes("--show-current");
+  const commands = ["branch", ...customArgs];
+  if (commands.length === 1) {
+    commands.push("-a");
+  }
+  if (!commands.includes("-v")) {
+    commands.splice(1, 0, "-v");
+  }
+  return {
+    format: "utf-8",
+    commands,
+    parser(stdOut, stdErr) {
+      if (isDelete) {
+        return parseBranchDeletions(stdOut, stdErr).all[0];
+      }
+      return parseBranchSummary(stdOut, isCurrentOnly);
+    }
+  };
+}
+__name(branchTask, "branchTask");
+function branchLocalTask() {
+  return {
+    format: "utf-8",
+    commands: ["branch", "-v"],
+    parser(stdOut) {
+      return parseBranchSummary(stdOut);
+    }
+  };
+}
+__name(branchLocalTask, "branchLocalTask");
+function deleteBranchesTask(branches, forceDelete = false) {
+  return {
+    format: "utf-8",
+    commands: ["branch", "-v", forceDelete ? "-D" : "-d", ...branches],
+    parser(stdOut, stdErr) {
+      return parseBranchDeletions(stdOut, stdErr);
+    },
+    onError({ exitCode, stdOut }, error2, done, fail) {
+      if (!hasBranchDeletionError(String(error2), exitCode)) {
+        return fail(error2);
+      }
+      done(stdOut);
+    }
+  };
+}
+__name(deleteBranchesTask, "deleteBranchesTask");
+function deleteBranchTask(branch, forceDelete = false) {
+  const task = {
+    format: "utf-8",
+    commands: ["branch", "-v", forceDelete ? "-D" : "-d", branch],
+    parser(stdOut, stdErr) {
+      return parseBranchDeletions(stdOut, stdErr).branches[branch];
+    },
+    onError({ exitCode, stdErr, stdOut }, error2, _, fail) {
+      if (!hasBranchDeletionError(String(error2), exitCode)) {
+        return fail(error2);
+      }
+      throw new GitResponseError(
+        task.parser(bufferToString(stdOut), bufferToString(stdErr)),
+        String(error2)
+      );
+    }
+  };
+  return task;
+}
+__name(deleteBranchTask, "deleteBranchTask");
+var init_branch = __esm({
+  "src/lib/tasks/branch.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_parse_branch_delete();
+    init_parse_branch();
+    init_utils();
+  }
+});
+function toPath(input) {
+  const path5 = input.trim().replace(/^["']|["']$/g, "");
+  return path5 && (0, import_node_path.normalize)(path5);
+}
+__name(toPath, "toPath");
+var parseCheckIgnore;
+var init_CheckIgnore = __esm({
+  "src/lib/responses/CheckIgnore.ts"() {
+    "use strict";
+    parseCheckIgnore = /* @__PURE__ */ __name((text) => {
+      return text.split(/\n/g).map(toPath).filter(Boolean);
+    }, "parseCheckIgnore");
+  }
+});
+var check_ignore_exports = {};
+__export(check_ignore_exports, {
+  checkIgnoreTask: /* @__PURE__ */ __name(() => checkIgnoreTask, "checkIgnoreTask")
+});
+function checkIgnoreTask(paths) {
+  return {
+    commands: ["check-ignore", ...paths],
+    format: "utf-8",
+    parser: parseCheckIgnore
+  };
+}
+__name(checkIgnoreTask, "checkIgnoreTask");
+var init_check_ignore = __esm({
+  "src/lib/tasks/check-ignore.ts"() {
+    "use strict";
+    init_CheckIgnore();
+  }
+});
+function parseFetchResult(stdOut, stdErr) {
+  const result = {
+    raw: stdOut,
+    remote: null,
+    branches: [],
+    tags: [],
+    updated: [],
+    deleted: []
+  };
+  return parseStringResponse(result, parsers10, [stdOut, stdErr]);
+}
+__name(parseFetchResult, "parseFetchResult");
+var parsers10;
+var init_parse_fetch = __esm({
+  "src/lib/parsers/parse-fetch.ts"() {
+    "use strict";
+    init_utils();
+    parsers10 = [
+      new LineParser(/From (.+)$/, (result, [remote]) => {
+        result.remote = remote;
+      }),
+      new LineParser(/\* \[new branch]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
+        result.branches.push({
+          name,
+          tracking
+        });
+      }),
+      new LineParser(/\* \[new tag]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
+        result.tags.push({
+          name,
+          tracking
+        });
+      }),
+      new LineParser(/- \[deleted]\s+\S+\s*-> (.+)$/, (result, [tracking]) => {
+        result.deleted.push({
+          tracking
+        });
+      }),
+      new LineParser(
+        /\s*([^.]+)\.\.(\S+)\s+(\S+)\s*-> (.+)$/,
+        (result, [from, to, name, tracking]) => {
+          result.updated.push({
+            name,
+            tracking,
+            to,
+            from
+          });
+        }
+      )
+    ];
+  }
+});
+var fetch_exports = {};
+__export(fetch_exports, {
+  fetchTask: /* @__PURE__ */ __name(() => fetchTask, "fetchTask")
+});
+function disallowedCommand(command) {
+  return /^--upload-pack(=|$)/.test(command);
+}
+__name(disallowedCommand, "disallowedCommand");
+function fetchTask(remote, branch, customArgs) {
+  const commands = ["fetch", ...customArgs];
+  if (remote && branch) {
+    commands.push(remote, branch);
+  }
+  const banned = commands.find(disallowedCommand);
+  if (banned) {
+    return configurationErrorTask(`git.fetch: potential exploit argument blocked.`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser: parseFetchResult
+  };
+}
+__name(fetchTask, "fetchTask");
+var init_fetch = __esm({
+  "src/lib/tasks/fetch.ts"() {
+    "use strict";
+    init_parse_fetch();
+    init_task();
+  }
+});
+function parseMoveResult(stdOut) {
+  return parseStringResponse({ moves: [] }, parsers11, stdOut);
+}
+__name(parseMoveResult, "parseMoveResult");
+var parsers11;
+var init_parse_move = __esm({
+  "src/lib/parsers/parse-move.ts"() {
+    "use strict";
+    init_utils();
+    parsers11 = [
+      new LineParser(/^Renaming (.+) to (.+)$/, (result, [from, to]) => {
+        result.moves.push({ from, to });
+      })
+    ];
+  }
+});
+var move_exports = {};
+__export(move_exports, {
+  moveTask: /* @__PURE__ */ __name(() => moveTask, "moveTask")
+});
+function moveTask(from, to) {
+  return {
+    commands: ["mv", "-v", ...asArray(from), to],
+    format: "utf-8",
+    parser: parseMoveResult
+  };
+}
+__name(moveTask, "moveTask");
+var init_move = __esm({
+  "src/lib/tasks/move.ts"() {
+    "use strict";
+    init_parse_move();
+    init_utils();
+  }
+});
+var pull_exports = {};
+__export(pull_exports, {
+  pullTask: /* @__PURE__ */ __name(() => pullTask, "pullTask")
+});
+function pullTask(remote, branch, customArgs) {
+  const commands = ["pull", ...customArgs];
+  if (remote && branch) {
+    commands.splice(1, 0, remote, branch);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(stdOut, stdErr) {
+      return parsePullResult(stdOut, stdErr);
+    },
+    onError(result, _error, _done, fail) {
+      const pullError = parsePullErrorResult(
+        bufferToString(result.stdOut),
+        bufferToString(result.stdErr)
+      );
+      if (pullError) {
+        return fail(new GitResponseError(pullError));
+      }
+      fail(_error);
+    }
+  };
+}
+__name(pullTask, "pullTask");
+var init_pull = __esm({
+  "src/lib/tasks/pull.ts"() {
+    "use strict";
+    init_git_response_error();
+    init_parse_pull();
+    init_utils();
+  }
+});
+function parseGetRemotes(text) {
+  const remotes = {};
+  forEach(text, ([name]) => remotes[name] = { name });
+  return Object.values(remotes);
+}
+__name(parseGetRemotes, "parseGetRemotes");
+function parseGetRemotesVerbose(text) {
+  const remotes = {};
+  forEach(text, ([name, url, purpose]) => {
+    if (!Object.hasOwn(remotes, name)) {
+      remotes[name] = {
+        name,
+        refs: { fetch: "", push: "" }
+      };
+    }
+    if (purpose && url) {
+      remotes[name].refs[purpose.replace(/[^a-z]/g, "")] = url;
+    }
+  });
+  return Object.values(remotes);
+}
+__name(parseGetRemotesVerbose, "parseGetRemotesVerbose");
+function forEach(text, handler) {
+  forEachLineWithContent(text, (line) => handler(line.split(/\s+/)));
+}
+__name(forEach, "forEach");
+var init_GetRemoteSummary = __esm({
+  "src/lib/responses/GetRemoteSummary.ts"() {
+    "use strict";
+    init_utils();
+  }
+});
+var remote_exports = {};
+__export(remote_exports, {
+  addRemoteTask: /* @__PURE__ */ __name(() => addRemoteTask, "addRemoteTask"),
+  getRemotesTask: /* @__PURE__ */ __name(() => getRemotesTask, "getRemotesTask"),
+  listRemotesTask: /* @__PURE__ */ __name(() => listRemotesTask, "listRemotesTask"),
+  remoteTask: /* @__PURE__ */ __name(() => remoteTask, "remoteTask"),
+  removeRemoteTask: /* @__PURE__ */ __name(() => removeRemoteTask, "removeRemoteTask")
+});
+function addRemoteTask(remoteName, remoteRepo, customArgs) {
+  return straightThroughStringTask(["remote", "add", ...customArgs, remoteName, remoteRepo]);
+}
+__name(addRemoteTask, "addRemoteTask");
+function getRemotesTask(verbose) {
+  const commands = ["remote"];
+  if (verbose) {
+    commands.push("-v");
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser: verbose ? parseGetRemotesVerbose : parseGetRemotes
+  };
+}
+__name(getRemotesTask, "getRemotesTask");
+function listRemotesTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "ls-remote") {
+    commands.unshift("ls-remote");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(listRemotesTask, "listRemotesTask");
+function remoteTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "remote") {
+    commands.unshift("remote");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(remoteTask, "remoteTask");
+function removeRemoteTask(remoteName) {
+  return straightThroughStringTask(["remote", "remove", remoteName]);
+}
+__name(removeRemoteTask, "removeRemoteTask");
+var init_remote = __esm({
+  "src/lib/tasks/remote.ts"() {
+    "use strict";
+    init_GetRemoteSummary();
+    init_task();
+  }
+});
+var stash_list_exports = {};
+__export(stash_list_exports, {
+  stashListTask: /* @__PURE__ */ __name(() => stashListTask, "stashListTask")
+});
+function stashListTask(opt = {}, customArgs) {
+  const options = parseLogOptions(opt);
+  const commands = ["stash", "list", ...options.commands, ...customArgs];
+  const parser4 = createListLogSummaryParser(
+    options.splitter,
+    options.fields,
+    logFormatFromCommand(commands)
+  );
+  return validateLogFormatConfig(commands) || {
+    commands,
+    format: "utf-8",
+    parser: parser4
+  };
+}
+__name(stashListTask, "stashListTask");
+var init_stash_list = __esm({
+  "src/lib/tasks/stash-list.ts"() {
+    "use strict";
+    init_log_format();
+    init_parse_list_log_summary();
+    init_diff();
+    init_log();
+  }
+});
+var sub_module_exports = {};
+__export(sub_module_exports, {
+  addSubModuleTask: /* @__PURE__ */ __name(() => addSubModuleTask, "addSubModuleTask"),
+  initSubModuleTask: /* @__PURE__ */ __name(() => initSubModuleTask, "initSubModuleTask"),
+  subModuleTask: /* @__PURE__ */ __name(() => subModuleTask, "subModuleTask"),
+  updateSubModuleTask: /* @__PURE__ */ __name(() => updateSubModuleTask, "updateSubModuleTask")
+});
+function addSubModuleTask(repo, path5) {
+  return subModuleTask(["add", repo, path5]);
+}
+__name(addSubModuleTask, "addSubModuleTask");
+function initSubModuleTask(customArgs) {
+  return subModuleTask(["init", ...customArgs]);
+}
+__name(initSubModuleTask, "initSubModuleTask");
+function subModuleTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "submodule") {
+    commands.unshift("submodule");
+  }
+  return straightThroughStringTask(commands);
+}
+__name(subModuleTask, "subModuleTask");
+function updateSubModuleTask(customArgs) {
+  return subModuleTask(["update", ...customArgs]);
+}
+__name(updateSubModuleTask, "updateSubModuleTask");
+var init_sub_module = __esm({
+  "src/lib/tasks/sub-module.ts"() {
+    "use strict";
+    init_task();
+  }
+});
+function singleSorted(a, b) {
+  const aIsNum = Number.isNaN(a);
+  const bIsNum = Number.isNaN(b);
+  if (aIsNum !== bIsNum) {
+    return aIsNum ? 1 : -1;
+  }
+  return aIsNum ? sorted(a, b) : 0;
+}
+__name(singleSorted, "singleSorted");
+function sorted(a, b) {
+  return a === b ? 0 : a > b ? 1 : -1;
+}
+__name(sorted, "sorted");
+function trimmed(input) {
+  return input.trim();
+}
+__name(trimmed, "trimmed");
+function toNumber(input) {
+  if (typeof input === "string") {
+    return parseInt(input.replace(/^\D+/g, ""), 10) || 0;
+  }
+  return 0;
+}
+__name(toNumber, "toNumber");
+var TagList;
+var parseTagList;
+var init_TagList = __esm({
+  "src/lib/responses/TagList.ts"() {
+    "use strict";
+    TagList = class {
+      static {
+        __name(this, "TagList");
+      }
+      constructor(all, latest) {
+        this.all = all;
+        this.latest = latest;
+      }
+    };
+    parseTagList = /* @__PURE__ */ __name(function(data, customSort = false) {
+      const tags = data.split("\n").map(trimmed).filter(Boolean);
+      if (!customSort) {
+        tags.sort(function(tagA, tagB) {
+          const partsA = tagA.split(".");
+          const partsB = tagB.split(".");
+          if (partsA.length === 1 || partsB.length === 1) {
+            return singleSorted(toNumber(partsA[0]), toNumber(partsB[0]));
+          }
+          for (let i = 0, l = Math.max(partsA.length, partsB.length); i < l; i++) {
+            const diff = sorted(toNumber(partsA[i]), toNumber(partsB[i]));
+            if (diff) {
+              return diff;
+            }
+          }
+          return 0;
+        });
+      }
+      const latest = customSort ? tags[0] : [...tags].reverse().find((tag) => tag.indexOf(".") >= 0);
+      return new TagList(tags, latest);
+    }, "parseTagList");
+  }
+});
+var tag_exports = {};
+__export(tag_exports, {
+  addAnnotatedTagTask: /* @__PURE__ */ __name(() => addAnnotatedTagTask, "addAnnotatedTagTask"),
+  addTagTask: /* @__PURE__ */ __name(() => addTagTask, "addTagTask"),
+  tagListTask: /* @__PURE__ */ __name(() => tagListTask, "tagListTask")
+});
+function tagListTask(customArgs = []) {
+  const hasCustomSort = customArgs.some((option) => /^--sort=/.test(option));
+  return {
+    format: "utf-8",
+    commands: ["tag", "-l", ...customArgs],
+    parser(text) {
+      return parseTagList(text, hasCustomSort);
+    }
+  };
+}
+__name(tagListTask, "tagListTask");
+function addTagTask(name) {
+  return {
+    format: "utf-8",
+    commands: ["tag", name],
+    parser() {
+      return { name };
+    }
+  };
+}
+__name(addTagTask, "addTagTask");
+function addAnnotatedTagTask(name, tagMessage) {
+  return {
+    format: "utf-8",
+    commands: ["tag", "-a", "-m", tagMessage, name],
+    parser() {
+      return { name };
+    }
+  };
+}
+__name(addAnnotatedTagTask, "addAnnotatedTagTask");
+var init_tag = __esm({
+  "src/lib/tasks/tag.ts"() {
+    "use strict";
+    init_TagList();
+  }
+});
+var require_git = __commonJS2({
+  "src/git.js"(exports2, module2) {
+    "use strict";
+    var { GitExecutor: GitExecutor2 } = (init_git_executor(), __toCommonJS(git_executor_exports));
+    var { SimpleGitApi: SimpleGitApi2 } = (init_simple_git_api(), __toCommonJS(simple_git_api_exports));
+    var { Scheduler: Scheduler2 } = (init_scheduler(), __toCommonJS(scheduler_exports));
+    var { adhocExecTask: adhocExecTask2, configurationErrorTask: configurationErrorTask2 } = (init_task(), __toCommonJS(
+    task_exports));
+    var {
+      asArray: asArray2,
+      filterArray: filterArray2,
+      filterPrimitives: filterPrimitives2,
+      filterString: filterString2,
+      filterStringOrStringArray: filterStringOrStringArray2,
+      filterType: filterType2,
+      getTrailingOptions: getTrailingOptions2,
+      trailingFunctionArgument: trailingFunctionArgument2,
+      trailingOptionsArgument: trailingOptionsArgument2
+    } = (init_utils(), __toCommonJS(utils_exports));
+    var { applyPatchTask: applyPatchTask2 } = (init_apply_patch(), __toCommonJS(apply_patch_exports));
+    var {
+      branchTask: branchTask2,
+      branchLocalTask: branchLocalTask2,
+      deleteBranchesTask: deleteBranchesTask2,
+      deleteBranchTask: deleteBranchTask2
+    } = (init_branch(), __toCommonJS(branch_exports));
+    var { checkIgnoreTask: checkIgnoreTask2 } = (init_check_ignore(), __toCommonJS(check_ignore_exports));
+    var { checkIsRepoTask: checkIsRepoTask2 } = (init_check_is_repo(), __toCommonJS(check_is_repo_exports));
+    var { cleanWithOptionsTask: cleanWithOptionsTask2, isCleanOptionsArray: isCleanOptionsArray2 } = (init_clean(), __toCommonJS(
+    clean_exports));
+    var { diffSummaryTask: diffSummaryTask2 } = (init_diff(), __toCommonJS(diff_exports));
+    var { fetchTask: fetchTask2 } = (init_fetch(), __toCommonJS(fetch_exports));
+    var { moveTask: moveTask2 } = (init_move(), __toCommonJS(move_exports));
+    var { pullTask: pullTask2 } = (init_pull(), __toCommonJS(pull_exports));
+    var { pushTagsTask: pushTagsTask2 } = (init_push(), __toCommonJS(push_exports));
+    var {
+      addRemoteTask: addRemoteTask2,
+      getRemotesTask: getRemotesTask2,
+      listRemotesTask: listRemotesTask2,
+      remoteTask: remoteTask2,
+      removeRemoteTask: removeRemoteTask2
+    } = (init_remote(), __toCommonJS(remote_exports));
+    var { getResetMode: getResetMode2, resetTask: resetTask2 } = (init_reset(), __toCommonJS(reset_exports));
+    var { stashListTask: stashListTask2 } = (init_stash_list(), __toCommonJS(stash_list_exports));
+    var {
+      addSubModuleTask: addSubModuleTask2,
+      initSubModuleTask: initSubModuleTask2,
+      subModuleTask: subModuleTask2,
+      updateSubModuleTask: updateSubModuleTask2
+    } = (init_sub_module(), __toCommonJS(sub_module_exports));
+    var { addAnnotatedTagTask: addAnnotatedTagTask2, addTagTask: addTagTask2, tagListTask: tagListTask2 } = (init_tag(),
+    __toCommonJS(tag_exports));
+    var { straightThroughBufferTask: straightThroughBufferTask2, straightThroughStringTask: straightThroughStringTask2 } = (init_task(),
+    __toCommonJS(task_exports));
+    function Git2(options, plugins) {
+      this._plugins = plugins;
+      this._executor = new GitExecutor2(
+        options.baseDir,
+        new Scheduler2(options.maxConcurrentProcesses),
+        plugins
+      );
+      this._trimmed = options.trimmed;
+    }
+    __name(Git2, "Git2");
+    (Git2.prototype = Object.create(SimpleGitApi2.prototype)).constructor = Git2;
+    Git2.prototype.customBinary = function(command) {
+      this._plugins.reconfigure("binary", command);
+      return this;
+    };
+    Git2.prototype.env = function(name, value) {
+      if (arguments.length === 1 && typeof name === "object") {
+        this._executor.env = name;
+      } else {
+        (this._executor.env = this._executor.env || {})[name] = value;
+      }
+      return this;
+    };
+    Git2.prototype.stashList = function(options) {
+      return this._runTask(
+        stashListTask2(
+          trailingOptionsArgument2(arguments) || {},
+          filterArray2(options) && options || []
+        ),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.mv = function(from, to) {
+      return this._runTask(moveTask2(from, to), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.checkoutLatestTag = function(then) {
+      var git = this;
+      return this.pull(function() {
+        git.tags(function(err, tags) {
+          git.checkout(tags.latest, then);
+        });
+      });
+    };
+    Git2.prototype.pull = function(remote, branch, options, then) {
+      return this._runTask(
+        pullTask2(
+          filterType2(remote, filterString2),
+          filterType2(branch, filterString2),
+          getTrailingOptions2(arguments)
+        ),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.fetch = function(remote, branch) {
+      return this._runTask(
+        fetchTask2(
+          filterType2(remote, filterString2),
+          filterType2(branch, filterString2),
+          getTrailingOptions2(arguments)
+        ),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.silent = function(silence) {
+      return this._runTask(
+        adhocExecTask2(
+          () => console.warn(
+            "simple-git deprecation notice: git.silent: logging should be configured using the `debug` library / `DEBUG`\
+ environment variable, this method will be removed."
+          )
+        )
+      );
+    };
+    Git2.prototype.tags = function(options, then) {
+      return this._runTask(
+        tagListTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.rebase = function() {
+      return this._runTask(
+        straightThroughStringTask2(["rebase", ...getTrailingOptions2(arguments)]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.reset = function(mode) {
+      return this._runTask(
+        resetTask2(getResetMode2(mode), getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.revert = function(commit) {
+      const next = trailingFunctionArgument2(arguments);
+      if (typeof commit !== "string") {
+        return this._runTask(configurationErrorTask2("Commit must be a string"), next);
+      }
+      return this._runTask(
+        straightThroughStringTask2(["revert", ...getTrailingOptions2(arguments, 0, true), commit]),
+        next
+      );
+    };
+    Git2.prototype.addTag = function(name) {
+      const task = typeof name === "string" ? addTagTask2(name) : configurationErrorTask2("Git.addTag requires a tag nam\
+e");
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.addAnnotatedTag = function(tagName, tagMessage) {
+      return this._runTask(
+        addAnnotatedTagTask2(tagName, tagMessage),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.deleteLocalBranch = function(branchName, forceDelete, then) {
+      return this._runTask(
+        deleteBranchTask2(branchName, typeof forceDelete === "boolean" ? forceDelete : false),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.deleteLocalBranches = function(branchNames, forceDelete, then) {
+      return this._runTask(
+        deleteBranchesTask2(branchNames, typeof forceDelete === "boolean" ? forceDelete : false),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.branch = function(options, then) {
+      return this._runTask(
+        branchTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.branchLocal = function(then) {
+      return this._runTask(branchLocalTask2(), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.raw = function(commands) {
+      const createRestCommands = !Array.isArray(commands);
+      const command = [].slice.call(createRestCommands ? arguments : commands, 0);
+      for (let i = 0; i < command.length && createRestCommands; i++) {
+        if (!filterPrimitives2(command[i])) {
+          command.splice(i, command.length - i);
+          break;
+        }
+      }
+      command.push(...getTrailingOptions2(arguments, 0, true));
+      var next = trailingFunctionArgument2(arguments);
+      if (!command.length) {
+        return this._runTask(
+          configurationErrorTask2("Raw: must supply one or more command to execute"),
+          next
+        );
+      }
+      return this._runTask(straightThroughStringTask2(command, this._trimmed), next);
+    };
+    Git2.prototype.submoduleAdd = function(repo, path5, then) {
+      return this._runTask(addSubModuleTask2(repo, path5), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.submoduleUpdate = function(args, then) {
+      return this._runTask(
+        updateSubModuleTask2(getTrailingOptions2(arguments, true)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.submoduleInit = function(args, then) {
+      return this._runTask(
+        initSubModuleTask2(getTrailingOptions2(arguments, true)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.subModule = function(options, then) {
+      return this._runTask(
+        subModuleTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.listRemote = function() {
+      return this._runTask(
+        listRemotesTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.addRemote = function(remoteName, remoteRepo, then) {
+      return this._runTask(
+        addRemoteTask2(remoteName, remoteRepo, getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.removeRemote = function(remoteName, then) {
+      return this._runTask(removeRemoteTask2(remoteName), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.getRemotes = function(verbose, then) {
+      return this._runTask(getRemotesTask2(verbose === true), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.remote = function(options, then) {
+      return this._runTask(
+        remoteTask2(getTrailingOptions2(arguments)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.tag = function(options, then) {
+      const command = getTrailingOptions2(arguments);
+      if (command[0] !== "tag") {
+        command.unshift("tag");
+      }
+      return this._runTask(straightThroughStringTask2(command), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.updateServerInfo = function(then) {
+      return this._runTask(
+        straightThroughStringTask2(["update-server-info"]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.pushTags = function(remote, then) {
+      const task = pushTagsTask2(
+        { remote: filterType2(remote, filterString2) },
+        getTrailingOptions2(arguments)
+      );
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.rm = function(files) {
+      return this._runTask(
+        straightThroughStringTask2(["rm", "-f", ...asArray2(files)]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.rmKeepLocal = function(files) {
+      return this._runTask(
+        straightThroughStringTask2(["rm", "--cached", ...asArray2(files)]),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.catFile = function(options, then) {
+      return this._catFile("utf-8", arguments);
+    };
+    Git2.prototype.binaryCatFile = function() {
+      return this._catFile("buffer", arguments);
+    };
+    Git2.prototype._catFile = function(format, args) {
+      var handler = trailingFunctionArgument2(args);
+      var command = ["cat-file"];
+      var options = args[0];
+      if (typeof options === "string") {
+        return this._runTask(
+          configurationErrorTask2("Git.catFile: options must be supplied as an array of strings"),
+          handler
+        );
+      }
+      if (Array.isArray(options)) {
+        command.push.apply(command, options);
+      }
+      const task = format === "buffer" ? straightThroughBufferTask2(command) : straightThroughStringTask2(command);
+      return this._runTask(task, handler);
+    };
+    Git2.prototype.diff = function(options, then) {
+      const task = filterString2(options) ? configurationErrorTask2(
+        "git.diff: supplying options as a single string is no longer supported, switch to an array of strings"
+      ) : straightThroughStringTask2(["diff", ...getTrailingOptions2(arguments)]);
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.diffSummary = function() {
+      return this._runTask(
+        diffSummaryTask2(getTrailingOptions2(arguments, 1)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.applyPatch = function(patches) {
+      const task = !filterStringOrStringArray2(patches) ? configurationErrorTask2(
+        `git.applyPatch requires one or more string patches as the first argument`
+      ) : applyPatchTask2(asArray2(patches), getTrailingOptions2([].slice.call(arguments, 1)));
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.revparse = function() {
+      const commands = ["rev-parse", ...getTrailingOptions2(arguments, true)];
+      return this._runTask(
+        straightThroughStringTask2(commands, true),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.clean = function(mode, options, then) {
+      const usingCleanOptionsArray = isCleanOptionsArray2(mode);
+      const cleanMode = usingCleanOptionsArray && mode.join("") || filterType2(mode, filterString2) || "";
+      const customArgs = getTrailingOptions2([].slice.call(arguments, usingCleanOptionsArray ? 1 : 0));
+      return this._runTask(
+        cleanWithOptionsTask2(cleanMode, customArgs),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.exec = function(then) {
+      const task = {
+        commands: [],
+        format: "utf-8",
+        parser() {
+          if (typeof then === "function") {
+            then();
+          }
+        }
+      };
+      return this._runTask(task);
+    };
+    Git2.prototype.clearQueue = function() {
+      return this._runTask(
+        adhocExecTask2(
+          () => console.warn(
+            "simple-git deprecation notice: clearQueue() is deprecated and will be removed, switch to using the abortPlu\
+gin instead."
+          )
+        )
+      );
+    };
+    Git2.prototype.checkIgnore = function(pathnames, then) {
+      return this._runTask(
+        checkIgnoreTask2(asArray2(filterType2(pathnames, filterStringOrStringArray2, []))),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    Git2.prototype.checkIsRepo = function(checkType, then) {
+      return this._runTask(
+        checkIsRepoTask2(filterType2(checkType, filterString2)),
+        trailingFunctionArgument2(arguments)
+      );
+    };
+    module2.exports = Git2;
+  }
+});
+init_pathspec();
+init_git_error();
+init_git_error();
+init_git_error();
+var GitPluginError = class extends GitError {
+  static {
+    __name(this, "GitPluginError");
+  }
+  constructor(task, plugin, message) {
+    super(task, message);
+    this.task = task;
+    this.plugin = plugin;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+};
+init_git_response_error();
+init_task_configuration_error();
+init_check_is_repo();
+init_clean();
+init_config();
+init_diff_name_status();
+init_grep();
+init_reset();
+function isConfigSwitch(arg) {
+  return typeof arg === "string" && arg.trim().toLowerCase() === "-c";
+}
+__name(isConfigSwitch, "isConfigSwitch");
+function preventConfigBuilder(config, setting, message = String(config)) {
+  const regex = typeof config === "string" ? new RegExp(`\\s*${config}`, "i") : config;
+  return /* @__PURE__ */ __name(function preventCommand(options, arg, next) {
+    if (options[setting] !== true && isConfigSwitch(arg) && regex.test(next)) {
+      throw new GitPluginError(
+        void 0,
+        "unsafe",
+        `Configuring ${message} is not permitted without enabling ${setting}`
+      );
+    }
+  }, "preventCommand");
+}
+__name(preventConfigBuilder, "preventConfigBuilder");
+var preventUnsafeConfig = [
+  preventConfigBuilder(
+    /^\s*protocol(.[a-z]+)?.allow/i,
+    "allowUnsafeProtocolOverride",
+    "protocol.allow"
+  ),
+  preventConfigBuilder("core.sshCommand", "allowUnsafeSshCommand"),
+  preventConfigBuilder("core.gitProxy", "allowUnsafeGitProxy"),
+  preventConfigBuilder("core.hooksPath", "allowUnsafeHooksPath"),
+  preventConfigBuilder("diff.external", "allowUnsafeDiffExternal")
+];
+init_utils();
+init_utils();
+var never = (0, import_promise_deferred2.deferred)().promise;
+init_utils();
+init_git_error();
+init_utils();
+init_utils();
+init_utils();
+init_pathspec();
+init_utils();
+var Git = require_git();
+init_git_response_error();
 
 // node_modules/@actions/core/lib/command.js
 var os = __toESM(require("os"), 1);
@@ -20438,13 +27737,13 @@ var Command = class {
     let cmdStr = CMD_STRING + this.command;
     if (this.properties && Object.keys(this.properties).length > 0) {
       cmdStr += " ";
-      let first = true;
+      let first2 = true;
       for (const key in this.properties) {
         if (this.properties.hasOwnProperty(key)) {
           const val = this.properties[key];
           if (val) {
-            if (first) {
-              first = false;
+            if (first2) {
+              first2 = false;
             } else {
               cmdStr += ",";
             }
@@ -20467,8 +27766,38 @@ function escapeProperty(s) {
 }
 __name(escapeProperty, "escapeProperty");
 
+// node_modules/@actions/core/lib/file-command.js
+var crypto = __toESM(require("crypto"), 1);
+var fs = __toESM(require("fs"), 1);
+var os2 = __toESM(require("os"), 1);
+function issueFileCommand(command, message) {
+  const filePath = process.env[`GITHUB_${command}`];
+  if (!filePath) {
+    throw new Error(`Unable to find environment variable for file command ${command}`);
+  }
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing file at path: ${filePath}`);
+  }
+  fs.appendFileSync(filePath, `${toCommandValue(message)}${os2.EOL}`, {
+    encoding: "utf8"
+  });
+}
+__name(issueFileCommand, "issueFileCommand");
+function prepareKeyValueMessage(key, value) {
+  const delimiter2 = `ghadelimiter_${crypto.randomUUID()}`;
+  const convertedValue = toCommandValue(value);
+  if (key.includes(delimiter2)) {
+    throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter2}"`);
+  }
+  if (convertedValue.includes(delimiter2)) {
+    throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter2}"`);
+  }
+  return `${key}<<${delimiter2}${os2.EOL}${convertedValue}${os2.EOL}${delimiter2}`;
+}
+__name(prepareKeyValueMessage, "prepareKeyValueMessage");
+
 // node_modules/@actions/core/lib/core.js
-var os3 = __toESM(require("os"), 1);
+var os5 = __toESM(require("os"), 1);
 
 // node_modules/@actions/http-client/lib/index.js
 var tunnel = __toESM(require_tunnel2(), 1);
@@ -20530,12 +27859,12 @@ var import_os = require("os");
 var import_fs = require("fs");
 var __awaiter = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve) {
-      resolve(value);
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
     });
   }
   __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve, reject) {
+  return new (P || (P = Promise))(function(resolve2, reject) {
     function fulfilled(value) {
       try {
         step(generator.next(value));
@@ -20553,7 +27882,7 @@ var __awaiter = function(thisArg, _arguments, P, generator) {
     }
     __name(rejected, "rejected");
     function step(result) {
-      result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
     }
     __name(step, "step");
     step((generator = generator.apply(thisArg, _arguments || [])).next());
@@ -20586,7 +27915,7 @@ supports job summaries.`);
       }
       try {
         yield access(pathFromEnv, import_fs.constants.R_OK | import_fs.constants.W_OK);
-      } catch (_a) {
+      } catch (_a2) {
         throw new Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permi\
 ssions.`);
       }
@@ -20821,14 +28150,799 @@ var _summary = new Summary();
 // node_modules/@actions/core/lib/platform.js
 var import_os2 = __toESM(require("os"), 1);
 
-// node_modules/@actions/io/lib/io-util.js
-var fs = __toESM(require("fs"), 1);
-var { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises;
-var IS_WINDOWS = process.platform === "win32";
-var READONLY = fs.constants.O_RDONLY;
+// node_modules/@actions/exec/lib/exec.js
+var import_string_decoder = require("string_decoder");
 
 // node_modules/@actions/exec/lib/toolrunner.js
+var os3 = __toESM(require("os"), 1);
+var events = __toESM(require("events"), 1);
+var child = __toESM(require("child_process"), 1);
+var path3 = __toESM(require("path"), 1);
+
+// node_modules/@actions/io/lib/io.js
+var path2 = __toESM(require("path"), 1);
+
+// node_modules/@actions/io/lib/io-util.js
+var fs2 = __toESM(require("fs"), 1);
+var path = __toESM(require("path"), 1);
+var __awaiter2 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+var { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs2.promises;
+var IS_WINDOWS = process.platform === "win32";
+var READONLY = fs2.constants.O_RDONLY;
+function exists2(fsPath) {
+  return __awaiter2(this, void 0, void 0, function* () {
+    try {
+      yield stat(fsPath);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        return false;
+      }
+      throw err;
+    }
+    return true;
+  });
+}
+__name(exists2, "exists");
+function isRooted(p) {
+  p = normalizeSeparators(p);
+  if (!p) {
+    throw new Error('isRooted() parameter "p" cannot be empty');
+  }
+  if (IS_WINDOWS) {
+    return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+  }
+  return p.startsWith("/");
+}
+__name(isRooted, "isRooted");
+function tryGetExecutablePath(filePath, extensions) {
+  return __awaiter2(this, void 0, void 0, function* () {
+    let stats = void 0;
+    try {
+      stats = yield stat(filePath);
+    } catch (err) {
+      if (err.code !== "ENOENT") {
+        console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+      }
+    }
+    if (stats && stats.isFile()) {
+      if (IS_WINDOWS) {
+        const upperExt = path.extname(filePath).toUpperCase();
+        if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+          return filePath;
+        }
+      } else {
+        if (isUnixExecutable(stats)) {
+          return filePath;
+        }
+      }
+    }
+    const originalFilePath = filePath;
+    for (const extension of extensions) {
+      filePath = originalFilePath + extension;
+      stats = void 0;
+      try {
+        stats = yield stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+        }
+      }
+      if (stats && stats.isFile()) {
+        if (IS_WINDOWS) {
+          try {
+            const directory = path.dirname(filePath);
+            const upperName = path.basename(filePath).toUpperCase();
+            for (const actualName of yield readdir(directory)) {
+              if (upperName === actualName.toUpperCase()) {
+                filePath = path.join(directory, actualName);
+                break;
+              }
+            }
+          } catch (err) {
+            console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+          }
+          return filePath;
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+    }
+    return "";
+  });
+}
+__name(tryGetExecutablePath, "tryGetExecutablePath");
+function normalizeSeparators(p) {
+  p = p || "";
+  if (IS_WINDOWS) {
+    p = p.replace(/\//g, "\\");
+    return p.replace(/\\\\+/g, "\\");
+  }
+  return p.replace(/\/\/+/g, "/");
+}
+__name(normalizeSeparators, "normalizeSeparators");
+function isUnixExecutable(stats) {
+  return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.
+  mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+__name(isUnixExecutable, "isUnixExecutable");
+
+// node_modules/@actions/io/lib/io.js
+var __awaiter3 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+function which(tool, check) {
+  return __awaiter3(this, void 0, void 0, function* () {
+    if (!tool) {
+      throw new Error("parameter 'tool' is required");
+    }
+    if (check) {
+      const result = yield which(tool, false);
+      if (!result) {
+        if (IS_WINDOWS) {
+          throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the f\
+ile can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extensi\
+on for an executable file.`);
+        } else {
+          throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the f\
+ile can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the f\
+ile is executable.`);
+        }
+      }
+      return result;
+    }
+    const matches = yield findInPath(tool);
+    if (matches && matches.length > 0) {
+      return matches[0];
+    }
+    return "";
+  });
+}
+__name(which, "which");
+function findInPath(tool) {
+  return __awaiter3(this, void 0, void 0, function* () {
+    if (!tool) {
+      throw new Error("parameter 'tool' is required");
+    }
+    const extensions = [];
+    if (IS_WINDOWS && process.env["PATHEXT"]) {
+      for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+        if (extension) {
+          extensions.push(extension);
+        }
+      }
+    }
+    if (isRooted(tool)) {
+      const filePath = yield tryGetExecutablePath(tool, extensions);
+      if (filePath) {
+        return [filePath];
+      }
+      return [];
+    }
+    if (tool.includes(path2.sep)) {
+      return [];
+    }
+    const directories = [];
+    if (process.env.PATH) {
+      for (const p of process.env.PATH.split(path2.delimiter)) {
+        if (p) {
+          directories.push(p);
+        }
+      }
+    }
+    const matches = [];
+    for (const directory of directories) {
+      const filePath = yield tryGetExecutablePath(path2.join(directory, tool), extensions);
+      if (filePath) {
+        matches.push(filePath);
+      }
+    }
+    return matches;
+  });
+}
+__name(findInPath, "findInPath");
+
+// node_modules/@actions/exec/lib/toolrunner.js
+var import_timers = require("timers");
+var __awaiter4 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
 var IS_WINDOWS2 = process.platform === "win32";
+var ToolRunner = class extends events.EventEmitter {
+  static {
+    __name(this, "ToolRunner");
+  }
+  constructor(toolPath, args, options) {
+    super();
+    if (!toolPath) {
+      throw new Error("Parameter 'toolPath' cannot be null or empty.");
+    }
+    this.toolPath = toolPath;
+    this.args = args || [];
+    this.options = options || {};
+  }
+  _debug(message) {
+    if (this.options.listeners && this.options.listeners.debug) {
+      this.options.listeners.debug(message);
+    }
+  }
+  _getCommandString(options, noPrefix) {
+    const toolPath = this._getSpawnFileName();
+    const args = this._getSpawnArgs(options);
+    let cmd = noPrefix ? "" : "[command]";
+    if (IS_WINDOWS2) {
+      if (this._isCmdFile()) {
+        cmd += toolPath;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      } else if (options.windowsVerbatimArguments) {
+        cmd += `"${toolPath}"`;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      } else {
+        cmd += this._windowsQuoteCmdArg(toolPath);
+        for (const a of args) {
+          cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+        }
+      }
+    } else {
+      cmd += toolPath;
+      for (const a of args) {
+        cmd += ` ${a}`;
+      }
+    }
+    return cmd;
+  }
+  _processLineBuffer(data, strBuffer, onLine) {
+    try {
+      let s = strBuffer + data.toString();
+      let n = s.indexOf(os3.EOL);
+      while (n > -1) {
+        const line = s.substring(0, n);
+        onLine(line);
+        s = s.substring(n + os3.EOL.length);
+        n = s.indexOf(os3.EOL);
+      }
+      return s;
+    } catch (err) {
+      this._debug(`error processing line. Failed with error ${err}`);
+      return "";
+    }
+  }
+  _getSpawnFileName() {
+    if (IS_WINDOWS2) {
+      if (this._isCmdFile()) {
+        return process.env["COMSPEC"] || "cmd.exe";
+      }
+    }
+    return this.toolPath;
+  }
+  _getSpawnArgs(options) {
+    if (IS_WINDOWS2) {
+      if (this._isCmdFile()) {
+        let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+        for (const a of this.args) {
+          argline += " ";
+          argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+        }
+        argline += '"';
+        return [argline];
+      }
+    }
+    return this.args;
+  }
+  _endsWith(str, end) {
+    return str.endsWith(end);
+  }
+  _isCmdFile() {
+    const upperToolPath = this.toolPath.toUpperCase();
+    return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
+  }
+  _windowsQuoteCmdArg(arg) {
+    if (!this._isCmdFile()) {
+      return this._uvQuoteCmdArg(arg);
+    }
+    if (!arg) {
+      return '""';
+    }
+    const cmdSpecialChars = [
+      " ",
+      "	",
+      "&",
+      "(",
+      ")",
+      "[",
+      "]",
+      "{",
+      "}",
+      "^",
+      "=",
+      ";",
+      "!",
+      "'",
+      "+",
+      ",",
+      "`",
+      "~",
+      "|",
+      "<",
+      ">",
+      '"'
+    ];
+    let needsQuotes = false;
+    for (const char of arg) {
+      if (cmdSpecialChars.some((x) => x === char)) {
+        needsQuotes = true;
+        break;
+      }
+    }
+    if (!needsQuotes) {
+      return arg;
+    }
+    let reverse = '"';
+    let quoteHit = true;
+    for (let i = arg.length; i > 0; i--) {
+      reverse += arg[i - 1];
+      if (quoteHit && arg[i - 1] === "\\") {
+        reverse += "\\";
+      } else if (arg[i - 1] === '"') {
+        quoteHit = true;
+        reverse += '"';
+      } else {
+        quoteHit = false;
+      }
+    }
+    reverse += '"';
+    return reverse.split("").reverse().join("");
+  }
+  _uvQuoteCmdArg(arg) {
+    if (!arg) {
+      return '""';
+    }
+    if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+      return arg;
+    }
+    if (!arg.includes('"') && !arg.includes("\\")) {
+      return `"${arg}"`;
+    }
+    let reverse = '"';
+    let quoteHit = true;
+    for (let i = arg.length; i > 0; i--) {
+      reverse += arg[i - 1];
+      if (quoteHit && arg[i - 1] === "\\") {
+        reverse += "\\";
+      } else if (arg[i - 1] === '"') {
+        quoteHit = true;
+        reverse += "\\";
+      } else {
+        quoteHit = false;
+      }
+    }
+    reverse += '"';
+    return reverse.split("").reverse().join("");
+  }
+  _cloneExecOptions(options) {
+    options = options || {};
+    const result = {
+      cwd: options.cwd || process.cwd(),
+      env: options.env || process.env,
+      silent: options.silent || false,
+      windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+      failOnStdErr: options.failOnStdErr || false,
+      ignoreReturnCode: options.ignoreReturnCode || false,
+      delay: options.delay || 1e4
+    };
+    result.outStream = options.outStream || process.stdout;
+    result.errStream = options.errStream || process.stderr;
+    return result;
+  }
+  _getSpawnOptions(options, toolPath) {
+    options = options || {};
+    const result = {};
+    result.cwd = options.cwd;
+    result.env = options.env;
+    result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+    if (options.windowsVerbatimArguments) {
+      result.argv0 = `"${toolPath}"`;
+    }
+    return result;
+  }
+  /**
+   * Exec a tool.
+   * Output will be streamed to the live console.
+   * Returns promise with return code
+   *
+   * @param     tool     path to tool to exec
+   * @param     options  optional exec options.  See ExecOptions
+   * @returns   number
+   */
+  exec() {
+    return __awaiter4(this, void 0, void 0, function* () {
+      if (!isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS2 && this.toolPath.includes("\\"))) {
+        this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+      }
+      this.toolPath = yield which(this.toolPath, true);
+      return new Promise((resolve2, reject) => __awaiter4(this, void 0, void 0, function* () {
+        this._debug(`exec tool: ${this.toolPath}`);
+        this._debug("arguments:");
+        for (const arg of this.args) {
+          this._debug(`   ${arg}`);
+        }
+        const optionsNonNull = this._cloneExecOptions(this.options);
+        if (!optionsNonNull.silent && optionsNonNull.outStream) {
+          optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os3.EOL);
+        }
+        const state = new ExecState(optionsNonNull, this.toolPath);
+        state.on("debug", (message) => {
+          this._debug(message);
+        });
+        if (this.options.cwd && !(yield exists2(this.options.cwd))) {
+          return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
+        }
+        const fileName = this._getSpawnFileName();
+        const cp2 = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+        let stdbuffer = "";
+        if (cp2.stdout) {
+          cp2.stdout.on("data", (data) => {
+            if (this.options.listeners && this.options.listeners.stdout) {
+              this.options.listeners.stdout(data);
+            }
+            if (!optionsNonNull.silent && optionsNonNull.outStream) {
+              optionsNonNull.outStream.write(data);
+            }
+            stdbuffer = this._processLineBuffer(data, stdbuffer, (line) => {
+              if (this.options.listeners && this.options.listeners.stdline) {
+                this.options.listeners.stdline(line);
+              }
+            });
+          });
+        }
+        let errbuffer = "";
+        if (cp2.stderr) {
+          cp2.stderr.on("data", (data) => {
+            state.processStderr = true;
+            if (this.options.listeners && this.options.listeners.stderr) {
+              this.options.listeners.stderr(data);
+            }
+            if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+              const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+              s.write(data);
+            }
+            errbuffer = this._processLineBuffer(data, errbuffer, (line) => {
+              if (this.options.listeners && this.options.listeners.errline) {
+                this.options.listeners.errline(line);
+              }
+            });
+          });
+        }
+        cp2.on("error", (err) => {
+          state.processError = err.message;
+          state.processExited = true;
+          state.processClosed = true;
+          state.CheckComplete();
+        });
+        cp2.on("exit", (code) => {
+          state.processExitCode = code;
+          state.processExited = true;
+          this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+          state.CheckComplete();
+        });
+        cp2.on("close", (code) => {
+          state.processExitCode = code;
+          state.processExited = true;
+          state.processClosed = true;
+          this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+          state.CheckComplete();
+        });
+        state.on("done", (error2, exitCode) => {
+          if (stdbuffer.length > 0) {
+            this.emit("stdline", stdbuffer);
+          }
+          if (errbuffer.length > 0) {
+            this.emit("errline", errbuffer);
+          }
+          cp2.removeAllListeners();
+          if (error2) {
+            reject(error2);
+          } else {
+            resolve2(exitCode);
+          }
+        });
+        if (this.options.input) {
+          if (!cp2.stdin) {
+            throw new Error("child process missing stdin");
+          }
+          cp2.stdin.end(this.options.input);
+        }
+      }));
+    });
+  }
+};
+function argStringToArray(argString) {
+  const args = [];
+  let inQuotes = false;
+  let escaped = false;
+  let arg = "";
+  function append2(c) {
+    if (escaped && c !== '"') {
+      arg += "\\";
+    }
+    arg += c;
+    escaped = false;
+  }
+  __name(append2, "append");
+  for (let i = 0; i < argString.length; i++) {
+    const c = argString.charAt(i);
+    if (c === '"') {
+      if (!escaped) {
+        inQuotes = !inQuotes;
+      } else {
+        append2(c);
+      }
+      continue;
+    }
+    if (c === "\\" && escaped) {
+      append2(c);
+      continue;
+    }
+    if (c === "\\" && inQuotes) {
+      escaped = true;
+      continue;
+    }
+    if (c === " " && !inQuotes) {
+      if (arg.length > 0) {
+        args.push(arg);
+        arg = "";
+      }
+      continue;
+    }
+    append2(c);
+  }
+  if (arg.length > 0) {
+    args.push(arg.trim());
+  }
+  return args;
+}
+__name(argStringToArray, "argStringToArray");
+var ExecState = class _ExecState extends events.EventEmitter {
+  static {
+    __name(this, "ExecState");
+  }
+  constructor(options, toolPath) {
+    super();
+    this.processClosed = false;
+    this.processError = "";
+    this.processExitCode = 0;
+    this.processExited = false;
+    this.processStderr = false;
+    this.delay = 1e4;
+    this.done = false;
+    this.timeout = null;
+    if (!toolPath) {
+      throw new Error("toolPath must not be empty");
+    }
+    this.options = options;
+    this.toolPath = toolPath;
+    if (options.delay) {
+      this.delay = options.delay;
+    }
+  }
+  CheckComplete() {
+    if (this.done) {
+      return;
+    }
+    if (this.processClosed) {
+      this._setResult();
+    } else if (this.processExited) {
+      this.timeout = (0, import_timers.setTimeout)(_ExecState.HandleTimeout, this.delay, this);
+    }
+  }
+  _debug(message) {
+    this.emit("debug", message);
+  }
+  _setResult() {
+    let error2;
+    if (this.processExited) {
+      if (this.processError) {
+        error2 = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indic\
+ate the process failed to start. Error: ${this.processError}`);
+      } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+        error2 = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+      } else if (this.processStderr && this.options.failOnStdErr) {
+        error2 = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR s\
+tream`);
+      }
+    }
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+    }
+    this.done = true;
+    this.emit("done", error2, this.processExitCode);
+  }
+  static HandleTimeout(state) {
+    if (state.done) {
+      return;
+    }
+    if (!state.processClosed && state.processExited) {
+      const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from proces\
+s '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+      state._debug(message);
+    }
+    state._setResult();
+  }
+};
+
+// node_modules/@actions/exec/lib/exec.js
+var __awaiter5 = function(thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function(resolve2) {
+      resolve2(value);
+    });
+  }
+  __name(adopt, "adopt");
+  return new (P || (P = Promise))(function(resolve2, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(fulfilled, "fulfilled");
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+    __name(rejected, "rejected");
+    function step(result) {
+      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+    __name(step, "step");
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+function exec(commandLine, args, options) {
+  return __awaiter5(this, void 0, void 0, function* () {
+    const commandArgs = argStringToArray(commandLine);
+    if (commandArgs.length === 0) {
+      throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+    }
+    const toolPath = commandArgs[0];
+    args = commandArgs.slice(1).concat(args || []);
+    const runner = new ToolRunner(toolPath, args, options);
+    return runner.exec();
+  });
+}
+__name(exec, "exec");
+function getExecOutput(commandLine, args, options) {
+  return __awaiter5(this, void 0, void 0, function* () {
+    var _a2, _b;
+    let stdout = "";
+    let stderr = "";
+    const stdoutDecoder = new import_string_decoder.StringDecoder("utf8");
+    const stderrDecoder = new import_string_decoder.StringDecoder("utf8");
+    const originalStdoutListener = (_a2 = options === null || options === void 0 ? void 0 : options.listeners) === null ||
+    _a2 === void 0 ? void 0 : _a2.stdout;
+    const originalStdErrListener = (_b = options === null || options === void 0 ? void 0 : options.listeners) === null ||
+    _b === void 0 ? void 0 : _b.stderr;
+    const stdErrListener = /* @__PURE__ */ __name((data) => {
+      stderr += stderrDecoder.write(data);
+      if (originalStdErrListener) {
+        originalStdErrListener(data);
+      }
+    }, "stdErrListener");
+    const stdOutListener = /* @__PURE__ */ __name((data) => {
+      stdout += stdoutDecoder.write(data);
+      if (originalStdoutListener) {
+        originalStdoutListener(data);
+      }
+    }, "stdOutListener");
+    const listeners = Object.assign(Object.assign({}, options === null || options === void 0 ? void 0 : options.listeners),
+    { stdout: stdOutListener, stderr: stdErrListener });
+    const exitCode = yield exec(commandLine, args, Object.assign(Object.assign({}, options), { listeners }));
+    stdout += stdoutDecoder.end();
+    stderr += stderrDecoder.end();
+    return {
+      exitCode,
+      stdout,
+      stderr
+    };
+  });
+}
+__name(getExecOutput, "getExecOutput");
 
 // node_modules/@actions/core/lib/platform.js
 var platform = import_os2.default.platform();
@@ -20840,22 +28954,67 @@ var ExitCode;
   ExitCode2[ExitCode2["Success"] = 0] = "Success";
   ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
 })(ExitCode || (ExitCode = {}));
-function debug(message) {
+function exportVariable(name, val) {
+  const convertedVal = toCommandValue(val);
+  process.env[name] = convertedVal;
+  const filePath = process.env["GITHUB_ENV"] || "";
+  if (filePath) {
+    return issueFileCommand("ENV", prepareKeyValueMessage(name, val));
+  }
+  issueCommand("set-env", { name }, convertedVal);
+}
+__name(exportVariable, "exportVariable");
+function setSecret(secret) {
+  issueCommand("add-mask", {}, secret);
+}
+__name(setSecret, "setSecret");
+function setFailed(message) {
+  process.exitCode = ExitCode.Failure;
+  error(message);
+}
+__name(setFailed, "setFailed");
+function debug2(message) {
   issueCommand("debug", {}, message);
 }
-__name(debug, "debug");
+__name(debug2, "debug");
+function error(message, properties = {}) {
+  issueCommand("error", toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+}
+__name(error, "error");
 function warning(message, properties = {}) {
   issueCommand("warning", toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
 __name(warning, "warning");
 function info(message) {
-  process.stdout.write(message + os3.EOL);
+  process.stdout.write(message + os5.EOL);
 }
 __name(info, "info");
 function getState(name) {
   return process.env[`STATE_${name}`] || "";
 }
 __name(getState, "getState");
+
+// utils/src/run.js
+var run = /* @__PURE__ */ __name(async (action) => {
+  try {
+    await action();
+  } catch (err) {
+    setFailed(err.message);
+  }
+}, "run");
+var run_default = run;
+
+// node_modules/@actions/tool-cache/lib/manifest.js
+var semver = __toESM(require_semver2(), 1);
+
+// node_modules/@actions/tool-cache/lib/tool-cache.js
+var semver2 = __toESM(require_semver2(), 1);
+var IS_WINDOWS3 = process.platform === "win32";
+var IS_MAC = process.platform === "darwin";
+
+// setup-gcloud/src/auth-stack.js
+var import_node_fs = __toESM(require("node:fs"), 1);
+var import_node_path2 = __toESM(require("node:path"), 1);
 
 // setup-gcloud/src/job-scope.js
 function getJobScope({ prefix = "setup-gcloud" } = {}) {
@@ -20869,13 +29028,133 @@ function getJobScope({ prefix = "setup-gcloud" } = {}) {
 }
 __name(getJobScope, "getJobScope");
 
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path2.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs.default.existsSync(authStackFilePath())) {
+    import_node_fs.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+
 // setup-gcloud/src/cleanup.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
 function deleteCredentialFiles(credentialFiles) {
   for (const filePath of credentialFiles) {
     try {
-      if (import_node_fs.default.existsSync(filePath)) {
-        import_node_fs.default.rmSync(filePath);
-        debug(`Deleted credential file: ${filePath}`);
+      if (import_node_fs2.default.existsSync(filePath)) {
+        import_node_fs2.default.rmSync(filePath);
+        debug2(`Deleted credential file: ${filePath}`);
       }
     } catch (err) {
       warning(
@@ -20888,9 +29167,9 @@ __name(deleteCredentialFiles, "deleteCredentialFiles");
 function deleteJobScopedDirectory() {
   try {
     const jobScopedDir = getJobScope();
-    if (import_node_fs.default.existsSync(jobScopedDir)) {
-      import_node_fs.default.rmSync(jobScopedDir, { recursive: true });
-      debug(`Deleted job-scoped credential directory: ${jobScopedDir}`);
+    if (import_node_fs2.default.existsSync(jobScopedDir)) {
+      import_node_fs2.default.rmSync(jobScopedDir, { recursive: true });
+      debug2(`Deleted job-scoped credential directory: ${jobScopedDir}`);
     }
   } catch (err) {
     warning(`Failed to delete job-scoped directory: ${err.message}`);
@@ -20900,9 +29179,9 @@ __name(deleteJobScopedDirectory, "deleteJobScopedDirectory");
 function deleteGcloudConfigDirectory() {
   try {
     const cloudSdkConfigPath = process.env.CLOUDSDK_CONFIG;
-    if (cloudSdkConfigPath && import_node_fs.default.existsSync(cloudSdkConfigPath)) {
-      import_node_fs.default.rmSync(cloudSdkConfigPath, { recursive: true });
-      debug(`Deleted CLOUDSDK_CONFIG directory: ${cloudSdkConfigPath}`);
+    if (cloudSdkConfigPath && import_node_fs2.default.existsSync(cloudSdkConfigPath)) {
+      import_node_fs2.default.rmSync(cloudSdkConfigPath, { recursive: true });
+      debug2(`Deleted CLOUDSDK_CONFIG directory: ${cloudSdkConfigPath}`);
     }
   } catch (err) {
     warning(`Failed to delete CLOUDSDK_CONFIG directory: ${err.message}`);
@@ -20926,11 +29205,12 @@ function cleanupCredentials(credentialFiles) {
 __name(cleanupCredentials, "cleanupCredentials");
 
 // setup-gcloud/src/post.js
-var postAction = /* @__PURE__ */ __name(() => {
+var postAction = /* @__PURE__ */ __name(async () => {
   const credentialFiles = getCredentialFilesFromState();
   cleanupCredentials(credentialFiles);
+  await resetAuthStack();
 }, "postAction");
-postAction();
+run_default(postAction);
 /*! Bundled license information:
 
 undici/lib/web/fetch/body.js:

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -30,8 +30,8 @@ var require_ms = __commonJS({
   "node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
-    var h = m * 60;
-    var d = h * 24;
+    var h2 = m * 60;
+    var d = h2 * 24;
     var w = d * 7;
     var y = d * 365.25;
     module2.exports = function(val, options) {
@@ -80,7 +80,7 @@ var require_ms = __commonJS({
         case "hrs":
         case "hr":
         case "h":
-          return n * h;
+          return n * h2;
         case "minutes":
         case "minute":
         case "mins":
@@ -109,8 +109,8 @@ var require_ms = __commonJS({
       if (msAbs >= d) {
         return Math.round(ms / d) + "d";
       }
-      if (msAbs >= h) {
-        return Math.round(ms / h) + "h";
+      if (msAbs >= h2) {
+        return Math.round(ms / h2) + "h";
       }
       if (msAbs >= m) {
         return Math.round(ms / m) + "m";
@@ -126,8 +126,8 @@ var require_ms = __commonJS({
       if (msAbs >= d) {
         return plural(ms, msAbs, d, "day");
       }
-      if (msAbs >= h) {
-        return plural(ms, msAbs, h, "hour");
+      if (msAbs >= h2) {
+        return plural(ms, msAbs, h2, "hour");
       }
       if (msAbs >= m) {
         return plural(ms, msAbs, m, "minute");
@@ -166,8 +166,8 @@ var require_common = __commonJS({
       createDebug.formatters = {};
       function selectColor(namespace) {
         let hash = 0;
-        for (let i = 0; i < namespace.length; i++) {
-          hash = (hash << 5) - hash + namespace.charCodeAt(i);
+        for (let i2 = 0; i2 < namespace.length; i2++) {
+          hash = (hash << 5) - hash + namespace.charCodeAt(i2);
           hash |= 0;
         }
         return createDebug.colors[Math.abs(hash) % createDebug.colors.length];
@@ -456,8 +456,8 @@ in the next major version of `debug`.");
       if (!this.useColors) {
         return;
       }
-      const c = "color: " + this.color;
-      args.splice(1, 0, c, "color: inherit");
+      const c3 = "color: " + this.color;
+      args.splice(1, 0, c3, "color: inherit");
       let index = 0;
       let lastC = 0;
       args[0].replace(/%[a-zA-Z%]/g, (match) => {
@@ -469,7 +469,7 @@ in the next major version of `debug`.");
           lastC = index;
         }
       });
-      args.splice(lastC, 0, c);
+      args.splice(lastC, 0, c3);
     }
     __name(formatArgs, "formatArgs");
     exports2.log = console.debug || console.log || (() => {
@@ -486,15 +486,15 @@ in the next major version of `debug`.");
     }
     __name(save, "save");
     function load() {
-      let r;
+      let r2;
       try {
-        r = exports2.storage.getItem("debug") || exports2.storage.getItem("DEBUG");
+        r2 = exports2.storage.getItem("debug") || exports2.storage.getItem("DEBUG");
       } catch (error2) {
       }
-      if (!r && typeof process !== "undefined" && "env" in process) {
-        r = process.env.DEBUG;
+      if (!r2 && typeof process !== "undefined" && "env" in process) {
+        r2 = process.env.DEBUG;
       }
-      return r;
+      return r2;
     }
     __name(load, "load");
     function localstorage() {
@@ -763,8 +763,8 @@ var require_node = __commonJS({
     function formatArgs(args) {
       const { namespace: name, useColors: useColors2 } = this;
       if (useColors2) {
-        const c = this.color;
-        const colorCode = "\x1B[3" + (c < 8 ? c : "8;5;" + c);
+        const c3 = this.color;
+        const colorCode = "\x1B[3" + (c3 < 8 ? c3 : "8;5;" + c3);
         const prefix = `  ${colorCode};1m${name} \x1B[0m`;
         args[0] = prefix + args[0].split("\n").join("\n" + prefix);
         args.push(colorCode + "m+" + module2.exports.humanize(this.diff) + "\x1B[0m");
@@ -799,8 +799,8 @@ var require_node = __commonJS({
     function init(debug3) {
       debug3.inspectOpts = {};
       const keys = Object.keys(exports2.inspectOpts);
-      for (let i = 0; i < keys.length; i++) {
-        debug3.inspectOpts[keys[i]] = exports2.inspectOpts[keys[i]];
+      for (let i2 = 0; i2 < keys.length; i2++) {
+        debug3.inspectOpts[keys[i2]] = exports2.inspectOpts[keys[i2]];
       }
     }
     __name(init, "init");
@@ -982,10 +982,10 @@ var require_tunnel = __commonJS({
       self.sockets = [];
       self.on("free", /* @__PURE__ */ __name(function onFree(socket, host, port, localAddress) {
         var options2 = toOptions(host, port, localAddress);
-        for (var i = 0, len = self.requests.length; i < len; ++i) {
-          var pending = self.requests[i];
+        for (var i2 = 0, len = self.requests.length; i2 < len; ++i2) {
+          var pending = self.requests[i2];
           if (pending.host === options2.host && pending.port === options2.port) {
-            self.requests.splice(i, 1);
+            self.requests.splice(i2, 1);
             pending.request.onSocket(socket);
             return;
           }
@@ -1140,8 +1140,8 @@ var require_tunnel = __commonJS({
     }
     __name(toOptions, "toOptions");
     function mergeOptions(target) {
-      for (var i = 1, len = arguments.length; i < len; ++i) {
-        var overrides = arguments[i];
+      for (var i2 = 1, len = arguments.length; i2 < len; ++i2) {
+        var overrides = arguments[i2];
         if (typeof overrides === "object") {
           var keys = Object.keys(overrides);
           for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
@@ -1788,8 +1788,8 @@ var require_constants = __commonJS({
       "X-Requested-With",
       "X-XSS-Protection"
     ];
-    for (let i = 0; i < wellknownHeaderNames.length; ++i) {
-      const key = wellknownHeaderNames[i];
+    for (let i2 = 0; i2 < wellknownHeaderNames.length; ++i2) {
+      const key = wellknownHeaderNames[i2];
       const lowerCasedKey = key.toLowerCase();
       headerNameLowerCasedRecord[key] = headerNameLowerCasedRecord[lowerCasedKey] = lowerCasedKey;
     }
@@ -1936,8 +1936,8 @@ var require_tree = __commonJS({
       }
     };
     var tree = new TernarySearchTree();
-    for (let i = 0; i < wellknownHeaderNames.length; ++i) {
-      const key = headerNameLowerCasedRecord[wellknownHeaderNames[i]];
+    for (let i2 = 0; i2 < wellknownHeaderNames.length; ++i2) {
+      const key = headerNameLowerCasedRecord[wellknownHeaderNames[i2]];
       tree.insert(key, key);
     }
     module2.exports = {
@@ -2190,21 +2190,21 @@ tion"));
     __name(bufferToLowerCasedHeaderName, "bufferToLowerCasedHeaderName");
     function parseHeaders(headers, obj) {
       if (obj === void 0) obj = {};
-      for (let i = 0; i < headers.length; i += 2) {
-        const key = headerNameToString(headers[i]);
+      for (let i2 = 0; i2 < headers.length; i2 += 2) {
+        const key = headerNameToString(headers[i2]);
         let val = obj[key];
         if (val) {
           if (typeof val === "string") {
             val = [val];
             obj[key] = val;
           }
-          val.push(headers[i + 1].toString("utf8"));
+          val.push(headers[i2 + 1].toString("utf8"));
         } else {
-          const headersValue = headers[i + 1];
+          const headersValue = headers[i2 + 1];
           if (typeof headersValue === "string") {
             obj[key] = headersValue;
           } else {
-            obj[key] = Array.isArray(headersValue) ? headersValue.map((x) => x.toString("utf8")) : headersValue.toString(
+            obj[key] = Array.isArray(headersValue) ? headersValue.map((x2) => x2.toString("utf8")) : headersValue.toString(
             "utf8");
           }
         }
@@ -2358,8 +2358,8 @@ nction" && typeof object.get === "function" && typeof object.getAll === "functio
       return hasIsWellFormed ? `${val}`.isWellFormed() : toUSVString(val) === `${val}`;
     }
     __name(isUSVString, "isUSVString");
-    function isTokenCharCode(c) {
-      switch (c) {
+    function isTokenCharCode(c3) {
+      switch (c3) {
         case 34:
         case 40:
         case 41:
@@ -2379,7 +2379,7 @@ nction" && typeof object.get === "function" && typeof object.getAll === "functio
         case 125:
           return false;
         default:
-          return c >= 33 && c <= 126;
+          return c3 >= 33 && c3 <= 126;
       }
     }
     __name(isTokenCharCode, "isTokenCharCode");
@@ -2387,8 +2387,8 @@ nction" && typeof object.get === "function" && typeof object.getAll === "functio
       if (characters.length === 0) {
         return false;
       }
-      for (let i = 0; i < characters.length; ++i) {
-        if (!isTokenCharCode(characters.charCodeAt(i))) {
+      for (let i2 = 0; i2 < characters.length; ++i2) {
+        if (!isTokenCharCode(characters.charCodeAt(i2))) {
           return false;
         }
       }
@@ -2824,8 +2824,8 @@ terable");
           if (headers.length % 2 !== 0) {
             throw new InvalidArgumentError("headers array must be even");
           }
-          for (let i = 0; i < headers.length; i += 2) {
-            processHeader(this, headers[i], headers[i + 1]);
+          for (let i2 = 0; i2 < headers.length; i2 += 2) {
+            processHeader(this, headers[i2], headers[i2 + 1]);
           }
         } else if (headers && typeof headers === "object") {
           if (headers[Symbol.iterator]) {
@@ -2837,8 +2837,8 @@ terable");
             }
           } else {
             const keys = Object.keys(headers);
-            for (let i = 0; i < keys.length; ++i) {
-              processHeader(this, keys[i], headers[keys[i]]);
+            for (let i2 = 0; i2 < keys.length; ++i2) {
+              processHeader(this, keys[i2], headers[keys[i2]]);
             }
           }
         } else if (headers != null) {
@@ -2966,18 +2966,18 @@ terable");
       }
       if (Array.isArray(val)) {
         const arr = [];
-        for (let i = 0; i < val.length; i++) {
-          if (typeof val[i] === "string") {
-            if (!isValidHeaderValue(val[i])) {
+        for (let i2 = 0; i2 < val.length; i2++) {
+          if (typeof val[i2] === "string") {
+            if (!isValidHeaderValue(val[i2])) {
               throw new InvalidArgumentError(`invalid ${key} header`);
             }
-            arr.push(val[i]);
-          } else if (val[i] === null) {
+            arr.push(val[i2]);
+          } else if (val[i2] === null) {
             arr.push("");
-          } else if (typeof val[i] === "object") {
+          } else if (typeof val[i2] === "object") {
             throw new InvalidArgumentError(`invalid ${key} header`);
           } else {
-            arr.push(`${val[i]}`);
+            arr.push(`${val[i2]}`);
           }
         }
         val = arr;
@@ -3127,8 +3127,8 @@ var require_dispatcher_base = __commonJS({
       }
       set interceptors(newInterceptors) {
         if (newInterceptors) {
-          for (let i = newInterceptors.length - 1; i >= 0; i--) {
-            const interceptor = this[kInterceptors][i];
+          for (let i2 = newInterceptors.length - 1; i2 >= 0; i2--) {
+            const interceptor = this[kInterceptors][i2];
             if (typeof interceptor !== "function") {
               throw new InvalidArgumentError("interceptor must be an function");
             }
@@ -3164,8 +3164,8 @@ var require_dispatcher_base = __commonJS({
         const onClosed = /* @__PURE__ */ __name(() => {
           const callbacks = this[kOnClosed];
           this[kOnClosed] = null;
-          for (let i = 0; i < callbacks.length; i++) {
-            callbacks[i](null, null);
+          for (let i2 = 0; i2 < callbacks.length; i2++) {
+            callbacks[i2](null, null);
           }
         }, "onClosed");
         this[kClose]().then(() => this.destroy()).then(() => {
@@ -3207,8 +3207,8 @@ var require_dispatcher_base = __commonJS({
         const onDestroyed = /* @__PURE__ */ __name(() => {
           const callbacks = this[kOnDestroyed];
           this[kOnDestroyed] = null;
-          for (let i = 0; i < callbacks.length; i++) {
-            callbacks[i](null, null);
+          for (let i2 = 0; i2 < callbacks.length; i2++) {
+            callbacks[i2](null, null);
           }
         }, "onDestroyed");
         this[kDestroy](err).then(() => {
@@ -3221,8 +3221,8 @@ var require_dispatcher_base = __commonJS({
           return this[kDispatch](opts, handler);
         }
         let dispatch = this[kDispatch].bind(this);
-        for (let i = this[kInterceptors].length - 1; i >= 0; i--) {
-          dispatch = this[kInterceptors][i](dispatch);
+        for (let i2 = this[kInterceptors].length - 1; i2 >= 0; i2--) {
+          dispatch = this[kInterceptors][i2](dispatch);
         }
         this[kInterceptedDispatch] = dispatch;
         return dispatch(opts, handler);
@@ -3886,9 +3886,9 @@ var require_constants2 = __commonJS({
       FINISH2[FINISH2["UNSAFE"] = 2] = "UNSAFE";
     })(FINISH = exports2.FINISH || (exports2.FINISH = {}));
     exports2.ALPHA = [];
-    for (let i = "A".charCodeAt(0); i <= "Z".charCodeAt(0); i++) {
-      exports2.ALPHA.push(String.fromCharCode(i));
-      exports2.ALPHA.push(String.fromCharCode(i + 32));
+    for (let i2 = "A".charCodeAt(0); i2 <= "Z".charCodeAt(0); i2++) {
+      exports2.ALPHA.push(String.fromCharCode(i2));
+      exports2.ALPHA.push(String.fromCharCode(i2 + 32));
     }
     exports2.NUM_MAP = {
       0: 0,
@@ -3974,8 +3974,8 @@ var require_constants2 = __commonJS({
       "~"
     ].concat(exports2.ALPHANUM);
     exports2.URL_CHAR = exports2.STRICT_URL_CHAR.concat(["	", "\f"]);
-    for (let i = 128; i <= 255; i++) {
-      exports2.URL_CHAR.push(i);
+    for (let i2 = 128; i2 <= 255; i2++) {
+      exports2.URL_CHAR.push(i2);
     }
     exports2.HEX = exports2.NUM.concat(["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
     exports2.STRICT_TOKEN = [
@@ -3997,12 +3997,12 @@ var require_constants2 = __commonJS({
     ].concat(exports2.ALPHANUM);
     exports2.TOKEN = exports2.STRICT_TOKEN.concat([" "]);
     exports2.HEADER_CHARS = ["	"];
-    for (let i = 32; i <= 255; i++) {
-      if (i !== 127) {
-        exports2.HEADER_CHARS.push(i);
+    for (let i2 = 32; i2 <= 255; i2++) {
+      if (i2 !== 127) {
+        exports2.HEADER_CHARS.push(i2);
       }
     }
-    exports2.CONNECTION_TOKEN_CHARS = exports2.HEADER_CHARS.filter((c) => c !== 44);
+    exports2.CONNECTION_TOKEN_CHARS = exports2.HEADER_CHARS.filter((c3) => c3 !== 44);
     exports2.MAJOR = exports2.NUM_MAP;
     exports2.MINOR = exports2.MAJOR;
     var HEADER_STATE;
@@ -4031,8 +4031,8 @@ var require_constants2 = __commonJS({
 var require_llhttp_wasm = __commonJS({
   "node_modules/undici/lib/llhttp/llhttp-wasm.js"(exports2, module2) {
     "use strict";
-    var { Buffer: Buffer3 } = require("node:buffer");
-    module2.exports = Buffer3.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
+    var { Buffer: Buffer2 } = require("node:buffer");
+    module2.exports = Buffer2.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
 b25faGVhZGVyc19jb21wbGV0ZQAEA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNl\
 bnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2Fn\
 ZV9jb21wbGV0ZQAAAy0sBQYAAAIAAAAAAAACAQIAAgICAAADAAAAAAMDAwMBAQEBAQEBAQEAAAIAAAAEBQFwARISBQMBAAIGCAF/AUGA1AQLB9EFIgZtZW1v\
@@ -4580,8 +4580,8 @@ RUJTQ1JJQkVBUkRPV05BQ0VJTkROS0NLVUJTQ1JJQkVIVFRQL0FEVFAv", "base64");
 var require_llhttp_simd_wasm = __commonJS({
   "node_modules/undici/lib/llhttp/llhttp_simd-wasm.js"(exports2, module2) {
     "use strict";
-    var { Buffer: Buffer3 } = require("node:buffer");
-    module2.exports = Buffer3.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
+    var { Buffer: Buffer2 } = require("node:buffer");
+    module2.exports = Buffer2.from("AGFzbQEAAAABJwdgAX8Bf2ADf39/AX9gAX8AYAJ/fwBgBH9/f38Bf2AAAGADf39/AALLAQgDZW52GHdhc21f\
 b25faGVhZGVyc19jb21wbGV0ZQAEA2VudhV3YXNtX29uX21lc3NhZ2VfYmVnaW4AAANlbnYLd2FzbV9vbl91cmwAAQNlbnYOd2FzbV9vbl9zdGF0dXMAAQNl\
 bnYUd2FzbV9vbl9oZWFkZXJfZmllbGQAAQNlbnYUd2FzbV9vbl9oZWFkZXJfdmFsdWUAAQNlbnYMd2FzbV9vbl9ib2R5AAEDZW52GHdhc21fb25fbWVzc2Fn\
 ZV9jb21wbGV0ZQAAAy0sBQYAAAIAAAAAAAACAQIAAgICAAADAAAAAAMDAwMBAQEBAQEBAQEAAAIAAAAEBQFwARISBQMBAAIGCAF/AUGA1AQLB9EFIgZtZW1v\
@@ -5482,15 +5482,15 @@ var require_data_url = __commonJS({
       const length = input.length;
       const output = new Uint8Array(length);
       let j = 0;
-      for (let i = 0; i < length; ++i) {
-        const byte = input[i];
+      for (let i2 = 0; i2 < length; ++i2) {
+        const byte = input[i2];
         if (byte !== 37) {
           output[j++] = byte;
-        } else if (byte === 37 && !(isHexCharByte(input[i + 1]) && isHexCharByte(input[i + 2]))) {
+        } else if (byte === 37 && !(isHexCharByte(input[i2 + 1]) && isHexCharByte(input[i2 + 2]))) {
           output[j++] = 37;
         } else {
-          output[j++] = hexByteToNumber(input[i + 1]) << 4 | hexByteToNumber(input[i + 2]);
-          i += 2;
+          output[j++] = hexByteToNumber(input[i2 + 1]) << 4 | hexByteToNumber(input[i2 + 2]);
+          i2 += 2;
         }
       }
       return length === j ? output : output.subarray(0, j);
@@ -5687,13 +5687,13 @@ var require_data_url = __commonJS({
         return String.fromCharCode.apply(null, input);
       }
       let result = "";
-      let i = 0;
+      let i2 = 0;
       let addition = (2 << 15) - 1;
-      while (i < length) {
-        if (i + addition > length) {
-          addition = length - i;
+      while (i2 < length) {
+        if (i2 + addition > length) {
+          addition = length - i2;
         }
-        result += String.fromCharCode.apply(null, input.subarray(i, i += addition));
+        result += String.fromCharCode.apply(null, input.subarray(i2, i2 += addition));
       }
       return result;
     }
@@ -5852,51 +5852,51 @@ var require_webidl = __commonJS({
         lowerBound = Math.pow(-2, bitLength) - 1;
         upperBound = Math.pow(2, bitLength - 1) - 1;
       }
-      let x = Number(V);
-      if (x === 0) {
-        x = 0;
+      let x2 = Number(V);
+      if (x2 === 0) {
+        x2 = 0;
       }
       if (opts?.enforceRange === true) {
-        if (Number.isNaN(x) || x === Number.POSITIVE_INFINITY || x === Number.NEGATIVE_INFINITY) {
+        if (Number.isNaN(x2) || x2 === Number.POSITIVE_INFINITY || x2 === Number.NEGATIVE_INFINITY) {
           throw webidl.errors.exception({
             header: "Integer conversion",
             message: `Could not convert ${webidl.util.Stringify(V)} to an integer.`
           });
         }
-        x = webidl.util.IntegerPart(x);
-        if (x < lowerBound || x > upperBound) {
+        x2 = webidl.util.IntegerPart(x2);
+        if (x2 < lowerBound || x2 > upperBound) {
           throw webidl.errors.exception({
             header: "Integer conversion",
-            message: `Value must be between ${lowerBound}-${upperBound}, got ${x}.`
+            message: `Value must be between ${lowerBound}-${upperBound}, got ${x2}.`
           });
         }
-        return x;
+        return x2;
       }
-      if (!Number.isNaN(x) && opts?.clamp === true) {
-        x = Math.min(Math.max(x, lowerBound), upperBound);
-        if (Math.floor(x) % 2 === 0) {
-          x = Math.floor(x);
+      if (!Number.isNaN(x2) && opts?.clamp === true) {
+        x2 = Math.min(Math.max(x2, lowerBound), upperBound);
+        if (Math.floor(x2) % 2 === 0) {
+          x2 = Math.floor(x2);
         } else {
-          x = Math.ceil(x);
+          x2 = Math.ceil(x2);
         }
-        return x;
+        return x2;
       }
-      if (Number.isNaN(x) || x === 0 && Object.is(0, x) || x === Number.POSITIVE_INFINITY || x === Number.NEGATIVE_INFINITY) {
+      if (Number.isNaN(x2) || x2 === 0 && Object.is(0, x2) || x2 === Number.POSITIVE_INFINITY || x2 === Number.NEGATIVE_INFINITY) {
         return 0;
       }
-      x = webidl.util.IntegerPart(x);
-      x = x % Math.pow(2, bitLength);
-      if (signedness === "signed" && x >= Math.pow(2, bitLength) - 1) {
-        return x - Math.pow(2, bitLength);
+      x2 = webidl.util.IntegerPart(x2);
+      x2 = x2 % Math.pow(2, bitLength);
+      if (signedness === "signed" && x2 >= Math.pow(2, bitLength) - 1) {
+        return x2 - Math.pow(2, bitLength);
       }
-      return x;
+      return x2;
     };
     webidl.util.IntegerPart = function(n) {
-      const r = Math.floor(Math.abs(n));
+      const r2 = Math.floor(Math.abs(n));
       if (n < 0) {
-        return -1 * r;
+        return -1 * r2;
       }
-      return r;
+      return r2;
     };
     webidl.util.Stringify = function(V) {
       const type = webidl.util.Type(V);
@@ -5968,12 +5968,12 @@ var require_webidl = __commonJS({
         return result;
       };
     };
-    webidl.interfaceConverter = function(i) {
+    webidl.interfaceConverter = function(i2) {
       return (V, prefix, argument, opts) => {
-        if (opts?.strict !== false && !(V instanceof i)) {
+        if (opts?.strict !== false && !(V instanceof i2)) {
           throw webidl.errors.exception({
             header: prefix,
-            message: `Expected ${argument} ("${webidl.util.Stringify(V)}") to be an instance of ${i.name}.`
+            message: `Expected ${argument} ("${webidl.util.Stringify(V)}") to be an instance of ${i2.name}.`
           });
         }
         return V;
@@ -6041,40 +6041,40 @@ var require_webidl = __commonJS({
       return String(V);
     };
     webidl.converters.ByteString = function(V, prefix, argument) {
-      const x = webidl.converters.DOMString(V, prefix, argument);
-      for (let index = 0; index < x.length; index++) {
-        if (x.charCodeAt(index) > 255) {
+      const x2 = webidl.converters.DOMString(V, prefix, argument);
+      for (let index = 0; index < x2.length; index++) {
+        if (x2.charCodeAt(index) > 255) {
           throw new TypeError(
-            `Cannot convert argument to a ByteString because the character at index ${index} has a value of ${x.charCodeAt(
+            `Cannot convert argument to a ByteString because the character at index ${index} has a value of ${x2.charCodeAt(
             index)} which is greater than 255.`
           );
         }
       }
-      return x;
+      return x2;
     };
     webidl.converters.USVString = toUSVString;
     webidl.converters.boolean = function(V) {
-      const x = Boolean(V);
-      return x;
+      const x2 = Boolean(V);
+      return x2;
     };
     webidl.converters.any = function(V) {
       return V;
     };
     webidl.converters["long long"] = function(V, prefix, argument) {
-      const x = webidl.util.ConvertToInt(V, 64, "signed", void 0, prefix, argument);
-      return x;
+      const x2 = webidl.util.ConvertToInt(V, 64, "signed", void 0, prefix, argument);
+      return x2;
     };
     webidl.converters["unsigned long long"] = function(V, prefix, argument) {
-      const x = webidl.util.ConvertToInt(V, 64, "unsigned", void 0, prefix, argument);
-      return x;
+      const x2 = webidl.util.ConvertToInt(V, 64, "unsigned", void 0, prefix, argument);
+      return x2;
     };
     webidl.converters["unsigned long"] = function(V, prefix, argument) {
-      const x = webidl.util.ConvertToInt(V, 32, "unsigned", void 0, prefix, argument);
-      return x;
+      const x2 = webidl.util.ConvertToInt(V, 32, "unsigned", void 0, prefix, argument);
+      return x2;
     };
     webidl.converters["unsigned short"] = function(V, prefix, argument, opts) {
-      const x = webidl.util.ConvertToInt(V, 16, "unsigned", opts, prefix, argument);
-      return x;
+      const x2 = webidl.util.ConvertToInt(V, 16, "unsigned", opts, prefix, argument);
+      return x2;
     };
     webidl.converters.ArrayBuffer = function(V, prefix, argument, opts) {
       if (webidl.util.Type(V) !== "Object" || !types.isAnyArrayBuffer(V)) {
@@ -6219,8 +6219,8 @@ var require_util2 = __commonJS({
     }
     __name(responseLocationURL, "responseLocationURL");
     function isValidEncodedURL(url) {
-      for (let i = 0; i < url.length; ++i) {
-        const code = url.charCodeAt(i);
+      for (let i2 = 0; i2 < url.length; ++i2) {
+        const code = url.charCodeAt(i2);
         if (code > 126 || // Non-US-ASCII + DEL
         code < 32) {
           return false;
@@ -6251,11 +6251,11 @@ ption");
     }
     __name(isErrorLike, "isErrorLike");
     function isValidReasonPhrase(statusText) {
-      for (let i = 0; i < statusText.length; ++i) {
-        const c = statusText.charCodeAt(i);
-        if (!(c === 9 || // HTAB
-        c >= 32 && c <= 126 || // SP / VCHAR
-        c >= 128 && c <= 255)) {
+      for (let i2 = 0; i2 < statusText.length; ++i2) {
+        const c3 = statusText.charCodeAt(i2);
+        if (!(c3 === 9 || // HTAB
+        c3 >= 32 && c3 <= 126 || // SP / VCHAR
+        c3 >= 128 && c3 <= 255)) {
           return false;
         }
       }
@@ -6274,8 +6274,8 @@ ption");
       const policyHeader = (headersList.get("referrer-policy", true) ?? "").split(",");
       let policy = "";
       if (policyHeader.length > 0) {
-        for (let i = policyHeader.length; i !== 0; i--) {
-          const token = policyHeader[i - 1].trim();
+        for (let i2 = policyHeader.length; i2 !== 0; i2--) {
+          const token = policyHeader[i2 - 1].trim();
           if (referrerPolicyTokens.has(token)) {
             policy = token;
             break;
@@ -6551,8 +6551,8 @@ ption");
       if (algorithm[3] === "5") {
         return algorithm;
       }
-      for (let i = 1; i < metadataList.length; ++i) {
-        const metadata = metadataList[i];
+      for (let i2 = 1; i2 < metadataList.length; ++i2) {
+        const metadata = metadataList[i2];
         if (metadata.algo[3] === "5") {
           algorithm = "sha512";
           break;
@@ -6570,9 +6570,9 @@ ption");
         return metadataList;
       }
       let pos = 0;
-      for (let i = 0; i < metadataList.length; ++i) {
-        if (metadataList[i].algo === algorithm) {
-          metadataList[pos++] = metadataList[i];
+      for (let i2 = 0; i2 < metadataList.length; ++i2) {
+        if (metadataList[i2].algo === algorithm) {
+          metadataList[pos++] = metadataList[i2];
         }
       }
       metadataList.length = pos;
@@ -6583,9 +6583,10 @@ ption");
       if (actualValue.length !== expectedValue.length) {
         return false;
       }
-      for (let i = 0; i < actualValue.length; ++i) {
-        if (actualValue[i] !== expectedValue[i]) {
-          if (actualValue[i] === "+" && expectedValue[i] === "-" || actualValue[i] === "/" && expectedValue[i] === "_") {
+      for (let i2 = 0; i2 < actualValue.length; ++i2) {
+        if (actualValue[i2] !== expectedValue[i2]) {
+          if (actualValue[i2] === "+" && expectedValue[i2] === "-" || actualValue[i2] === "/" && expectedValue[i2] === "\
+_") {
             continue;
           }
           return false;
@@ -7144,12 +7145,12 @@ var require_file = __commonJS({
       }
       constructor(blobLike, fileName, options = {}) {
         const n = fileName;
-        const t = options.type;
+        const t2 = options.type;
         const d = options.lastModified ?? Date.now();
         this[kState] = {
           blobLike,
           name: n,
-          type: t,
+          type: t2,
           lastModified: d
         };
       }
@@ -7370,8 +7371,8 @@ var require_formdata_parser = __commonJS({
     var dd = Buffer.from("--");
     var ddcrlf = Buffer.from("--\r\n");
     function isAsciiString(chars) {
-      for (let i = 0; i < chars.length; ++i) {
-        if ((chars.charCodeAt(i) & ~127) !== 0) {
+      for (let i2 = 0; i2 < chars.length; ++i2) {
+        if ((chars.charCodeAt(i2) & ~127) !== 0) {
           return false;
         }
       }
@@ -7383,8 +7384,8 @@ var require_formdata_parser = __commonJS({
       if (length < 27 || length > 70) {
         return false;
       }
-      for (let i = 0; i < length; ++i) {
-        const cp2 = boundary.charCodeAt(i);
+      for (let i2 = 0; i2 < length; ++i2) {
+        const cp2 = boundary.charCodeAt(i2);
         if (!(cp2 >= 48 && cp2 <= 57 || cp2 >= 65 && cp2 <= 90 || cp2 >= 97 && cp2 <= 122 || cp2 === 39 || cp2 === 45 ||
         cp2 === 95)) {
           return false;
@@ -7599,8 +7600,8 @@ var require_formdata_parser = __commonJS({
       if (buffer.length < start.length) {
         return false;
       }
-      for (let i = 0; i < start.length; i++) {
-        if (start[i] !== buffer[position.position + i]) {
+      for (let i2 = 0; i2 < start.length; i2++) {
+        if (start[i2] !== buffer[position.position + i2]) {
           return false;
         }
       }
@@ -8493,8 +8494,8 @@ var require_client_h1 = __commonJS({
         if (client2.destroyed) {
           assert(client2[kPending] === 0);
           const requests = client2[kQueue].splice(client2[kRunningIdx]);
-          for (let i = 0; i < requests.length; i++) {
-            const request = requests[i];
+          for (let i2 = 0; i2 < requests.length; i2++) {
+            const request = requests[i2];
             util.errorRequest(client2, request, err);
           }
         } else if (client2[kRunning] > 0 && err.code !== "UND_ERR_INFO") {
@@ -8672,8 +8673,8 @@ upgrade: ${upgrade}\r
           const key = headers[n + 0];
           const val = headers[n + 1];
           if (Array.isArray(val)) {
-            for (let i = 0; i < val.length; i++) {
-              header += `${key}: ${val[i]}\r
+            for (let i2 = 0; i2 < val.length; i2++) {
+              header += `${key}: ${val[i2]}\r
 `;
             }
           } else {
@@ -9076,8 +9077,8 @@ var require_client_h2 = __commonJS({
         if (client2.destroyed) {
           assert(client2[kPending] === 0);
           const requests = client2[kQueue].splice(client2[kRunningIdx]);
-          for (let i = 0; i < requests.length; i++) {
-            const request = requests[i];
+          for (let i2 = 0; i2 < requests.length; i2++) {
+            const request = requests[i2];
             util.errorRequest(client2, request, err);
           }
         }
@@ -9205,11 +9206,11 @@ var require_client_h2 = __commonJS({
         const key = reqHeaders[n + 0];
         const val = reqHeaders[n + 1];
         if (Array.isArray(val)) {
-          for (let i = 0; i < val.length; i++) {
+          for (let i2 = 0; i2 < val.length; i2++) {
             if (headers[key]) {
-              headers[key] += `,${val[i]}`;
+              headers[key] += `,${val[i2]}`;
             } else {
-              headers[key] = val[i];
+              headers[key] = val[i2];
             }
           }
         } else {
@@ -9668,9 +9669,9 @@ var require_redirect_handler = __commonJS({
       if (redirectableStatusCodes.indexOf(statusCode) === -1) {
         return null;
       }
-      for (let i = 0; i < headers.length; i += 2) {
-        if (headers[i].length === 8 && util.headerNameToString(headers[i]) === "location") {
-          return headers[i + 1];
+      for (let i2 = 0; i2 < headers.length; i2 += 2) {
+        if (headers[i2].length === 8 && util.headerNameToString(headers[i2]) === "location") {
+          return headers[i2 + 1];
         }
       }
     }
@@ -9692,9 +9693,9 @@ var require_redirect_handler = __commonJS({
     function cleanRequestHeaders(headers, removeContent, unknownOrigin) {
       const ret = [];
       if (Array.isArray(headers)) {
-        for (let i = 0; i < headers.length; i += 2) {
-          if (!shouldRemoveHeader(headers[i], removeContent, unknownOrigin)) {
-            ret.push(headers[i], headers[i + 1]);
+        for (let i2 = 0; i2 < headers.length; i2 += 2) {
+          if (!shouldRemoveHeader(headers[i2], removeContent, unknownOrigin)) {
+            ret.push(headers[i2], headers[i2 + 1]);
           }
         }
       } else if (headers && typeof headers === "object") {
@@ -10017,8 +10018,8 @@ var require_client = __commonJS({
       async [kDestroy](err) {
         return new Promise((resolve2) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
-          for (let i = 0; i < requests.length; i++) {
-            const request = requests[i];
+          for (let i2 = 0; i2 < requests.length; i2++) {
+            const request = requests[i2];
             util.errorRequest(this, request, err);
           }
           const callback = /* @__PURE__ */ __name(() => {
@@ -10043,8 +10044,8 @@ var require_client = __commonJS({
       if (client[kRunning] === 0 && err.code !== "UND_ERR_INFO" && err.code !== "UND_ERR_SOCKET") {
         assert(client[kPendingIdx] === client[kRunningIdx]);
         const requests = client[kQueue].splice(client[kRunningIdx]);
-        for (let i = 0; i < requests.length; i++) {
-          const request = requests[i];
+        for (let i2 = 0; i2 < requests.length; i2++) {
+          const request = requests[i2];
           util.errorRequest(client, request, err);
         }
         assert(client[kSize] === 0);
@@ -10392,7 +10393,7 @@ var require_pool_base = __commonJS({
             pool.emit("drain", origin, [pool, ...targets]);
           }
           if (pool[kClosedResolve] && queue.isEmpty()) {
-            Promise.all(pool[kClients].map((c) => c.close())).then(pool[kClosedResolve]);
+            Promise.all(pool[kClients].map((c3) => c3.close())).then(pool[kClosedResolve]);
           }
         }, "onDrain");
         this[kOnConnect] = (origin, targets) => {
@@ -10441,7 +10442,7 @@ var require_pool_base = __commonJS({
       }
       async [kClose]() {
         if (this[kQueue].isEmpty()) {
-          await Promise.all(this[kClients].map((c) => c.close()));
+          await Promise.all(this[kClients].map((c3) => c3.close()));
         } else {
           await new Promise((resolve2) => {
             this[kClosedResolve] = resolve2;
@@ -10456,7 +10457,7 @@ var require_pool_base = __commonJS({
           }
           item.handler.onError(err);
         }
-        await Promise.all(this[kClients].map((c) => c.destroy(err)));
+        await Promise.all(this[kClients].map((c3) => c3.destroy(err)));
       }
       [kDispatch](opts, handler) {
         const dispatcher = this[kGetDispatcher]();
@@ -10631,9 +10632,9 @@ var require_balanced_pool = __commonJS({
     function getGreatestCommonDivisor(a, b) {
       if (a === 0) return b;
       while (b !== 0) {
-        const t = b;
+        const t2 = b;
         b = a % b;
-        a = t;
+        a = t2;
       }
       return a;
     }
@@ -10697,8 +10698,8 @@ var require_balanced_pool = __commonJS({
       }
       _updateBalancedPoolStats() {
         let result = 0;
-        for (let i = 0; i < this[kClients].length; i++) {
-          result = getGreatestCommonDivisor(this[kClients][i][kWeight], result);
+        for (let i2 = 0; i2 < this[kClients].length; i2++) {
+          result = getGreatestCommonDivisor(this[kClients][i2][kWeight], result);
         }
         this[kGreatestCommonDivisor] = result;
       }
@@ -11075,8 +11076,8 @@ var require_proxy_agent = __commonJS({
     function buildHeaders(headers) {
       if (Array.isArray(headers)) {
         const headersPair = {};
-        for (let i = 0; i < headers.length; i += 2) {
-          headersPair[headers[i]] = headers[i + 1];
+        for (let i2 = 0; i2 < headers.length; i2 += 2) {
+          headersPair[headers[i2]] = headers[i2 + 1];
         }
         return headersPair;
       }
@@ -11184,8 +11185,8 @@ var require_env_http_proxy_agent = __commonJS({
         if (this.#noProxyValue === "*") {
           return false;
         }
-        for (let i = 0; i < this.#noProxyEntries.length; i++) {
-          const entry = this.#noProxyEntries[i];
+        for (let i2 = 0; i2 < this.#noProxyEntries.length; i2++) {
+          const entry = this.#noProxyEntries[i2];
           if (entry.port && entry.port !== port) {
             continue;
           }
@@ -11205,8 +11206,8 @@ var require_env_http_proxy_agent = __commonJS({
         const noProxyValue = this.#opts.noProxy ?? this.#noProxyEnv;
         const noProxySplit = noProxyValue.split(/[,\s]/);
         const noProxyEntries = [];
-        for (let i = 0; i < noProxySplit.length; i++) {
-          const entry = noProxySplit[i];
+        for (let i2 = 0; i2 < noProxySplit.length; i2++) {
+          const entry = noProxySplit[i2];
           if (!entry) {
             continue;
           }
@@ -11828,8 +11829,8 @@ var require_readable = __commonJS({
       }
       const buffer = new Uint8Array(Buffer.allocUnsafeSlow(length).buffer);
       let offset = 0;
-      for (let i = 0; i < chunks.length; ++i) {
-        const chunk = chunks[i];
+      for (let i2 = 0; i2 < chunks.length; ++i2) {
+        const chunk = chunks[i2];
         buffer.set(chunk, offset);
         offset += chunk.length;
       }
@@ -12879,9 +12880,9 @@ var require_mock_utils = __commonJS({
     __name(lowerCaseEntries, "lowerCaseEntries");
     function getHeaderByName(headers, key) {
       if (Array.isArray(headers)) {
-        for (let i = 0; i < headers.length; i += 2) {
-          if (headers[i].toLocaleLowerCase() === key.toLocaleLowerCase()) {
-            return headers[i + 1];
+        for (let i2 = 0; i2 < headers.length; i2 += 2) {
+          if (headers[i2].toLocaleLowerCase() === key.toLocaleLowerCase()) {
+            return headers[i2 + 1];
           }
         }
         return void 0;
@@ -13017,8 +13018,8 @@ var require_mock_utils = __commonJS({
     function generateKeyValues(data) {
       const keys = Object.keys(data);
       const result = [];
-      for (let i = 0; i < keys.length; ++i) {
-        const key = keys[i];
+      for (let i2 = 0; i2 < keys.length; ++i2) {
+        const key = keys[i2];
         const value = data[key];
         const name = Buffer.from(`${key}`);
         if (Array.isArray(value)) {
@@ -14197,17 +14198,17 @@ var require_headers = __commonJS({
     }
     __name(isHTTPWhiteSpaceCharCode, "isHTTPWhiteSpaceCharCode");
     function headerValueNormalize(potentialValue) {
-      let i = 0;
+      let i2 = 0;
       let j = potentialValue.length;
-      while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(j - 1))) --j;
-      while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i))) ++i;
-      return i === 0 && j === potentialValue.length ? potentialValue : potentialValue.substring(i, j);
+      while (j > i2 && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(j - 1))) --j;
+      while (j > i2 && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i2))) ++i2;
+      return i2 === 0 && j === potentialValue.length ? potentialValue : potentialValue.substring(i2, j);
     }
     __name(headerValueNormalize, "headerValueNormalize");
     function fill(headers, object) {
       if (Array.isArray(object)) {
-        for (let i = 0; i < object.length; ++i) {
-          const header = object[i];
+        for (let i2 = 0; i2 < object.length; ++i2) {
+          const header = object[i2];
           if (header.length !== 2) {
             throw webidl.errors.exception({
               header: "Headers constructor",
@@ -14218,8 +14219,8 @@ var require_headers = __commonJS({
         }
       } else if (typeof object === "object" && object !== null) {
         const keys = Object.keys(object);
-        for (let i = 0; i < keys.length; ++i) {
-          appendHeader(headers, keys[i], object[keys[i]]);
+        for (let i2 = 0; i2 < keys.length; ++i2) {
+          appendHeader(headers, keys[i2], object[keys[i2]]);
         }
       } else {
         throw webidl.errors.conversionFailed({
@@ -14387,26 +14388,26 @@ var require_headers = __commonJS({
           const firstValue = iterator.next().value;
           array[0] = [firstValue[0], firstValue[1].value];
           assert(firstValue[1].value !== null);
-          for (let i = 1, j = 0, right = 0, left = 0, pivot = 0, x, value; i < size; ++i) {
+          for (let i2 = 1, j = 0, right = 0, left = 0, pivot = 0, x2, value; i2 < size; ++i2) {
             value = iterator.next().value;
-            x = array[i] = [value[0], value[1].value];
-            assert(x[1] !== null);
+            x2 = array[i2] = [value[0], value[1].value];
+            assert(x2[1] !== null);
             left = 0;
-            right = i;
+            right = i2;
             while (left < right) {
               pivot = left + (right - left >> 1);
-              if (array[pivot][0] <= x[0]) {
+              if (array[pivot][0] <= x2[0]) {
                 left = pivot + 1;
               } else {
                 right = pivot;
               }
             }
-            if (i !== pivot) {
-              j = i;
+            if (i2 !== pivot) {
+              j = i2;
               while (j > left) {
                 array[j] = array[--j];
               }
-              array[left] = x;
+              array[left] = x2;
             }
           }
           if (!iterator.next().done) {
@@ -14414,9 +14415,9 @@ var require_headers = __commonJS({
           }
           return array;
         } else {
-          let i = 0;
+          let i2 = 0;
           for (const { 0: name, 1: { value } } of this[kHeadersMap]) {
-            array[i++] = [name, value];
+            array[i2++] = [name, value];
             assert(value !== null);
           }
           return array.sort(compareHeaderName);
@@ -14547,8 +14548,8 @@ var require_headers = __commonJS({
         if (cookies === null || cookies.length === 1) {
           return this.#headersList[kHeadersSortedMap] = names;
         }
-        for (let i = 0; i < names.length; ++i) {
-          const { 0: name, 1: value } = names[i];
+        for (let i2 = 0; i2 < names.length; ++i2) {
+          const { 0: name, 1: value } = names[i2];
           if (name === "set-cookie") {
             for (let j = 0; j < cookies.length; ++j) {
               headers.push([name, cookies[j]]);
@@ -14563,17 +14564,17 @@ var require_headers = __commonJS({
         options.depth ??= depth;
         return `Headers ${util.formatWithOptions(options, this.#headersList.entries)}`;
       }
-      static getHeadersGuard(o) {
-        return o.#guard;
+      static getHeadersGuard(o2) {
+        return o2.#guard;
       }
-      static setHeadersGuard(o, guard) {
-        o.#guard = guard;
+      static setHeadersGuard(o2, guard) {
+        o2.#guard = guard;
       }
-      static getHeadersList(o) {
-        return o.#headersList;
+      static getHeadersList(o2) {
+        return o2.#headersList;
       }
-      static setHeadersList(o, list) {
-        o.#headersList = list;
+      static setHeadersList(o2, list) {
+        o2.#headersList = list;
       }
     };
     var { getHeadersGuard, setHeadersGuard, getHeadersList, setHeadersList } = Headers2;
@@ -16780,8 +16781,8 @@ processBodyError");
               }
               let location = "";
               const headersList = new HeadersList();
-              for (let i = 0; i < rawHeaders.length; i += 2) {
-                headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i]), rawHeaders[i + 1].toString("latin1"), true);
+              for (let i2 = 0; i2 < rawHeaders.length; i2 += 2) {
+                headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i2]), rawHeaders[i2 + 1].toString("latin1"), true);
               }
               location = headersList.get("location", true);
               this.body = new Readable({ read: resume });
@@ -16795,8 +16796,8 @@ processBodyError");
                   reject(new Error(`too many content-encodings in response: ${codings.length}, maximum allowed is ${maxContentEncodings}`));
                   return true;
                 }
-                for (let i = codings.length - 1; i >= 0; --i) {
-                  const coding = codings[i].trim();
+                for (let i2 = codings.length - 1; i2 >= 0; --i2) {
+                  const coding = codings[i2].trim();
                   if (coding === "x-gzip" || coding === "gzip") {
                     decoders.push(zlib.createGunzip({
                       // Be less strict when decoding compressed responses, since sometimes
@@ -16866,8 +16867,8 @@ processBodyError");
                 return;
               }
               const headersList = new HeadersList();
-              for (let i = 0; i < rawHeaders.length; i += 2) {
-                headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i]), rawHeaders[i + 1].toString("latin1"), true);
+              for (let i2 = 0; i2 < rawHeaders.length; i2 += 2) {
+                headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i2]), rawHeaders[i2 + 1].toString("latin1"), true);
               }
               resolve2({
                 status,
@@ -17425,8 +17426,8 @@ var require_util4 = __commonJS({
     }
     __name(decode, "decode");
     function BOMSniffing(ioQueue) {
-      const [a, b, c] = ioQueue;
-      if (a === 239 && b === 187 && c === 191) {
+      const [a, b, c3] = ioQueue;
+      if (a === 239 && b === 187 && c3 === 191) {
         return "UTF-8";
       } else if (a === 254 && b === 255) {
         return "UTF-16BE";
@@ -17836,8 +17837,8 @@ var require_cache = __commonJS({
           if (typeof request === "string") {
             continue;
           }
-          const r = request[kState];
-          if (!urlIsHttpHttpsScheme(r.url) || r.method !== "GET") {
+          const r2 = request[kState];
+          if (!urlIsHttpHttpsScheme(r2.url) || r2.method !== "GET") {
             throw webidl.errors.exception({
               header: prefix,
               message: "Expected http/s scheme when method is not GET."
@@ -17846,19 +17847,19 @@ var require_cache = __commonJS({
         }
         const fetchControllers = [];
         for (const request of requests) {
-          const r = new Request(request)[kState];
-          if (!urlIsHttpHttpsScheme(r.url)) {
+          const r2 = new Request(request)[kState];
+          if (!urlIsHttpHttpsScheme(r2.url)) {
             throw webidl.errors.exception({
               header: prefix,
               message: "Expected http/s scheme."
             });
           }
-          r.initiator = "fetch";
-          r.destination = "subresource";
-          requestList.push(r);
+          r2.initiator = "fetch";
+          r2.destination = "subresource";
+          requestList.push(r2);
           const responsePromise = createDeferredPromise();
           fetchControllers.push(fetching({
-            request: r,
+            request: r2,
             processResponse(response) {
               if (response.type === "error" || response.status === 206 || response.status < 200 || response.status > 299) {
                 responsePromise.reject(webidl.errors.exception({
@@ -18010,20 +18011,20 @@ var require_cache = __commonJS({
         webidl.argumentLengthCheck(arguments, 1, prefix);
         request = webidl.converters.RequestInfo(request, prefix, "request");
         options = webidl.converters.CacheQueryOptions(options, prefix, "options");
-        let r = null;
+        let r2 = null;
         if (request instanceof Request) {
-          r = request[kState];
-          if (r.method !== "GET" && !options.ignoreMethod) {
+          r2 = request[kState];
+          if (r2.method !== "GET" && !options.ignoreMethod) {
             return false;
           }
         } else {
           assert(typeof request === "string");
-          r = new Request(request)[kState];
+          r2 = new Request(request)[kState];
         }
         const operations = [];
         const operation = {
           type: "delete",
-          request: r,
+          request: r2,
           options
         };
         operations.push(operation);
@@ -18055,15 +18056,15 @@ var require_cache = __commonJS({
         const prefix = "Cache.keys";
         if (request !== void 0) request = webidl.converters.RequestInfo(request, prefix, "request");
         options = webidl.converters.CacheQueryOptions(options, prefix, "options");
-        let r = null;
+        let r2 = null;
         if (request !== void 0) {
           if (request instanceof Request) {
-            r = request[kState];
-            if (r.method !== "GET" && !options.ignoreMethod) {
+            r2 = request[kState];
+            if (r2.method !== "GET" && !options.ignoreMethod) {
               return [];
             }
           } else if (typeof request === "string") {
-            r = new Request(request)[kState];
+            r2 = new Request(request)[kState];
           }
         }
         const promise = createDeferredPromise();
@@ -18073,7 +18074,7 @@ var require_cache = __commonJS({
             requests.push(requestResponse[0]);
           }
         } else {
-          const requestResponses = this.#queryCache(r, options);
+          const requestResponses = this.#queryCache(r2, options);
           for (const requestResponse of requestResponses) {
             requests.push(requestResponse[0]);
           }
@@ -18098,8 +18099,8 @@ var require_cache = __commonJS({
        * @returns {requestResponseList}
        */
       #batchCacheOperations(operations) {
-        const cache2 = this.#relevantRequestResponseList;
-        const backupCache = [...cache2];
+        const cache = this.#relevantRequestResponseList;
+        const backupCache = [...cache];
         const addedItems = [];
         const resultList = [];
         try {
@@ -18126,9 +18127,9 @@ var require_cache = __commonJS({
                 return [];
               }
               for (const requestResponse of requestResponses) {
-                const idx = cache2.indexOf(requestResponse);
+                const idx = cache.indexOf(requestResponse);
                 assert(idx !== -1);
-                cache2.splice(idx, 1);
+                cache.splice(idx, 1);
               }
             } else if (operation.type === "put") {
               if (operation.response == null) {
@@ -18137,14 +18138,14 @@ var require_cache = __commonJS({
                   message: "put operation should have an associated response"
                 });
               }
-              const r = operation.request;
-              if (!urlIsHttpHttpsScheme(r.url)) {
+              const r2 = operation.request;
+              if (!urlIsHttpHttpsScheme(r2.url)) {
                 throw webidl.errors.exception({
                   header: "Cache.#batchCacheOperations",
                   message: "expected http or https scheme"
                 });
               }
-              if (r.method !== "GET") {
+              if (r2.method !== "GET") {
                 throw webidl.errors.exception({
                   header: "Cache.#batchCacheOperations",
                   message: "not get method"
@@ -18158,11 +18159,11 @@ var require_cache = __commonJS({
               }
               requestResponses = this.#queryCache(operation.request);
               for (const requestResponse of requestResponses) {
-                const idx = cache2.indexOf(requestResponse);
+                const idx = cache.indexOf(requestResponse);
                 assert(idx !== -1);
-                cache2.splice(idx, 1);
+                cache.splice(idx, 1);
               }
-              cache2.push([operation.request, operation.response]);
+              cache.push([operation.request, operation.response]);
               addedItems.push([operation.request, operation.response]);
             }
             resultList.push([operation.request, operation.response]);
@@ -18227,15 +18228,15 @@ var require_cache = __commonJS({
         return true;
       }
       #internalMatchAll(request, options, maxResponses = Infinity) {
-        let r = null;
+        let r2 = null;
         if (request !== void 0) {
           if (request instanceof Request) {
-            r = request[kState];
-            if (r.method !== "GET" && !options.ignoreMethod) {
+            r2 = request[kState];
+            if (r2.method !== "GET" && !options.ignoreMethod) {
               return [];
             }
           } else if (typeof request === "string") {
-            r = new Request(request)[kState];
+            r2 = new Request(request)[kState];
           }
         }
         const responses = [];
@@ -18244,7 +18245,7 @@ var require_cache = __commonJS({
             responses.push(requestResponse[1]);
           }
         } else {
-          const requestResponses = this.#queryCache(r, options);
+          const requestResponses = this.#queryCache(r2, options);
           for (const requestResponse of requestResponses) {
             responses.push(requestResponse[1]);
           }
@@ -18339,13 +18340,13 @@ var require_cachestorage = __commonJS({
         if (options.cacheName != null) {
           if (this.#caches.has(options.cacheName)) {
             const cacheList = this.#caches.get(options.cacheName);
-            const cache2 = new Cache(kConstruct, cacheList);
-            return await cache2.match(request, options);
+            const cache = new Cache(kConstruct, cacheList);
+            return await cache.match(request, options);
           }
         } else {
           for (const cacheList of this.#caches.values()) {
-            const cache2 = new Cache(kConstruct, cacheList);
-            const response = await cache2.match(request, options);
+            const cache = new Cache(kConstruct, cacheList);
+            const response = await cache.match(request, options);
             if (response !== void 0) {
               return response;
             }
@@ -18375,12 +18376,12 @@ var require_cachestorage = __commonJS({
         webidl.argumentLengthCheck(arguments, 1, prefix);
         cacheName = webidl.converters.DOMString(cacheName, prefix, "cacheName");
         if (this.#caches.has(cacheName)) {
-          const cache3 = this.#caches.get(cacheName);
-          return new Cache(kConstruct, cache3);
+          const cache2 = this.#caches.get(cacheName);
+          return new Cache(kConstruct, cache2);
         }
-        const cache2 = [];
-        this.#caches.set(cacheName, cache2);
-        return new Cache(kConstruct, cache2);
+        const cache = [];
+        this.#caches.set(cacheName, cache);
+        return new Cache(kConstruct, cache);
       }
       /**
        * @see https://w3c.github.io/ServiceWorker/#cache-storage-delete
@@ -18439,8 +18440,8 @@ var require_util6 = __commonJS({
   "node_modules/undici/lib/web/cookies/util.js"(exports2, module2) {
     "use strict";
     function isCTLExcludingHtab(value) {
-      for (let i = 0; i < value.length; ++i) {
-        const code = value.charCodeAt(i);
+      for (let i2 = 0; i2 < value.length; ++i2) {
+        const code = value.charCodeAt(i2);
         if (code >= 0 && code <= 8 || code >= 10 && code <= 31 || code === 127) {
           return true;
         }
@@ -18449,8 +18450,8 @@ var require_util6 = __commonJS({
     }
     __name(isCTLExcludingHtab, "isCTLExcludingHtab");
     function validateCookieName(name) {
-      for (let i = 0; i < name.length; ++i) {
-        const code = name.charCodeAt(i);
+      for (let i2 = 0; i2 < name.length; ++i2) {
+        const code = name.charCodeAt(i2);
         if (code < 33 || // exclude CTLs (0-31), SP and HT
         code > 126 || // exclude non-ascii and DEL
         code === 34 || // "
@@ -18477,16 +18478,16 @@ var require_util6 = __commonJS({
     __name(validateCookieName, "validateCookieName");
     function validateCookieValue(value) {
       let len = value.length;
-      let i = 0;
+      let i2 = 0;
       if (value[0] === '"') {
         if (len === 1 || value[len - 1] !== '"') {
           throw new Error("Invalid cookie value");
         }
         --len;
-        ++i;
+        ++i2;
       }
-      while (i < len) {
-        const code = value.charCodeAt(i++);
+      while (i2 < len) {
+        const code = value.charCodeAt(i2++);
         if (code < 33 || // exclude CTLs (0-31)
         code > 126 || // non-ascii and DEL (127)
         code === 34 || // "
@@ -18499,8 +18500,8 @@ var require_util6 = __commonJS({
     }
     __name(validateCookieValue, "validateCookieValue");
     function validateCookiePath(path5) {
-      for (let i = 0; i < path5.length; ++i) {
-        const code = path5.charCodeAt(i);
+      for (let i2 = 0; i2 < path5.length; ++i2) {
+        const code = path5.charCodeAt(i2);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18538,7 +18539,7 @@ var require_util6 = __commonJS({
       "Nov",
       "Dec"
     ];
-    var IMFPaddedNumbers = Array(61).fill(0).map((_, i) => i.toString().padStart(2, "0"));
+    var IMFPaddedNumbers = Array(61).fill(0).map((_, i2) => i2.toString().padStart(2, "0"));
     function toIMFDate(date) {
       if (typeof date === "number") {
         date = new Date(date);
@@ -19304,8 +19305,8 @@ var require_util7 = __commonJS({
       if (protocol.length === 0) {
         return false;
       }
-      for (let i = 0; i < protocol.length; ++i) {
-        const code = protocol.charCodeAt(i);
+      for (let i2 = 0; i2 < protocol.length; ++i2) {
+        const code = protocol.charCodeAt(i2);
         if (code < 33 || // CTL, contains SP (0x20) and HT (0x09)
         code > 126 || code === 34 || // "
         code === 40 || // (
@@ -19388,8 +19389,8 @@ var require_util7 = __commonJS({
       if (value.length === 0) {
         return false;
       }
-      for (let i = 0; i < value.length; i++) {
-        const byte = value.charCodeAt(i);
+      for (let i2 = 0; i2 < value.length; i2++) {
+        const byte = value.charCodeAt(i2);
         if (byte < 48 || byte > 57) {
           return false;
         }
@@ -19442,8 +19443,8 @@ var require_frame = __commonJS({
       crypto2 = {
         // not full compatibility, but minimum.
         randomFillSync: /* @__PURE__ */ __name(function randomFillSync(buffer2, _offset, _size) {
-          for (let i = 0; i < buffer2.length; ++i) {
-            buffer2[i] = Math.random() * 255 | 0;
+          for (let i2 = 0; i2 < buffer2.length; ++i2) {
+            buffer2[i2] = Math.random() * 255 | 0;
           }
           return buffer2;
         }, "randomFillSync")
@@ -19496,8 +19497,8 @@ var require_frame = __commonJS({
           buffer2.writeUIntBE(bodyLength, 4, 6);
         }
         buffer2[1] |= 128;
-        for (let i = 0; i < bodyLength; ++i) {
-          buffer2[offset + i] = frameData[i] ^ maskKey[i & 3];
+        for (let i2 = 0; i2 < bodyLength; ++i2) {
+          buffer2[offset + i2] = frameData[i2] ^ maskKey[i2 & 3];
         }
         return buffer2;
       }
@@ -20594,8 +20595,8 @@ var require_util8 = __commonJS({
     __name(isValidLastEventId, "isValidLastEventId");
     function isASCIINumber(value) {
       if (value.length === 0) return false;
-      for (let i = 0; i < value.length; i++) {
-        if (value.charCodeAt(i) < 48 || value.charCodeAt(i) > 57) return false;
+      for (let i2 = 0; i2 < value.length; i2++) {
+        if (value.charCodeAt(i2) < 48 || value.charCodeAt(i2) > 57) return false;
       }
       return true;
     }
@@ -21348,7 +21349,7 @@ var require_re = __commonJS({
     var safeRe = exports2.safeRe = [];
     var src = exports2.src = [];
     var safeSrc = exports2.safeSrc = [];
-    var t = exports2.t = {};
+    var t2 = exports2.t = {};
     var R = 0;
     var LETTERDASHNUMBER = "[a-zA-Z0-9-]";
     var safeRegexReplacements = [
@@ -21366,7 +21367,7 @@ var require_re = __commonJS({
       const safe = makeSafeRegex(value);
       const index = R++;
       debug3(name, index, value);
-      t[name] = index;
+      t2[name] = index;
       src[index] = value;
       safeSrc[index] = safe;
       re[index] = new RegExp(value, isGlobal ? "g" : void 0);
@@ -21375,52 +21376,52 @@ var require_re = __commonJS({
     createToken("NUMERICIDENTIFIER", "0|[1-9]\\d*");
     createToken("NUMERICIDENTIFIERLOOSE", "\\d+");
     createToken("NONNUMERICIDENTIFIER", `\\d*[a-zA-Z-]${LETTERDASHNUMBER}*`);
-    createToken("MAINVERSION", `(${src[t.NUMERICIDENTIFIER]})\\.(${src[t.NUMERICIDENTIFIER]})\\.(${src[t.NUMERICIDENTIFIER]}\
+    createToken("MAINVERSION", `(${src[t2.NUMERICIDENTIFIER]})\\.(${src[t2.NUMERICIDENTIFIER]})\\.(${src[t2.NUMERICIDENTIFIER]}\
 )`);
-    createToken("MAINVERSIONLOOSE", `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.(${src[t.NUMERICIDENTIFIERLOOSE]})\\.(${src[t.
+    createToken("MAINVERSIONLOOSE", `(${src[t2.NUMERICIDENTIFIERLOOSE]})\\.(${src[t2.NUMERICIDENTIFIERLOOSE]})\\.(${src[t2.
     NUMERICIDENTIFIERLOOSE]})`);
-    createToken("PRERELEASEIDENTIFIER", `(?:${src[t.NONNUMERICIDENTIFIER]}|${src[t.NUMERICIDENTIFIER]})`);
-    createToken("PRERELEASEIDENTIFIERLOOSE", `(?:${src[t.NONNUMERICIDENTIFIER]}|${src[t.NUMERICIDENTIFIERLOOSE]})`);
-    createToken("PRERELEASE", `(?:-(${src[t.PRERELEASEIDENTIFIER]}(?:\\.${src[t.PRERELEASEIDENTIFIER]})*))`);
-    createToken("PRERELEASELOOSE", `(?:-?(${src[t.PRERELEASEIDENTIFIERLOOSE]}(?:\\.${src[t.PRERELEASEIDENTIFIERLOOSE]})*\
-))`);
+    createToken("PRERELEASEIDENTIFIER", `(?:${src[t2.NONNUMERICIDENTIFIER]}|${src[t2.NUMERICIDENTIFIER]})`);
+    createToken("PRERELEASEIDENTIFIERLOOSE", `(?:${src[t2.NONNUMERICIDENTIFIER]}|${src[t2.NUMERICIDENTIFIERLOOSE]})`);
+    createToken("PRERELEASE", `(?:-(${src[t2.PRERELEASEIDENTIFIER]}(?:\\.${src[t2.PRERELEASEIDENTIFIER]})*))`);
+    createToken("PRERELEASELOOSE", `(?:-?(${src[t2.PRERELEASEIDENTIFIERLOOSE]}(?:\\.${src[t2.PRERELEASEIDENTIFIERLOOSE]}\
+)*))`);
     createToken("BUILDIDENTIFIER", `${LETTERDASHNUMBER}+`);
-    createToken("BUILD", `(?:\\+(${src[t.BUILDIDENTIFIER]}(?:\\.${src[t.BUILDIDENTIFIER]})*))`);
-    createToken("FULLPLAIN", `v?${src[t.MAINVERSION]}${src[t.PRERELEASE]}?${src[t.BUILD]}?`);
-    createToken("FULL", `^${src[t.FULLPLAIN]}$`);
-    createToken("LOOSEPLAIN", `[v=\\s]*${src[t.MAINVERSIONLOOSE]}${src[t.PRERELEASELOOSE]}?${src[t.BUILD]}?`);
-    createToken("LOOSE", `^${src[t.LOOSEPLAIN]}$`);
+    createToken("BUILD", `(?:\\+(${src[t2.BUILDIDENTIFIER]}(?:\\.${src[t2.BUILDIDENTIFIER]})*))`);
+    createToken("FULLPLAIN", `v?${src[t2.MAINVERSION]}${src[t2.PRERELEASE]}?${src[t2.BUILD]}?`);
+    createToken("FULL", `^${src[t2.FULLPLAIN]}$`);
+    createToken("LOOSEPLAIN", `[v=\\s]*${src[t2.MAINVERSIONLOOSE]}${src[t2.PRERELEASELOOSE]}?${src[t2.BUILD]}?`);
+    createToken("LOOSE", `^${src[t2.LOOSEPLAIN]}$`);
     createToken("GTLT", "((?:<|>)?=?)");
-    createToken("XRANGEIDENTIFIERLOOSE", `${src[t.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`);
-    createToken("XRANGEIDENTIFIER", `${src[t.NUMERICIDENTIFIER]}|x|X|\\*`);
-    createToken("XRANGEPLAIN", `[v=\\s]*(${src[t.XRANGEIDENTIFIER]})(?:\\.(${src[t.XRANGEIDENTIFIER]})(?:\\.(${src[t.XRANGEIDENTIFIER]}\
-)(?:${src[t.PRERELEASE]})?${src[t.BUILD]}?)?)?`);
-    createToken("XRANGEPLAINLOOSE", `[v=\\s]*(${src[t.XRANGEIDENTIFIERLOOSE]})(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})(?:\
-\\.(${src[t.XRANGEIDENTIFIERLOOSE]})(?:${src[t.PRERELEASELOOSE]})?${src[t.BUILD]}?)?)?`);
-    createToken("XRANGE", `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAIN]}$`);
-    createToken("XRANGELOOSE", `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("XRANGEIDENTIFIERLOOSE", `${src[t2.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`);
+    createToken("XRANGEIDENTIFIER", `${src[t2.NUMERICIDENTIFIER]}|x|X|\\*`);
+    createToken("XRANGEPLAIN", `[v=\\s]*(${src[t2.XRANGEIDENTIFIER]})(?:\\.(${src[t2.XRANGEIDENTIFIER]})(?:\\.(${src[t2.
+    XRANGEIDENTIFIER]})(?:${src[t2.PRERELEASE]})?${src[t2.BUILD]}?)?)?`);
+    createToken("XRANGEPLAINLOOSE", `[v=\\s]*(${src[t2.XRANGEIDENTIFIERLOOSE]})(?:\\.(${src[t2.XRANGEIDENTIFIERLOOSE]})(\
+?:\\.(${src[t2.XRANGEIDENTIFIERLOOSE]})(?:${src[t2.PRERELEASELOOSE]})?${src[t2.BUILD]}?)?)?`);
+    createToken("XRANGE", `^${src[t2.GTLT]}\\s*${src[t2.XRANGEPLAIN]}$`);
+    createToken("XRANGELOOSE", `^${src[t2.GTLT]}\\s*${src[t2.XRANGEPLAINLOOSE]}$`);
     createToken("COERCEPLAIN", `${"(^|[^\\d])(\\d{1,"}${MAX_SAFE_COMPONENT_LENGTH}})(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}\
 }))?(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?`);
-    createToken("COERCE", `${src[t.COERCEPLAIN]}(?:$|[^\\d])`);
-    createToken("COERCEFULL", src[t.COERCEPLAIN] + `(?:${src[t.PRERELEASE]})?(?:${src[t.BUILD]})?(?:$|[^\\d])`);
-    createToken("COERCERTL", src[t.COERCE], true);
-    createToken("COERCERTLFULL", src[t.COERCEFULL], true);
+    createToken("COERCE", `${src[t2.COERCEPLAIN]}(?:$|[^\\d])`);
+    createToken("COERCEFULL", src[t2.COERCEPLAIN] + `(?:${src[t2.PRERELEASE]})?(?:${src[t2.BUILD]})?(?:$|[^\\d])`);
+    createToken("COERCERTL", src[t2.COERCE], true);
+    createToken("COERCERTLFULL", src[t2.COERCEFULL], true);
     createToken("LONETILDE", "(?:~>?)");
-    createToken("TILDETRIM", `(\\s*)${src[t.LONETILDE]}\\s+`, true);
+    createToken("TILDETRIM", `(\\s*)${src[t2.LONETILDE]}\\s+`, true);
     exports2.tildeTrimReplace = "$1~";
-    createToken("TILDE", `^${src[t.LONETILDE]}${src[t.XRANGEPLAIN]}$`);
-    createToken("TILDELOOSE", `^${src[t.LONETILDE]}${src[t.XRANGEPLAINLOOSE]}$`);
+    createToken("TILDE", `^${src[t2.LONETILDE]}${src[t2.XRANGEPLAIN]}$`);
+    createToken("TILDELOOSE", `^${src[t2.LONETILDE]}${src[t2.XRANGEPLAINLOOSE]}$`);
     createToken("LONECARET", "(?:\\^)");
-    createToken("CARETTRIM", `(\\s*)${src[t.LONECARET]}\\s+`, true);
+    createToken("CARETTRIM", `(\\s*)${src[t2.LONECARET]}\\s+`, true);
     exports2.caretTrimReplace = "$1^";
-    createToken("CARET", `^${src[t.LONECARET]}${src[t.XRANGEPLAIN]}$`);
-    createToken("CARETLOOSE", `^${src[t.LONECARET]}${src[t.XRANGEPLAINLOOSE]}$`);
-    createToken("COMPARATORLOOSE", `^${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]})$|^$`);
-    createToken("COMPARATOR", `^${src[t.GTLT]}\\s*(${src[t.FULLPLAIN]})$|^$`);
-    createToken("COMPARATORTRIM", `(\\s*)${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]}|${src[t.XRANGEPLAIN]})`, true);
+    createToken("CARET", `^${src[t2.LONECARET]}${src[t2.XRANGEPLAIN]}$`);
+    createToken("CARETLOOSE", `^${src[t2.LONECARET]}${src[t2.XRANGEPLAINLOOSE]}$`);
+    createToken("COMPARATORLOOSE", `^${src[t2.GTLT]}\\s*(${src[t2.LOOSEPLAIN]})$|^$`);
+    createToken("COMPARATOR", `^${src[t2.GTLT]}\\s*(${src[t2.FULLPLAIN]})$|^$`);
+    createToken("COMPARATORTRIM", `(\\s*)${src[t2.GTLT]}\\s*(${src[t2.LOOSEPLAIN]}|${src[t2.XRANGEPLAIN]})`, true);
     exports2.comparatorTrimReplace = "$1$2$3";
-    createToken("HYPHENRANGE", `^\\s*(${src[t.XRANGEPLAIN]})\\s+-\\s+(${src[t.XRANGEPLAIN]})\\s*$`);
-    createToken("HYPHENRANGELOOSE", `^\\s*(${src[t.XRANGEPLAINLOOSE]})\\s+-\\s+(${src[t.XRANGEPLAINLOOSE]})\\s*$`);
+    createToken("HYPHENRANGE", `^\\s*(${src[t2.XRANGEPLAIN]})\\s+-\\s+(${src[t2.XRANGEPLAIN]})\\s*$`);
+    createToken("HYPHENRANGELOOSE", `^\\s*(${src[t2.XRANGEPLAINLOOSE]})\\s+-\\s+(${src[t2.XRANGEPLAINLOOSE]})\\s*$`);
     createToken("STAR", "(<|>)?=?\\s*\\*");
     createToken("GTE0", "^\\s*>=\\s*0\\.0\\.0\\s*$");
     createToken("GTE0PRE", "^\\s*>=\\s*0\\.0\\.0-0\\s*$");
@@ -21477,7 +21478,7 @@ var require_semver = __commonJS({
     "use strict";
     var debug3 = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants6();
-    var { safeRe: re, t } = require_re();
+    var { safeRe: re, t: t2 } = require_re();
     var parseOptions = require_parse_options();
     var { compareIdentifiers } = require_identifiers();
     var SemVer = class _SemVer {
@@ -21504,7 +21505,7 @@ var require_semver = __commonJS({
         this.options = options;
         this.loose = !!options.loose;
         this.includePrerelease = !!options.includePrerelease;
-        const m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL]);
+        const m = version.trim().match(options.loose ? re[t2.LOOSE] : re[t2.FULL]);
         if (!m) {
           throw new TypeError(`Invalid Version: ${version}`);
         }
@@ -21595,11 +21596,11 @@ var require_semver = __commonJS({
         } else if (!this.prerelease.length && !other.prerelease.length) {
           return 0;
         }
-        let i = 0;
+        let i2 = 0;
         do {
-          const a = this.prerelease[i];
-          const b = other.prerelease[i];
-          debug3("prerelease compare", i, a, b);
+          const a = this.prerelease[i2];
+          const b = other.prerelease[i2];
+          debug3("prerelease compare", i2, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -21611,17 +21612,17 @@ var require_semver = __commonJS({
           } else {
             return compareIdentifiers(a, b);
           }
-        } while (++i);
+        } while (++i2);
       }
       compareBuild(other) {
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        let i = 0;
+        let i2 = 0;
         do {
-          const a = this.build[i];
-          const b = other.build[i];
-          debug3("build compare", i, a, b);
+          const a = this.build[i2];
+          const b = other.build[i2];
+          debug3("build compare", i2, a, b);
           if (a === void 0 && b === void 0) {
             return 0;
           } else if (b === void 0) {
@@ -21633,7 +21634,7 @@ var require_semver = __commonJS({
           } else {
             return compareIdentifiers(a, b);
           }
-        } while (++i);
+        } while (++i2);
       }
       // preminor will bump the version up to the next minor release, and immediately
       // down to pre-release. premajor and prepatch work the same way.
@@ -21643,7 +21644,7 @@ var require_semver = __commonJS({
             throw new Error("invalid increment argument: identifier is empty");
           }
           if (identifier) {
-            const match = `-${identifier}`.match(this.options.loose ? re[t.PRERELEASELOOSE] : re[t.PRERELEASE]);
+            const match = `-${identifier}`.match(this.options.loose ? re[t2.PRERELEASELOOSE] : re[t2.PRERELEASE]);
             if (!match || match[1] !== identifier) {
               throw new Error(`invalid identifier: ${identifier}`);
             }
@@ -21710,14 +21711,14 @@ var require_semver = __commonJS({
             if (this.prerelease.length === 0) {
               this.prerelease = [base];
             } else {
-              let i = this.prerelease.length;
-              while (--i >= 0) {
-                if (typeof this.prerelease[i] === "number") {
-                  this.prerelease[i]++;
-                  i = -2;
+              let i2 = this.prerelease.length;
+              while (--i2 >= 0) {
+                if (typeof this.prerelease[i2] === "number") {
+                  this.prerelease[i2]++;
+                  i2 = -2;
                 }
               }
-              if (i === -1) {
+              if (i2 === -1) {
                 if (identifier === this.prerelease.join(".") && identifierBase === false) {
                   throw new Error("invalid increment argument: identifier already exists");
                 }
@@ -22092,7 +22093,7 @@ var require_coerce = __commonJS({
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse2();
-    var { safeRe: re, t } = require_re();
+    var { safeRe: re, t: t2 } = require_re();
     var coerce = /* @__PURE__ */ __name((version, options) => {
       if (version instanceof SemVer) {
         return version;
@@ -22106,9 +22107,9 @@ var require_coerce = __commonJS({
       options = options || {};
       let match = null;
       if (!options.rtl) {
-        match = version.match(options.includePrerelease ? re[t.COERCEFULL] : re[t.COERCE]);
+        match = version.match(options.includePrerelease ? re[t2.COERCEFULL] : re[t2.COERCE]);
       } else {
-        const coerceRtlRegex = options.includePrerelease ? re[t.COERCERTLFULL] : re[t.COERCERTL];
+        const coerceRtlRegex = options.includePrerelease ? re[t2.COERCERTLFULL] : re[t2.COERCERTL];
         let next;
         while ((next = coerceRtlRegex.exec(version)) && (!match || match.index + match[0].length !== version.length)) {
           if (!match || next.index + next[0].length !== match.index + match[0].length) {
@@ -22201,19 +22202,19 @@ var require_range = __commonJS({
         this.loose = !!options.loose;
         this.includePrerelease = !!options.includePrerelease;
         this.raw = range.trim().replace(SPACE_CHARACTERS, " ");
-        this.set = this.raw.split("||").map((r) => this.parseRange(r.trim())).filter((c) => c.length);
+        this.set = this.raw.split("||").map((r2) => this.parseRange(r2.trim())).filter((c3) => c3.length);
         if (!this.set.length) {
           throw new TypeError(`Invalid SemVer Range: ${this.raw}`);
         }
         if (this.set.length > 1) {
           const first2 = this.set[0];
-          this.set = this.set.filter((c) => !isNullSet(c[0]));
+          this.set = this.set.filter((c3) => !isNullSet(c3[0]));
           if (this.set.length === 0) {
             this.set = [first2];
           } else if (this.set.length > 1) {
-            for (const c of this.set) {
-              if (c.length === 1 && isAny(c[0])) {
-                this.set = [c];
+            for (const c3 of this.set) {
+              if (c3.length === 1 && isAny(c3[0])) {
+                this.set = [c3];
                 break;
               }
             }
@@ -22224,11 +22225,11 @@ var require_range = __commonJS({
       get range() {
         if (this.formatted === void 0) {
           this.formatted = "";
-          for (let i = 0; i < this.set.length; i++) {
-            if (i > 0) {
+          for (let i2 = 0; i2 < this.set.length; i2++) {
+            if (i2 > 0) {
               this.formatted += "||";
             }
-            const comps = this.set[i];
+            const comps = this.set[i2];
             for (let k = 0; k < comps.length; k++) {
               if (k > 0) {
                 this.formatted += " ";
@@ -22248,26 +22249,26 @@ var require_range = __commonJS({
       parseRange(range) {
         const memoOpts = (this.options.includePrerelease && FLAG_INCLUDE_PRERELEASE) | (this.options.loose && FLAG_LOOSE);
         const memoKey = memoOpts + ":" + range;
-        const cached = cache2.get(memoKey);
+        const cached = cache.get(memoKey);
         if (cached) {
           return cached;
         }
         const loose = this.options.loose;
-        const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
+        const hr = loose ? re[t2.HYPHENRANGELOOSE] : re[t2.HYPHENRANGE];
         range = range.replace(hr, hyphenReplace(this.options.includePrerelease));
         debug3("hyphen replace", range);
-        range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
+        range = range.replace(re[t2.COMPARATORTRIM], comparatorTrimReplace);
         debug3("comparator trim", range);
-        range = range.replace(re[t.TILDETRIM], tildeTrimReplace);
+        range = range.replace(re[t2.TILDETRIM], tildeTrimReplace);
         debug3("tilde trim", range);
-        range = range.replace(re[t.CARETTRIM], caretTrimReplace);
+        range = range.replace(re[t2.CARETTRIM], caretTrimReplace);
         debug3("caret trim", range);
         let rangeList = range.split(" ").map((comp) => parseComparator(comp, this.options)).join(" ").split(/\s+/).map((comp) => replaceGTE0(
         comp, this.options));
         if (loose) {
           rangeList = rangeList.filter((comp) => {
             debug3("loose invalid filter", comp, this.options);
-            return !!comp.match(re[t.COMPARATORLOOSE]);
+            return !!comp.match(re[t2.COMPARATORLOOSE]);
           });
         }
         debug3("range list", rangeList);
@@ -22283,7 +22284,7 @@ var require_range = __commonJS({
           rangeMap.delete("");
         }
         const result = [...rangeMap.values()];
-        cache2.set(memoKey, result);
+        cache.set(memoKey, result);
         return result;
       }
       intersects(range, options) {
@@ -22312,8 +22313,8 @@ var require_range = __commonJS({
             return false;
           }
         }
-        for (let i = 0; i < this.set.length; i++) {
-          if (testSet(this.set[i], version, this.options)) {
+        for (let i2 = 0; i2 < this.set.length; i2++) {
+          if (testSet(this.set[i2], version, this.options)) {
             return true;
           }
         }
@@ -22322,21 +22323,21 @@ var require_range = __commonJS({
     };
     module2.exports = Range;
     var LRU = require_lrucache();
-    var cache2 = new LRU();
+    var cache = new LRU();
     var parseOptions = require_parse_options();
     var Comparator = require_comparator();
     var debug3 = require_debug();
     var SemVer = require_semver();
     var {
       safeRe: re,
-      t,
+      t: t2,
       comparatorTrimReplace,
       tildeTrimReplace,
       caretTrimReplace
     } = require_re();
     var { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = require_constants6();
-    var isNullSet = /* @__PURE__ */ __name((c) => c.value === "<0.0.0-0", "isNullSet");
-    var isAny = /* @__PURE__ */ __name((c) => c.value === "", "isAny");
+    var isNullSet = /* @__PURE__ */ __name((c3) => c3.value === "<0.0.0-0", "isNullSet");
+    var isAny = /* @__PURE__ */ __name((c3) => c3.value === "", "isAny");
     var isSatisfiable = /* @__PURE__ */ __name((comparators, options) => {
       let result = true;
       const remainingComparators = comparators.slice();
@@ -22350,7 +22351,7 @@ var require_range = __commonJS({
       return result;
     }, "isSatisfiable");
     var parseComparator = /* @__PURE__ */ __name((comp, options) => {
-      comp = comp.replace(re[t.BUILD], "");
+      comp = comp.replace(re[t2.BUILD], "");
       debug3("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug3("caret", comp);
@@ -22364,11 +22365,11 @@ var require_range = __commonJS({
     }, "parseComparator");
     var isX = /* @__PURE__ */ __name((id) => !id || id.toLowerCase() === "x" || id === "*", "isX");
     var replaceTildes = /* @__PURE__ */ __name((comp, options) => {
-      return comp.trim().split(/\s+/).map((c) => replaceTilde(c, options)).join(" ");
+      return comp.trim().split(/\s+/).map((c3) => replaceTilde(c3, options)).join(" ");
     }, "replaceTildes");
     var replaceTilde = /* @__PURE__ */ __name((comp, options) => {
-      const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
-      return comp.replace(r, (_, M, m, p, pr) => {
+      const r2 = options.loose ? re[t2.TILDELOOSE] : re[t2.TILDE];
+      return comp.replace(r2, (_, M, m, p, pr) => {
         debug3("tilde", comp, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
@@ -22388,13 +22389,13 @@ var require_range = __commonJS({
       });
     }, "replaceTilde");
     var replaceCarets = /* @__PURE__ */ __name((comp, options) => {
-      return comp.trim().split(/\s+/).map((c) => replaceCaret(c, options)).join(" ");
+      return comp.trim().split(/\s+/).map((c3) => replaceCaret(c3, options)).join(" ");
     }, "replaceCarets");
     var replaceCaret = /* @__PURE__ */ __name((comp, options) => {
       debug3("caret", comp, options);
-      const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET];
+      const r2 = options.loose ? re[t2.CARETLOOSE] : re[t2.CARET];
       const z = options.includePrerelease ? "-0" : "";
-      return comp.replace(r, (_, M, m, p, pr) => {
+      return comp.replace(r2, (_, M, m, p, pr) => {
         debug3("caret", comp, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
@@ -22436,12 +22437,12 @@ var require_range = __commonJS({
     }, "replaceCaret");
     var replaceXRanges = /* @__PURE__ */ __name((comp, options) => {
       debug3("replaceXRanges", comp, options);
-      return comp.split(/\s+/).map((c) => replaceXRange(c, options)).join(" ");
+      return comp.split(/\s+/).map((c3) => replaceXRange(c3, options)).join(" ");
     }, "replaceXRanges");
     var replaceXRange = /* @__PURE__ */ __name((comp, options) => {
       comp = comp.trim();
-      const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
-      return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
+      const r2 = options.loose ? re[t2.XRANGELOOSE] : re[t2.XRANGE];
+      return comp.replace(r2, (ret, gtlt, M, m, p, pr) => {
         debug3("xRange", comp, ret, gtlt, M, m, p, pr);
         const xM = isX(M);
         const xm = xM || isX(m);
@@ -22495,11 +22496,11 @@ var require_range = __commonJS({
     }, "replaceXRange");
     var replaceStars = /* @__PURE__ */ __name((comp, options) => {
       debug3("replaceStars", comp, options);
-      return comp.trim().replace(re[t.STAR], "");
+      return comp.trim().replace(re[t2.STAR], "");
     }, "replaceStars");
     var replaceGTE0 = /* @__PURE__ */ __name((comp, options) => {
       debug3("replaceGTE0", comp, options);
-      return comp.trim().replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], "");
+      return comp.trim().replace(re[options.includePrerelease ? t2.GTE0PRE : t2.GTE0], "");
     }, "replaceGTE0");
     var hyphenReplace = /* @__PURE__ */ __name((incPr) => ($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr) => {
       if (isX(fM)) {
@@ -22529,19 +22530,19 @@ var require_range = __commonJS({
       return `${from} ${to}`.trim();
     }, "hyphenReplace");
     var testSet = /* @__PURE__ */ __name((set, version, options) => {
-      for (let i = 0; i < set.length; i++) {
-        if (!set[i].test(version)) {
+      for (let i2 = 0; i2 < set.length; i2++) {
+        if (!set[i2].test(version)) {
           return false;
         }
       }
       if (version.prerelease.length && !options.includePrerelease) {
-        for (let i = 0; i < set.length; i++) {
-          debug3(set[i].semver);
-          if (set[i].semver === Comparator.ANY) {
+        for (let i2 = 0; i2 < set.length; i2++) {
+          debug3(set[i2].semver);
+          if (set[i2].semver === Comparator.ANY) {
             continue;
           }
-          if (set[i].semver.prerelease.length > 0) {
-            const allowed = set[i].semver;
+          if (set[i2].semver.prerelease.length > 0) {
+            const allowed = set[i2].semver;
             if (allowed.major === version.major && allowed.minor === version.minor && allowed.patch === version.patch) {
               return true;
             }
@@ -22588,8 +22589,8 @@ var require_comparator = __commonJS({
         debug3("comp", this);
       }
       parse(comp) {
-        const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
-        const m = comp.match(r);
+        const r2 = this.options.loose ? re[t2.COMPARATORLOOSE] : re[t2.COMPARATOR];
+        const m = comp.match(r2);
         if (!m) {
           throw new TypeError(`Invalid comparator: ${comp}`);
         }
@@ -22662,7 +22663,7 @@ var require_comparator = __commonJS({
     };
     module2.exports = Comparator;
     var parseOptions = require_parse_options();
-    var { safeRe: re, t } = require_re();
+    var { safeRe: re, t: t2 } = require_re();
     var cmp = require_cmp();
     var debug3 = require_debug();
     var SemVer = require_semver();
@@ -22693,7 +22694,7 @@ var require_to_comparators = __commonJS({
     "use strict";
     var Range = require_range();
     var toComparators = /* @__PURE__ */ __name((range, options) => new Range(range, options).set.map((comp) => comp.map(
-    (c) => c.value).join(" ").trim().split(" ")), "toComparators");
+    (c3) => c3.value).join(" ").trim().split(" ")), "toComparators");
     module2.exports = toComparators;
   }
 });
@@ -22774,8 +22775,8 @@ var require_min_version = __commonJS({
         return minver;
       }
       minver = null;
-      for (let i = 0; i < range.set.length; ++i) {
-        const comparators = range.set[i];
+      for (let i2 = 0; i2 < range.set.length; ++i2) {
+        const comparators = range.set[i2];
         let setMin = null;
         comparators.forEach((comparator) => {
           const compver = new SemVer(comparator.semver.version);
@@ -22869,8 +22870,8 @@ var require_outside = __commonJS({
       if (satisfies3(version, range, options)) {
         return false;
       }
-      for (let i = 0; i < range.set.length; ++i) {
-        const comparators = range.set[i];
+      for (let i2 = 0; i2 < range.set.length; ++i2) {
+        const comparators = range.set[i2];
         let high = null;
         let low = null;
         comparators.forEach((comparator) => {
@@ -23038,13 +23039,13 @@ var require_subset = __commonJS({
       }
       const eqSet = /* @__PURE__ */ new Set();
       let gt2, lt;
-      for (const c of sub) {
-        if (c.operator === ">" || c.operator === ">=") {
-          gt2 = higherGT(gt2, c, options);
-        } else if (c.operator === "<" || c.operator === "<=") {
-          lt = lowerLT(lt, c, options);
+      for (const c3 of sub) {
+        if (c3.operator === ">" || c3.operator === ">=") {
+          gt2 = higherGT(gt2, c3, options);
+        } else if (c3.operator === "<" || c3.operator === "<=") {
+          lt = lowerLT(lt, c3, options);
         } else {
-          eqSet.add(c.semver);
+          eqSet.add(c3.semver);
         }
       }
       if (eqSet.size > 1) {
@@ -23066,8 +23067,8 @@ var require_subset = __commonJS({
         if (lt && !satisfies3(eq, String(lt), options)) {
           return null;
         }
-        for (const c of dom) {
-          if (!satisfies3(eq, String(c), options)) {
+        for (const c3 of dom) {
+          if (!satisfies3(eq, String(c3), options)) {
             return false;
           }
         }
@@ -23080,42 +23081,42 @@ var require_subset = __commonJS({
       if (needDomLTPre && needDomLTPre.prerelease.length === 1 && lt.operator === "<" && needDomLTPre.prerelease[0] === 0) {
         needDomLTPre = false;
       }
-      for (const c of dom) {
-        hasDomGT = hasDomGT || c.operator === ">" || c.operator === ">=";
-        hasDomLT = hasDomLT || c.operator === "<" || c.operator === "<=";
+      for (const c3 of dom) {
+        hasDomGT = hasDomGT || c3.operator === ">" || c3.operator === ">=";
+        hasDomLT = hasDomLT || c3.operator === "<" || c3.operator === "<=";
         if (gt2) {
           if (needDomGTPre) {
-            if (c.semver.prerelease && c.semver.prerelease.length && c.semver.major === needDomGTPre.major && c.semver.minor ===
-            needDomGTPre.minor && c.semver.patch === needDomGTPre.patch) {
+            if (c3.semver.prerelease && c3.semver.prerelease.length && c3.semver.major === needDomGTPre.major && c3.semver.
+            minor === needDomGTPre.minor && c3.semver.patch === needDomGTPre.patch) {
               needDomGTPre = false;
             }
           }
-          if (c.operator === ">" || c.operator === ">=") {
-            higher = higherGT(gt2, c, options);
-            if (higher === c && higher !== gt2) {
+          if (c3.operator === ">" || c3.operator === ">=") {
+            higher = higherGT(gt2, c3, options);
+            if (higher === c3 && higher !== gt2) {
               return false;
             }
-          } else if (gt2.operator === ">=" && !satisfies3(gt2.semver, String(c), options)) {
+          } else if (gt2.operator === ">=" && !satisfies3(gt2.semver, String(c3), options)) {
             return false;
           }
         }
         if (lt) {
           if (needDomLTPre) {
-            if (c.semver.prerelease && c.semver.prerelease.length && c.semver.major === needDomLTPre.major && c.semver.minor ===
-            needDomLTPre.minor && c.semver.patch === needDomLTPre.patch) {
+            if (c3.semver.prerelease && c3.semver.prerelease.length && c3.semver.major === needDomLTPre.major && c3.semver.
+            minor === needDomLTPre.minor && c3.semver.patch === needDomLTPre.patch) {
               needDomLTPre = false;
             }
           }
-          if (c.operator === "<" || c.operator === "<=") {
-            lower = lowerLT(lt, c, options);
-            if (lower === c && lower !== lt) {
+          if (c3.operator === "<" || c3.operator === "<=") {
+            lower = lowerLT(lt, c3, options);
+            if (lower === c3 && lower !== lt) {
               return false;
             }
-          } else if (lt.operator === "<=" && !satisfies3(lt.semver, String(c), options)) {
+          } else if (lt.operator === "<=" && !satisfies3(lt.semver, String(c3), options)) {
             return false;
           }
         }
-        if (!c.operator && (lt || gt2) && gtltComp !== 0) {
+        if (!c3.operator && (lt || gt2) && gtltComp !== 0) {
           return false;
         }
       }
@@ -23244,12 +23245,125 @@ var require_semver2 = __commonJS({
 });
 
 // node_modules/simple-git/dist/esm/index.js
-var import_node_buffer = require("node:buffer");
 var import_file_exists = __toESM(require_dist(), 1);
+
+// node_modules/@simple-git/args-pathspec/dist/index.mjs
+var t = /* @__PURE__ */ new WeakMap();
+function c(...n) {
+  const e = new String(n);
+  return t.set(e, n), e;
+}
+__name(c, "c");
+function r(n) {
+  return n instanceof String && t.has(n);
+}
+__name(r, "r");
+
+// node_modules/simple-git/dist/esm/index.js
 var import_debug = __toESM(require_src(), 1);
 var import_child_process = require("child_process");
 var import_promise_deferred = __toESM(require_dist2(), 1);
 var import_node_path = require("node:path");
+
+// node_modules/@simple-git/argv-parser/dist/index.mjs
+var x = {
+  short: /* @__PURE__ */ new Map([
+    ["c", true]
+    //  -c <k=v>    set config key for this invocation
+  ])
+};
+var D = {
+  short: new Map([
+    ["C", true],
+    //  -C <path>   change working directory
+    ["P", false],
+    // -P          no pager (alias for --no-pager)
+    ["h", false],
+    // -h          help
+    ["p", false],
+    // -p          paginate
+    ["v", false],
+    // -v          version
+    ...x.short.entries()
+  ]),
+  long: /* @__PURE__ */ new Set([
+    "attr-source",
+    "config-env",
+    "exec-path",
+    "git-dir",
+    "list-cmds",
+    "namespace",
+    "super-prefix",
+    "work-tree"
+  ])
+};
+function c2(e, t2, n = String(e)) {
+  const o2 = typeof e == "string" ? new RegExp(`\\s*${e.toLowerCase()}`) : e;
+  return function(r2) {
+    if (o2.test(r2))
+      return {
+        category: t2,
+        message: `Configuring ${n} is not permitted without enabling ${t2}`
+      };
+  };
+}
+__name(c2, "c");
+function i(e, t2) {
+  const n = new RegExp(`\\s*${e.toLowerCase().replace(/\./g, "(..+)?.")}`);
+  return c2(n, t2, e);
+}
+__name(i, "i");
+var q = [
+  c2("alias", "allowUnsafeAlias"),
+  c2("core.askPass", "allowUnsafeAskPass"),
+  c2("core.editor", "allowUnsafeEditor"),
+  c2("core.fsmonitor", "allowUnsafeFsMonitor"),
+  c2("core.gitProxy", "allowUnsafeGitProxy"),
+  c2("core.hooksPath", "allowUnsafeHooksPath"),
+  c2("core.pager", "allowUnsafePager"),
+  c2("core.sshCommand", "allowUnsafeSshCommand"),
+  i("credential.helper", "allowUnsafeCredentialHelper"),
+  i("diff.command", "allowUnsafeDiffExternal"),
+  c2("diff.external", "allowUnsafeDiffExternal"),
+  i("diff.textconv", "allowUnsafeDiffTextConv"),
+  i("filter.clean", "allowUnsafeFilter"),
+  i("filter.smudge", "allowUnsafeFilter"),
+  i("gpg.program", "allowUnsafeGpgProgram"),
+  c2("init.templateDir", "allowUnsafeTemplateDir"),
+  i("merge.driver", "allowUnsafeMergeDriver"),
+  i("mergetool.path", "allowUnsafeMergeDriver"),
+  i("mergetool.cmd", "allowUnsafeMergeDriver"),
+  i("protocol.allow", "allowUnsafeProtocolOverride"),
+  i("remote.receivepack", "allowUnsafePack"),
+  i("remote.uploadpack", "allowUnsafePack"),
+  c2("sequence.editor", "allowUnsafeEditor")
+];
+function h(e, t2, n, o2 = String(t2)) {
+  const s = typeof t2 == "string" ? new RegExp(`\\s*${t2.toLowerCase()}`) : t2, r2 = `Use of ${e ? `${e} with option ` :
+  ""}${o2} is not permitted without enabling ${n}`;
+  return function(a, f) {
+    if ((!e || a === e) && s.test(f))
+      return {
+        category: n,
+        message: r2
+      };
+  };
+}
+__name(h, "h");
+var H = [
+  h(
+    null,
+    /--(upload|receive)-pack/,
+    "allowUnsafePack",
+    "--upload-pack or --receive-pack"
+  ),
+  h("clone", /^-\w*u/, "allowUnsafePack"),
+  h("clone", "--u", "allowUnsafePack"),
+  h("push", "--exec", "allowUnsafePack"),
+  h(null, "--template", "allowUnsafeTemplateDir")
+];
+
+// node_modules/simple-git/dist/esm/index.js
 var import_promise_deferred2 = __toESM(require_dist2(), 1);
 var __defProp2 = Object.defineProperty;
 var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
@@ -23276,23 +23390,6 @@ var __copyProps2 = /* @__PURE__ */ __name((to, from, except, desc) => {
 }, "__copyProps");
 var __toCommonJS = /* @__PURE__ */ __name((mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod), "__\
 toCommonJS");
-function pathspec(...paths) {
-  const key = new String(paths);
-  cache.set(key, paths);
-  return key;
-}
-__name(pathspec, "pathspec");
-function isPathSpec(path5) {
-  return path5 instanceof String && cache.has(path5);
-}
-__name(isPathSpec, "isPathSpec");
-var cache;
-var init_pathspec = __esm({
-  "src/lib/args/pathspec.ts"() {
-    "use strict";
-    cache = /* @__PURE__ */ new WeakMap();
-  }
-});
 var GitError;
 var init_git_error = __esm({
   "src/lib/errors/git-error.ts"() {
@@ -23447,14 +23544,14 @@ function asNumber(source, onNaN = 0) {
 __name(asNumber, "asNumber");
 function prefixedArray(input, prefix) {
   const output = [];
-  for (let i = 0, max = input.length; i < max; i++) {
-    output.push(prefix, input[i]);
+  for (let i2 = 0, max = input.length; i2 < max; i2++) {
+    output.push(prefix, input[i2]);
   }
   return output;
 }
 __name(prefixedArray, "prefixedArray");
 function bufferToString(input) {
-  return (Array.isArray(input) ? import_node_buffer.Buffer.concat(input) : input).toString("utf-8");
+  return (Array.isArray(input) ? Buffer.concat(input) : input).toString("utf-8");
 }
 __name(bufferToString, "bufferToString");
 function pick(source, properties) {
@@ -23499,7 +23596,7 @@ function filterType(input, filter, def) {
 }
 __name(filterType, "filterType");
 function filterPrimitives(input, omit) {
-  const type = isPathSpec(input) ? "string" : typeof input;
+  const type = r(input) ? "string" : typeof input;
   return /number|string|boolean/.test(type) && (!omit || !omit.includes(type));
 }
 __name(filterPrimitives, "filterPrimitives");
@@ -23519,7 +23616,6 @@ var filterHasLength;
 var init_argument_filters = __esm({
   "src/lib/utils/argument-filters.ts"() {
     "use strict";
-    init_pathspec();
     init_util();
     filterArray = /* @__PURE__ */ __name((input) => {
       return Array.isArray(input);
@@ -23528,7 +23624,7 @@ var init_argument_filters = __esm({
       return typeof input === "number";
     }, "filterNumber");
     filterString = /* @__PURE__ */ __name((input) => {
-      return typeof input === "string" || isPathSpec(input);
+      return typeof input === "string" || r(input);
     }, "filterString");
     filterStringOrStringArray = /* @__PURE__ */ __name((input) => {
       return filterString(input) || Array.isArray(input) && input.every(filterString);
@@ -23636,7 +23732,7 @@ function createInstanceConfig(...options) {
   const baseDir = process.cwd();
   const config = Object.assign(
     { baseDir, ...defaultOptions },
-    ...options.filter((o) => typeof o === "object" && o)
+    ...options.filter((o2) => typeof o2 === "object" && o2)
   );
   config.baseDir = config.baseDir || baseDir;
   config.trimmed = config.trimmed === true;
@@ -23661,7 +23757,7 @@ function appendTaskOptions(options, commands = []) {
   }
   return Object.keys(options).reduce((commands2, key) => {
     const value = options[key];
-    if (isPathSpec(value)) {
+    if (r(value)) {
       commands2.push(value);
     } else if (filterPrimitives(value, ["boolean"])) {
       commands2.push(key + "=" + value);
@@ -23680,9 +23776,9 @@ function appendTaskOptions(options, commands = []) {
 __name(appendTaskOptions, "appendTaskOptions");
 function getTrailingOptions(args, initialPrimitive = 0, objectOnly = false) {
   const command = [];
-  for (let i = 0, max = initialPrimitive < 0 ? args.length : initialPrimitive; i < max; i++) {
-    if ("string|number".includes(typeof args[i])) {
-      command.push(String(args[i]));
+  for (let i2 = 0, max = initialPrimitive < 0 ? args.length : initialPrimitive; i2 < max; i2++) {
+    if ("string|number".includes(typeof args[i2])) {
+      command.push(String(args[i2]));
     }
   }
   appendTaskOptions(trailingOptionsArgument(args), command);
@@ -23712,7 +23808,6 @@ var init_task_options = __esm({
     "use strict";
     init_argument_filters();
     init_util();
-    init_pathspec();
   }
 });
 function callTaskParser(parser4, streams) {
@@ -23721,12 +23816,12 @@ function callTaskParser(parser4, streams) {
 __name(callTaskParser, "callTaskParser");
 function parseStringResponse(result, parsers12, texts, trim = true) {
   asArray(texts).forEach((text) => {
-    for (let lines = toLinesWithContent(text, trim), i = 0, max = lines.length; i < max; i++) {
+    for (let lines = toLinesWithContent(text, trim), i2 = 0, max = lines.length; i2 < max; i2++) {
       const line = /* @__PURE__ */ __name((offset = 0) => {
-        if (i + offset >= max) {
+        if (i2 + offset >= max) {
           return;
         }
-        return lines[i + offset];
+        return lines[i2 + offset];
       }, "line");
       parsers12.some(({ parse }) => parse(line, result));
     }
@@ -24113,9 +24208,9 @@ function configFilePath(filePath) {
 __name(configFilePath, "configFilePath");
 function* configParser(text, requestedKey = null) {
   const lines = text.split("\0");
-  for (let i = 0, max = lines.length - 1; i < max; ) {
-    const file = configFilePath(lines[i++]);
-    let value = lines[i++];
+  for (let i2 = 0, max = lines.length - 1; i2 < max; ) {
+    const file = configFilePath(lines[i2++]);
+    let value = lines[i2++];
     let key = requestedKey;
     if (value.includes("\n")) {
       const line = splitOn(value, "\n");
@@ -24651,11 +24746,10 @@ var init_git_executor_chain = __esm({
       }
       async attemptRemoteTask(task, logger) {
         const binary = this._plugins.exec("spawn.binary", "", pluginContext(task, task.commands));
-        const args = this._plugins.exec(
-          "spawn.args",
-          [...task.commands],
-          pluginContext(task, task.commands)
-        );
+        const args = this._plugins.exec("spawn.args", [...task.commands], {
+          ...pluginContext(task, task.commands),
+          env: { ...this.env }
+        });
         const raw = await this.gitResponse(
           task,
           binary,
@@ -25177,8 +25271,8 @@ var init_init = __esm({
   }
 });
 function logFormatFromCommand(customArgs) {
-  for (let i = 0; i < customArgs.length; i++) {
-    const format = logFormatRegex.exec(customArgs[i]);
+  for (let i2 = 0; i2 < customArgs.length; i2++) {
+    const format = logFormatRegex.exec(customArgs[i2]);
     if (format) {
       return `--${format[1]}`;
     }
@@ -25484,7 +25578,7 @@ function parseLogOptions(opt = {}, customArgs = []) {
     suffix.push(`${opt.from || ""}${rangeOperator}${opt.to || ""}`);
   }
   if (filterString(opt.file)) {
-    command.push("--follow", pathspec(opt.file));
+    command.push("--follow", c(opt.file));
   }
   appendTaskOptions(userOptions(opt), command);
   return {
@@ -25532,7 +25626,6 @@ var init_log = __esm({
   "src/lib/tasks/log.ts"() {
     "use strict";
     init_log_format();
-    init_pathspec();
     init_parse_list_log_summary();
     init_utils();
     init_task();
@@ -26207,13 +26300,13 @@ var init_StatusSummary = __esm({
     parseStatusSummary = /* @__PURE__ */ __name(function(text) {
       const lines = text.split(NULL);
       const status = new StatusSummary();
-      for (let i = 0, l = lines.length; i < l; ) {
-        let line = lines[i++].trim();
+      for (let i2 = 0, l = lines.length; i2 < l; ) {
+        let line = lines[i2++].trim();
         if (!line) {
           continue;
         }
         if (line.charAt(0) === "R") {
-          line += NULL + (lines[i++] || "");
+          line += NULL + (lines[i2++] || "");
         }
         splitLine(status, line);
       }
@@ -26353,11 +26446,10 @@ var init_clone = __esm({
     "use strict";
     init_task();
     init_utils();
-    init_pathspec();
     cloneTask = /* @__PURE__ */ __name((repo, directory, customArgs) => {
       const commands = ["clone", ...customArgs];
-      filterString(repo) && commands.push(pathspec(repo));
-      filterString(directory) && commands.push(pathspec(directory));
+      filterString(repo) && commands.push(c(repo));
+      filterString(directory) && commands.push(c(directory));
       return straightThroughStringTask(commands);
     }, "cloneTask");
     cloneMirrorTask = /* @__PURE__ */ __name((repo, directory, customArgs) => {
@@ -27189,8 +27281,8 @@ var init_TagList = __esm({
           if (partsA.length === 1 || partsB.length === 1) {
             return singleSorted(toNumber(partsA[0]), toNumber(partsB[0]));
           }
-          for (let i = 0, l = Math.max(partsA.length, partsB.length); i < l; i++) {
-            const diff = sorted(toNumber(partsA[i]), toNumber(partsB[i]));
+          for (let i2 = 0, l = Math.max(partsA.length, partsB.length); i2 < l; i2++) {
+            const diff = sorted(toNumber(partsA[i2]), toNumber(partsB[i2]));
             if (diff) {
               return diff;
             }
@@ -27436,9 +27528,9 @@ e");
     Git2.prototype.raw = function(commands) {
       const createRestCommands = !Array.isArray(commands);
       const command = [].slice.call(createRestCommands ? arguments : commands, 0);
-      for (let i = 0; i < command.length && createRestCommands; i++) {
-        if (!filterPrimitives2(command[i])) {
-          command.splice(i, command.length - i);
+      for (let i2 = 0; i2 < command.length && createRestCommands; i2++) {
+        if (!filterPrimitives2(command[i2])) {
+          command.splice(i2, command.length - i2);
           break;
         }
       }
@@ -27622,21 +27714,9 @@ gin instead."
     module2.exports = Git2;
   }
 });
-init_pathspec();
 init_git_error();
 init_git_error();
 init_git_error();
-var GitPluginError = class extends GitError {
-  static {
-    __name(this, "GitPluginError");
-  }
-  constructor(task, plugin, message) {
-    super(task, message);
-    this.task = task;
-    this.plugin = plugin;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-};
 init_git_response_error();
 init_task_configuration_error();
 init_check_is_repo();
@@ -27645,34 +27725,6 @@ init_config();
 init_diff_name_status();
 init_grep();
 init_reset();
-function isConfigSwitch(arg) {
-  return typeof arg === "string" && arg.trim().toLowerCase() === "-c";
-}
-__name(isConfigSwitch, "isConfigSwitch");
-function preventConfigBuilder(config, setting, message = String(config)) {
-  const regex = typeof config === "string" ? new RegExp(`\\s*${config}`, "i") : config;
-  return /* @__PURE__ */ __name(function preventCommand(options, arg, next) {
-    if (options[setting] !== true && isConfigSwitch(arg) && regex.test(next)) {
-      throw new GitPluginError(
-        void 0,
-        "unsafe",
-        `Configuring ${message} is not permitted without enabling ${setting}`
-      );
-    }
-  }, "preventCommand");
-}
-__name(preventConfigBuilder, "preventConfigBuilder");
-var preventUnsafeConfig = [
-  preventConfigBuilder(
-    /^\s*protocol(.[a-z]+)?.allow/i,
-    "allowUnsafeProtocolOverride",
-    "protocol.allow"
-  ),
-  preventConfigBuilder("core.sshCommand", "allowUnsafeSshCommand"),
-  preventConfigBuilder("core.gitProxy", "allowUnsafeGitProxy"),
-  preventConfigBuilder("core.hooksPath", "allowUnsafeHooksPath"),
-  preventConfigBuilder("diff.external", "allowUnsafeDiffExternal")
-];
 init_utils();
 init_utils();
 var never = (0, import_promise_deferred2.deferred)().promise;
@@ -27681,7 +27733,6 @@ init_git_error();
 init_utils();
 init_utils();
 init_utils();
-init_pathspec();
 init_utils();
 var Git = require_git();
 init_git_response_error();
@@ -28560,7 +28611,7 @@ var ToolRunner = class extends events.EventEmitter {
     ];
     let needsQuotes = false;
     for (const char of arg) {
-      if (cmdSpecialChars.some((x) => x === char)) {
+      if (cmdSpecialChars.some((x2) => x2 === char)) {
         needsQuotes = true;
         break;
       }
@@ -28570,11 +28621,11 @@ var ToolRunner = class extends events.EventEmitter {
     }
     let reverse = '"';
     let quoteHit = true;
-    for (let i = arg.length; i > 0; i--) {
-      reverse += arg[i - 1];
-      if (quoteHit && arg[i - 1] === "\\") {
+    for (let i2 = arg.length; i2 > 0; i2--) {
+      reverse += arg[i2 - 1];
+      if (quoteHit && arg[i2 - 1] === "\\") {
         reverse += "\\";
-      } else if (arg[i - 1] === '"') {
+      } else if (arg[i2 - 1] === '"') {
         quoteHit = true;
         reverse += '"';
       } else {
@@ -28596,11 +28647,11 @@ var ToolRunner = class extends events.EventEmitter {
     }
     let reverse = '"';
     let quoteHit = true;
-    for (let i = arg.length; i > 0; i--) {
-      reverse += arg[i - 1];
-      if (quoteHit && arg[i - 1] === "\\") {
+    for (let i2 = arg.length; i2 > 0; i2--) {
+      reverse += arg[i2 - 1];
+      if (quoteHit && arg[i2 - 1] === "\\") {
         reverse += "\\";
-      } else if (arg[i - 1] === '"') {
+      } else if (arg[i2 - 1] === '"') {
         quoteHit = true;
         reverse += "\\";
       } else {
@@ -28752,40 +28803,40 @@ function argStringToArray(argString) {
   let inQuotes = false;
   let escaped = false;
   let arg = "";
-  function append2(c) {
-    if (escaped && c !== '"') {
+  function append2(c3) {
+    if (escaped && c3 !== '"') {
       arg += "\\";
     }
-    arg += c;
+    arg += c3;
     escaped = false;
   }
   __name(append2, "append");
-  for (let i = 0; i < argString.length; i++) {
-    const c = argString.charAt(i);
-    if (c === '"') {
+  for (let i2 = 0; i2 < argString.length; i2++) {
+    const c3 = argString.charAt(i2);
+    if (c3 === '"') {
       if (!escaped) {
         inQuotes = !inQuotes;
       } else {
-        append2(c);
+        append2(c3);
       }
       continue;
     }
-    if (c === "\\" && escaped) {
-      append2(c);
+    if (c3 === "\\" && escaped) {
+      append2(c3);
       continue;
     }
-    if (c === "\\" && inQuotes) {
+    if (c3 === "\\" && inQuotes) {
       escaped = true;
       continue;
     }
-    if (c === " " && !inQuotes) {
+    if (c3 === " " && !inQuotes) {
       if (arg.length > 0) {
         args.push(arg);
         arg = "";
       }
       continue;
     }
-    append2(c);
+    append2(c3);
   }
   if (arg.length > 0) {
     args.push(arg.trim());

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -242,8 +242,8 @@ var require_common = __commonJS({
         return debug3;
       }
       __name(createDebug, "createDebug");
-      function extend(namespace, delimiter2) {
-        const newDebug = createDebug(this.namespace + (typeof delimiter2 === "undefined" ? ":" : delimiter2) + namespace);
+      function extend(namespace, delimiter) {
+        const newDebug = createDebug(this.namespace + (typeof delimiter === "undefined" ? ":" : delimiter) + namespace);
         newDebug.log = this.log;
         return newDebug;
       }
@@ -533,7 +533,7 @@ var require_has_flag = __commonJS({
 var require_supports_color = __commonJS({
   "node_modules/supports-color/index.js"(exports2, module2) {
     "use strict";
-    var os7 = require("os");
+    var os5 = require("os");
     var tty = require("tty");
     var hasFlag = require_has_flag();
     var { env: env2 } = process;
@@ -582,7 +582,7 @@ var require_supports_color = __commonJS({
         return min;
       }
       if (process.platform === "win32") {
-        const osRelease = os7.release().split(".");
+        const osRelease = os5.release().split(".");
         if (Number(osRelease[0]) >= 10 && Number(osRelease[2]) >= 10586) {
           return Number(osRelease[2]) >= 14931 ? 3 : 2;
         }
@@ -839,10 +839,10 @@ var require_src2 = __commonJS({
     var fs_1 = require("fs");
     var debug_1 = __importDefault(require_src());
     var log = debug_1.default("@kwsites/file-exists");
-    function check(path5, isFile, isDirectory2) {
-      log(`checking %s`, path5);
+    function check(path2, isFile, isDirectory2) {
+      log(`checking %s`, path2);
       try {
-        const stat2 = fs_1.statSync(path5);
+        const stat2 = fs_1.statSync(path2);
         if (stat2.isFile() && isFile) {
           log(`[OK] path represents a file`);
           return true;
@@ -863,8 +863,8 @@ var require_src2 = __commonJS({
       }
     }
     __name(check, "check");
-    function exists3(path5, type = exports2.READABLE) {
-      return check(path5, (type & exports2.FILE) > 0, (type & exports2.FOLDER) > 0);
+    function exists3(path2, type = exports2.READABLE) {
+      return check(path2, (type & exports2.FILE) > 0, (type & exports2.FOLDER) > 0);
     }
     __name(exists3, "exists");
     exports2.exists = exists3;
@@ -938,7 +938,7 @@ var require_tunnel = __commonJS({
     var tls = require("tls");
     var http = require("http");
     var https = require("https");
-    var events2 = require("events");
+    var events = require("events");
     var assert = require("assert");
     var util = require("util");
     exports2.httpOverHttp = httpOverHttp2;
@@ -995,7 +995,7 @@ var require_tunnel = __commonJS({
       }, "onFree"));
     }
     __name(TunnelingAgent, "TunnelingAgent");
-    util.inherits(TunnelingAgent, events2.EventEmitter);
+    util.inherits(TunnelingAgent, events.EventEmitter);
     TunnelingAgent.prototype.addRequest = /* @__PURE__ */ __name(function addRequest(req, host, port, localAddress) {
       var self = this;
       var options = mergeOptions({ request: req }, self.options, toOptions(host, port, localAddress));
@@ -2076,14 +2076,14 @@ eger.");
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path5 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path2 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path5 && path5[0] !== "/") {
-          path5 = `/${path5}`;
+        if (path2 && path2[0] !== "/") {
+          path2 = `/${path2}`;
         }
-        return new URL(`${origin}${path5}`);
+        return new URL(`${origin}${path2}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -2574,39 +2574,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path5, origin }
+          request: { method, path: path2, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path5);
+        debuglog("sending request to %s %s/%s", method, origin, path2);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path5, origin },
+          request: { method, path: path2, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path5,
+          path2,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path5, origin }
+          request: { method, path: path2, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path5);
+        debuglog("trailers received from %s %s/%s", method, origin, path2);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path5, origin },
+          request: { method, path: path2, origin },
           error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path5,
+          path2,
           error2.message
         );
       });
@@ -2655,9 +2655,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path5, origin }
+            request: { method, path: path2, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path5);
+          debuglog("sending request to %s %s/%s", method, origin, path2);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -2723,7 +2723,7 @@ var require_request = __commonJS({
         __name(this, "Request");
       }
       constructor(origin, {
-        path: path5,
+        path: path2,
         method,
         body,
         headers,
@@ -2738,12 +2738,12 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler) {
-        if (typeof path5 !== "string") {
+        if (typeof path2 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path5[0] !== "/" && !(path5.startsWith("http://") || path5.startsWith("https://")) && method !== "CON\
+        } else if (path2[0] !== "/" && !(path2.startsWith("http://") || path2.startsWith("https://")) && method !== "CON\
 NECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path5)) {
+        } else if (invalidPathRegex.test(path2)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -2810,7 +2810,7 @@ terable");
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path5, query) : path5;
+        this.path = query ? buildURL(path2, query) : path2;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -3034,8 +3034,8 @@ terable");
 var require_dispatcher = __commonJS({
   "node_modules/undici/lib/dispatcher/dispatcher.js"(exports2, module2) {
     "use strict";
-    var EventEmitter2 = require("node:events");
-    var Dispatcher = class extends EventEmitter2 {
+    var EventEmitter = require("node:events");
+    var Dispatcher = class extends EventEmitter {
       static {
         __name(this, "Dispatcher");
       }
@@ -3138,9 +3138,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback) {
         if (callback === void 0) {
-          return new Promise((resolve2, reject) => {
+          return new Promise((resolve, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve2(data);
+              return err ? reject(err) : resolve(data);
             });
           });
         }
@@ -3178,12 +3178,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback === void 0) {
-          return new Promise((resolve2, reject) => {
+          return new Promise((resolve, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve2(data);
+              ) : resolve(data);
             });
           });
         }
@@ -6611,8 +6611,8 @@ _") {
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise = new Promise((resolve2, reject) => {
-        res = resolve2;
+      const promise = new Promise((resolve, reject) => {
+        res = resolve;
         rej = reject;
       });
       return { promise, resolve: res, reject: rej };
@@ -8583,7 +8583,7 @@ var require_client_h1 = __commonJS({
     }
     __name(shouldSendContentLength, "shouldSendContentLength");
     function writeH1(client, request) {
-      const { method, path: path5, host, upgrade, blocking, reset } = request;
+      const { method, path: path2, host, upgrade, blocking, reset } = request;
       let { body, headers, contentLength } = request;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method ===
       "PROPFIND" || method === "PROPPATCH";
@@ -8651,7 +8651,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path5} HTTP/1.1\r
+      let header = `${method} ${path2} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -8843,12 +8843,12 @@ upgrade: ${upgrade}\r
         }
       }
       __name(onDrain, "onDrain");
-      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve2, reject) => {
+      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve, reject) => {
         assert(callback === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback = resolve2;
+          callback = resolve;
         }
       }), "waitForDrain");
       socket.on("close", onDrain).on("drain", onDrain);
@@ -9195,7 +9195,7 @@ var require_client_h2 = __commonJS({
     __name(shouldSendContentLength, "shouldSendContentLength");
     function writeH2(client, request) {
       const session = client[kHTTP2Session];
-      const { method, path: path5, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
+      const { method, path: path2, host, upgrade, expectContinue, signal, headers: reqHeaders } = request;
       let { body } = request;
       if (upgrade) {
         util.errorRequest(client, request, new Error("Upgrade not supported for H2"));
@@ -9262,7 +9262,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path5;
+      headers[HTTP2_HEADER_PATH] = path2;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -9506,12 +9506,12 @@ var require_client_h2 = __commonJS({
         }
       }
       __name(onDrain, "onDrain");
-      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve2, reject) => {
+      const waitForDrain = /* @__PURE__ */ __name(() => new Promise((resolve, reject) => {
         assert(callback === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback = resolve2;
+          callback = resolve;
         }
       }), "waitForDrain");
       h2stream.on("close", onDrain).on("drain", onDrain);
@@ -9633,9 +9633,9 @@ var require_redirect_handler = __commonJS({
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.
         path, this.opts.origin)));
-        const path5 = search ? `${pathname}${search}` : pathname;
+        const path2 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path5;
+        this.opts.path = path2;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -10007,16 +10007,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve2) => {
+        return new Promise((resolve) => {
           if (this[kSize]) {
-            this[kClosedResolve] = resolve2;
+            this[kClosedResolve] = resolve;
           } else {
-            resolve2(null);
+            resolve(null);
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve2) => {
+        return new Promise((resolve) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i2 = 0; i2 < requests.length; i2++) {
             const request = requests[i2];
@@ -10027,7 +10027,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve2(null);
+            resolve(null);
           }, "callback");
           if (this[kHTTPContext]) {
             this[kHTTPContext].destroy(err, callback);
@@ -10079,7 +10079,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve2, reject) => {
+        const socket = await new Promise((resolve, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -10091,7 +10091,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve2(socket2);
+              resolve(socket2);
             }
           });
         });
@@ -10444,8 +10444,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           await Promise.all(this[kClients].map((c3) => c3.close()));
         } else {
-          await new Promise((resolve2) => {
-            this[kClosedResolve] = resolve2;
+          await new Promise((resolve) => {
+            this[kClosedResolve] = resolve;
           });
         }
       }
@@ -10925,10 +10925,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path5 = "/",
+          path: path2 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path5;
+        opts.path = origin + path2;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -11713,7 +11713,7 @@ var require_readable = __commonJS({
         if (this._readableState.closeEmitted) {
           return null;
         }
-        return await new Promise((resolve2, reject) => {
+        return await new Promise((resolve, reject) => {
           if (this[kContentLength] > limit) {
             this.destroy(new AbortError());
           }
@@ -11726,7 +11726,7 @@ var require_readable = __commonJS({
             if (signal?.aborted) {
               reject(signal.reason ?? new AbortError());
             } else {
-              resolve2(null);
+              resolve(null);
             }
           }).on("error", noop).on("data", function(chunk) {
             limit -= chunk.length;
@@ -11747,7 +11747,7 @@ var require_readable = __commonJS({
     __name(isUnusable, "isUnusable");
     async function consume(stream, type) {
       assert(!stream[kConsume]);
-      return new Promise((resolve2, reject) => {
+      return new Promise((resolve, reject) => {
         if (isUnusable(stream)) {
           const rState = stream._readableState;
           if (rState.destroyed && rState.closeEmitted === false) {
@@ -11764,7 +11764,7 @@ var require_readable = __commonJS({
             stream[kConsume] = {
               type,
               stream,
-              resolve: resolve2,
+              resolve,
               reject,
               length: 0,
               body: []
@@ -11838,18 +11838,18 @@ var require_readable = __commonJS({
     }
     __name(chunksConcat, "chunksConcat");
     function consumeEnd(consume2) {
-      const { type, body, resolve: resolve2, stream, length } = consume2;
+      const { type, body, resolve, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve2(chunksDecode(body, length));
+          resolve(chunksDecode(body, length));
         } else if (type === "json") {
-          resolve2(JSON.parse(chunksDecode(body, length)));
+          resolve(JSON.parse(chunksDecode(body, length)));
         } else if (type === "arrayBuffer") {
-          resolve2(chunksConcat(body, length).buffer);
+          resolve(chunksConcat(body, length).buffer);
         } else if (type === "blob") {
-          resolve2(new Blob(body, { type: stream[kContentType] }));
+          resolve(new Blob(body, { type: stream[kContentType] }));
         } else if (type === "bytes") {
-          resolve2(chunksConcat(body, length));
+          resolve(chunksConcat(body, length));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -12117,9 +12117,9 @@ var require_api_request = __commonJS({
     };
     function request(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve2, reject) => {
+        return new Promise((resolve, reject) => {
           request.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve2(data);
+            return err ? reject(err) : resolve(data);
           });
         });
       }
@@ -12349,9 +12349,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback) {
       if (callback === void 0) {
-        return new Promise((resolve2, reject) => {
+        return new Promise((resolve, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve2(data);
+            return err ? reject(err) : resolve(data);
           });
         });
       }
@@ -12650,9 +12650,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve2, reject) => {
+        return new Promise((resolve, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve2(data);
+            return err ? reject(err) : resolve(data);
           });
         });
       }
@@ -12748,9 +12748,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback) {
       if (callback === void 0) {
-        return new Promise((resolve2, reject) => {
+        return new Promise((resolve, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve2(data);
+            return err ? reject(err) : resolve(data);
           });
         });
       }
@@ -12924,21 +12924,21 @@ var require_mock_utils = __commonJS({
       return true;
     }
     __name(matchHeaders, "matchHeaders");
-    function safeUrl(path5) {
-      if (typeof path5 !== "string") {
-        return path5;
+    function safeUrl(path2) {
+      if (typeof path2 !== "string") {
+        return path2;
       }
-      const pathSegments = path5.split("?");
+      const pathSegments = path2.split("?");
       if (pathSegments.length !== 2) {
-        return path5;
+        return path2;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
     __name(safeUrl, "safeUrl");
-    function matchKey(mockDispatch2, { path: path5, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path5);
+    function matchKey(mockDispatch2, { path: path2, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path2);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -12962,8 +12962,8 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path5 }) => matchValue(
-      safeUrl(path5), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path2 }) => matchValue(
+      safeUrl(path2), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -13005,9 +13005,9 @@ var require_mock_utils = __commonJS({
     }
     __name(deleteMockDispatch, "deleteMockDispatch");
     function buildKey(opts) {
-      const { path: path5, method, body, headers, query } = opts;
+      const { path: path2, method, body, headers, query } = opts;
       return {
-        path: path5,
+        path: path2,
         method,
         body,
         headers,
@@ -13500,10 +13500,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path5, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path2, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path5,
+            Path: path2,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -14296,10 +14296,10 @@ var require_headers = __commonJS({
         const lowercaseName = isLowerCase ? name : name.toLowerCase();
         const exists3 = this[kHeadersMap].get(lowercaseName);
         if (exists3) {
-          const delimiter2 = lowercaseName === "cookie" ? "; " : ", ";
+          const delimiter = lowercaseName === "cookie" ? "; " : ", ";
           this[kHeadersMap].set(lowercaseName, {
             name: exists3.name,
-            value: `${exists3.value}${delimiter2}${value}`
+            value: `${exists3.value}${delimiter}${value}`
           });
         } else {
           this[kHeadersMap].set(lowercaseName, { name, value });
@@ -15904,7 +15904,7 @@ var require_fetch = __commonJS({
       finalizeAndReportTiming(response, "fetch");
     }
     __name(handleFetchDone, "handleFetchDone");
-    function fetch2(input, init = void 0) {
+    function fetch(input, init = void 0) {
       webidl.argumentLengthCheck(arguments, 1, "globalThis.fetch");
       let p = createDeferredPromise();
       let requestObject;
@@ -15961,7 +15961,7 @@ var require_fetch = __commonJS({
       });
       return p.promise;
     }
-    __name(fetch2, "fetch");
+    __name(fetch, "fetch");
     function finalizeAndReportTiming(response, initiatorType = "other") {
       if (response.type === "error" && response.aborted) {
         return;
@@ -16747,7 +16747,7 @@ processBodyError");
       function dispatch({ body }) {
         const url = requestCurrentURL(request);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve2, reject) => agent.dispatch(
+        return new Promise((resolve, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -16824,7 +16824,7 @@ processBodyError");
                 }
               }
               const onError2 = this.onError.bind(this);
-              resolve2({
+              resolve({
                 status,
                 statusText,
                 headersList,
@@ -16870,7 +16870,7 @@ processBodyError");
               for (let i2 = 0; i2 < rawHeaders.length; i2 += 2) {
                 headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i2]), rawHeaders[i2 + 1].toString("latin1"), true);
               }
-              resolve2({
+              resolve({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList,
@@ -16885,7 +16885,7 @@ processBodyError");
     }
     __name(httpNetworkFetch, "httpNetworkFetch");
     module2.exports = {
-      fetch: fetch2,
+      fetch,
       Fetch,
       fetching,
       finalizeAndReportTiming
@@ -17281,7 +17281,7 @@ var require_util4 = __commonJS({
     var { getEncoding } = require_encoding();
     var { serializeAMimeType, parseMIMEType } = require_data_url();
     var { types } = require("node:util");
-    var { StringDecoder: StringDecoder2 } = require("string_decoder");
+    var { StringDecoder } = require("string_decoder");
     var { btoa } = require("node:buffer");
     var staticPropertyDescriptors = {
       enumerable: true,
@@ -17374,7 +17374,7 @@ var require_util4 = __commonJS({
             dataURL += serializeAMimeType(parsed);
           }
           dataURL += ";base64,";
-          const decoder = new StringDecoder2("latin1");
+          const decoder = new StringDecoder("latin1");
           for (const chunk of bytes) {
             dataURL += btoa(decoder.write(chunk));
           }
@@ -17403,7 +17403,7 @@ var require_util4 = __commonJS({
         }
         case "BinaryString": {
           let binaryString = "";
-          const decoder = new StringDecoder2("latin1");
+          const decoder = new StringDecoder("latin1");
           for (const chunk of bytes) {
             binaryString += decoder.write(chunk);
           }
@@ -18499,9 +18499,9 @@ var require_util6 = __commonJS({
       }
     }
     __name(validateCookieValue, "validateCookieValue");
-    function validateCookiePath(path5) {
-      for (let i2 = 0; i2 < path5.length; ++i2) {
-        const code = path5.charCodeAt(i2);
+    function validateCookiePath(path2) {
+      for (let i2 = 0; i2 < path2.length; ++i2) {
+        const code = path2.charCodeAt(i2);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -20602,8 +20602,8 @@ var require_util8 = __commonJS({
     }
     __name(isASCIINumber, "isASCIINumber");
     function delay2(ms) {
-      return new Promise((resolve2) => {
-        setTimeout(resolve2, ms).unref();
+      return new Promise((resolve) => {
+        setTimeout(resolve, ms).unref();
       });
     }
     __name(delay2, "delay");
@@ -21215,11 +21215,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path5 = opts.path;
+          let path2 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path5 = `/${path5}`;
+            path2 = `/${path2}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path5);
+          url = new URL(util.parseOrigin(url).origin + path2);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -21242,7 +21242,7 @@ var require_undici = __commonJS({
     module2.exports.setGlobalDispatcher = setGlobalDispatcher;
     module2.exports.getGlobalDispatcher = getGlobalDispatcher;
     var fetchImpl = require_fetch().fetch;
-    module2.exports.fetch = /* @__PURE__ */ __name(async function fetch2(init, options = void 0) {
+    module2.exports.fetch = /* @__PURE__ */ __name(async function fetch(init, options = void 0) {
       try {
         return await fetchImpl(init, options);
       } catch (err) {
@@ -23484,8 +23484,8 @@ function forEachLineWithContent(input, callback) {
   return toLinesWithContent(input, true).map((line) => callback(line));
 }
 __name(forEachLineWithContent, "forEachLineWithContent");
-function folderExists(path5) {
-  return (0, import_file_exists.exists)(path5, import_file_exists.FOLDER);
+function folderExists(path2) {
+  return (0, import_file_exists.exists)(path2, import_file_exists.FOLDER);
 }
 __name(folderExists, "folderExists");
 function append(target, item) {
@@ -23923,8 +23923,8 @@ function checkIsRepoRootTask() {
     commands,
     format: "utf-8",
     onError,
-    parser(path5) {
-      return /^\.(git)?$/.test(path5.trim());
+    parser(path2) {
+      return /^\.(git)?$/.test(path2.trim());
     }
   };
 }
@@ -24393,11 +24393,11 @@ function parseGrep(grep) {
   const paths = /* @__PURE__ */ new Set();
   const results = {};
   forEachLineWithContent(grep, (input) => {
-    const [path5, line, preview] = input.split(NULL);
-    paths.add(path5);
-    (results[path5] = results[path5] || []).push({
+    const [path2, line, preview] = input.split(NULL);
+    paths.add(path2);
+    (results[path2] = results[path2] || []).push({
       line: asNumber(line),
-      path: path5,
+      path: path2,
       preview
     });
   });
@@ -25202,14 +25202,14 @@ var init_hash_object = __esm({
     init_task();
   }
 });
-function parseInit(bare, path5, text) {
+function parseInit(bare, path2, text) {
   const response = String(text).trim();
   let result;
   if (result = initResponseRegex.exec(response)) {
-    return new InitSummary(bare, path5, false, result[1]);
+    return new InitSummary(bare, path2, false, result[1]);
   }
   if (result = reInitResponseRegex.exec(response)) {
-    return new InitSummary(bare, path5, true, result[1]);
+    return new InitSummary(bare, path2, true, result[1]);
   }
   let gitDir = "";
   const tokens = response.split(" ");
@@ -25220,7 +25220,7 @@ function parseInit(bare, path5, text) {
       break;
     }
   }
-  return new InitSummary(bare, path5, /^re/i.test(response), gitDir);
+  return new InitSummary(bare, path2, /^re/i.test(response), gitDir);
 }
 __name(parseInit, "parseInit");
 var InitSummary;
@@ -25233,9 +25233,9 @@ var init_InitSummary = __esm({
       static {
         __name(this, "InitSummary");
       }
-      constructor(bare, path5, existing, gitDir) {
+      constructor(bare, path2, existing, gitDir) {
         this.bare = bare;
-        this.path = path5;
+        this.path = path2;
         this.existing = existing;
         this.gitDir = gitDir;
       }
@@ -25248,7 +25248,7 @@ function hasBareCommand(command) {
   return command.includes(bareCommand);
 }
 __name(hasBareCommand, "hasBareCommand");
-function initTask(bare = false, path5, customArgs) {
+function initTask(bare = false, path2, customArgs) {
   const commands = ["init", ...customArgs];
   if (bare && !hasBareCommand(commands)) {
     commands.splice(1, 0, bareCommand);
@@ -25257,7 +25257,7 @@ function initTask(bare = false, path5, customArgs) {
     commands,
     format: "utf-8",
     parser(text) {
-      return parseInit(commands.includes("--bare"), path5, text);
+      return parseInit(commands.includes("--bare"), path2, text);
     }
   };
 }
@@ -26117,12 +26117,12 @@ var init_FileStatusSummary = __esm({
       static {
         __name(this, "FileStatusSummary");
       }
-      constructor(path5, index, working_dir) {
-        this.path = path5;
+      constructor(path2, index, working_dir) {
+        this.path = path2;
         this.index = index;
         this.working_dir = working_dir;
         if (index === "R" || working_dir === "R") {
-          const detail = fromPathRegex.exec(path5) || [null, path5, path5];
+          const detail = fromPathRegex.exec(path2) || [null, path2, path2];
           this.from = detail[2] || "";
           this.path = detail[1] || "";
         }
@@ -26156,14 +26156,14 @@ function splitLine(result, lineStr) {
     default:
       return;
   }
-  function data(index, workingDir, path5) {
+  function data(index, workingDir, path2) {
     const raw = `${index}${workingDir}`;
     const handler = parsers6.get(raw);
     if (handler) {
-      handler(result, path5);
+      handler(result, path2);
     }
     if (raw !== "##" && raw !== "!!") {
-      result.files.push(new FileStatusSummary(path5, index, workingDir));
+      result.files.push(new FileStatusSummary(path2, index, workingDir));
     }
   }
   __name(data, "data");
@@ -26529,9 +26529,9 @@ var init_simple_git_api = __esm({
           next
         );
       }
-      hashObject(path5, write) {
+      hashObject(path2, write) {
         return this._runTask(
-          hashObjectTask(path5, write === true),
+          hashObjectTask(path2, write === true),
           trailingFunctionArgument(arguments)
         );
       }
@@ -26905,8 +26905,8 @@ var init_branch = __esm({
   }
 });
 function toPath(input) {
-  const path5 = input.trim().replace(/^["']|["']$/g, "");
-  return path5 && (0, import_node_path.normalize)(path5);
+  const path2 = input.trim().replace(/^["']|["']$/g, "");
+  return path2 && (0, import_node_path.normalize)(path2);
 }
 __name(toPath, "toPath");
 var parseCheckIgnore;
@@ -27208,8 +27208,8 @@ __export(sub_module_exports, {
   subModuleTask: /* @__PURE__ */ __name(() => subModuleTask, "subModuleTask"),
   updateSubModuleTask: /* @__PURE__ */ __name(() => updateSubModuleTask, "updateSubModuleTask")
 });
-function addSubModuleTask(repo, path5) {
-  return subModuleTask(["add", repo, path5]);
+function addSubModuleTask(repo, path2) {
+  return subModuleTask(["add", repo, path2]);
 }
 __name(addSubModuleTask, "addSubModuleTask");
 function initSubModuleTask(customArgs) {
@@ -27544,8 +27544,8 @@ e");
       }
       return this._runTask(straightThroughStringTask2(command, this._trimmed), next);
     };
-    Git2.prototype.submoduleAdd = function(repo, path5, then) {
-      return this._runTask(addSubModuleTask2(repo, path5), trailingFunctionArgument2(arguments));
+    Git2.prototype.submoduleAdd = function(repo, path2, then) {
+      return this._runTask(addSubModuleTask2(repo, path2), trailingFunctionArgument2(arguments));
     };
     Git2.prototype.submoduleUpdate = function(args, then) {
       return this._runTask(
@@ -27835,20 +27835,20 @@ function issueFileCommand(command, message) {
 }
 __name(issueFileCommand, "issueFileCommand");
 function prepareKeyValueMessage(key, value) {
-  const delimiter2 = `ghadelimiter_${crypto.randomUUID()}`;
+  const delimiter = `ghadelimiter_${crypto.randomUUID()}`;
   const convertedValue = toCommandValue(value);
-  if (key.includes(delimiter2)) {
-    throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter2}"`);
+  if (key.includes(delimiter)) {
+    throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
   }
-  if (convertedValue.includes(delimiter2)) {
-    throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter2}"`);
+  if (convertedValue.includes(delimiter)) {
+    throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
   }
-  return `${key}<<${delimiter2}${os2.EOL}${convertedValue}${os2.EOL}${delimiter2}`;
+  return `${key}<<${delimiter}${os2.EOL}${convertedValue}${os2.EOL}${delimiter}`;
 }
 __name(prepareKeyValueMessage, "prepareKeyValueMessage");
 
 // node_modules/@actions/core/lib/core.js
-var os5 = __toESM(require("os"), 1);
+var os4 = __toESM(require("os"), 1);
 
 // node_modules/@actions/http-client/lib/index.js
 var tunnel = __toESM(require_tunnel2(), 1);
@@ -27910,12 +27910,12 @@ var import_os = require("os");
 var import_fs = require("fs");
 var __awaiter = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve2) {
-      resolve2(value);
+    return value instanceof P ? value : new P(function(resolve) {
+      resolve(value);
     });
   }
   __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve2, reject) {
+  return new (P || (P = Promise))(function(resolve, reject) {
     function fulfilled(value) {
       try {
         step(generator.next(value));
@@ -27933,7 +27933,7 @@ var __awaiter = function(thisArg, _arguments, P, generator) {
     }
     __name(rejected, "rejected");
     function step(result) {
-      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
+      result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
     }
     __name(step, "step");
     step((generator = generator.apply(thisArg, _arguments || [])).next());
@@ -28201,799 +28201,14 @@ var _summary = new Summary();
 // node_modules/@actions/core/lib/platform.js
 var import_os2 = __toESM(require("os"), 1);
 
-// node_modules/@actions/exec/lib/exec.js
-var import_string_decoder = require("string_decoder");
-
-// node_modules/@actions/exec/lib/toolrunner.js
-var os3 = __toESM(require("os"), 1);
-var events = __toESM(require("events"), 1);
-var child = __toESM(require("child_process"), 1);
-var path3 = __toESM(require("path"), 1);
-
-// node_modules/@actions/io/lib/io.js
-var path2 = __toESM(require("path"), 1);
-
 // node_modules/@actions/io/lib/io-util.js
 var fs2 = __toESM(require("fs"), 1);
-var path = __toESM(require("path"), 1);
-var __awaiter2 = function(thisArg, _arguments, P, generator) {
-  function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve2) {
-      resolve2(value);
-    });
-  }
-  __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve2, reject) {
-    function fulfilled(value) {
-      try {
-        step(generator.next(value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(fulfilled, "fulfilled");
-    function rejected(value) {
-      try {
-        step(generator["throw"](value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(rejected, "rejected");
-    function step(result) {
-      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
-    }
-    __name(step, "step");
-    step((generator = generator.apply(thisArg, _arguments || [])).next());
-  });
-};
 var { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs2.promises;
 var IS_WINDOWS = process.platform === "win32";
 var READONLY = fs2.constants.O_RDONLY;
-function exists2(fsPath) {
-  return __awaiter2(this, void 0, void 0, function* () {
-    try {
-      yield stat(fsPath);
-    } catch (err) {
-      if (err.code === "ENOENT") {
-        return false;
-      }
-      throw err;
-    }
-    return true;
-  });
-}
-__name(exists2, "exists");
-function isRooted(p) {
-  p = normalizeSeparators(p);
-  if (!p) {
-    throw new Error('isRooted() parameter "p" cannot be empty');
-  }
-  if (IS_WINDOWS) {
-    return p.startsWith("\\") || /^[A-Z]:/i.test(p);
-  }
-  return p.startsWith("/");
-}
-__name(isRooted, "isRooted");
-function tryGetExecutablePath(filePath, extensions) {
-  return __awaiter2(this, void 0, void 0, function* () {
-    let stats = void 0;
-    try {
-      stats = yield stat(filePath);
-    } catch (err) {
-      if (err.code !== "ENOENT") {
-        console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-      }
-    }
-    if (stats && stats.isFile()) {
-      if (IS_WINDOWS) {
-        const upperExt = path.extname(filePath).toUpperCase();
-        if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-          return filePath;
-        }
-      } else {
-        if (isUnixExecutable(stats)) {
-          return filePath;
-        }
-      }
-    }
-    const originalFilePath = filePath;
-    for (const extension of extensions) {
-      filePath = originalFilePath + extension;
-      stats = void 0;
-      try {
-        stats = yield stat(filePath);
-      } catch (err) {
-        if (err.code !== "ENOENT") {
-          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-        }
-      }
-      if (stats && stats.isFile()) {
-        if (IS_WINDOWS) {
-          try {
-            const directory = path.dirname(filePath);
-            const upperName = path.basename(filePath).toUpperCase();
-            for (const actualName of yield readdir(directory)) {
-              if (upperName === actualName.toUpperCase()) {
-                filePath = path.join(directory, actualName);
-                break;
-              }
-            }
-          } catch (err) {
-            console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-          }
-          return filePath;
-        } else {
-          if (isUnixExecutable(stats)) {
-            return filePath;
-          }
-        }
-      }
-    }
-    return "";
-  });
-}
-__name(tryGetExecutablePath, "tryGetExecutablePath");
-function normalizeSeparators(p) {
-  p = p || "";
-  if (IS_WINDOWS) {
-    p = p.replace(/\//g, "\\");
-    return p.replace(/\\\\+/g, "\\");
-  }
-  return p.replace(/\/\/+/g, "/");
-}
-__name(normalizeSeparators, "normalizeSeparators");
-function isUnixExecutable(stats) {
-  return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.
-  mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
-}
-__name(isUnixExecutable, "isUnixExecutable");
-
-// node_modules/@actions/io/lib/io.js
-var __awaiter3 = function(thisArg, _arguments, P, generator) {
-  function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve2) {
-      resolve2(value);
-    });
-  }
-  __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve2, reject) {
-    function fulfilled(value) {
-      try {
-        step(generator.next(value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(fulfilled, "fulfilled");
-    function rejected(value) {
-      try {
-        step(generator["throw"](value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(rejected, "rejected");
-    function step(result) {
-      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
-    }
-    __name(step, "step");
-    step((generator = generator.apply(thisArg, _arguments || [])).next());
-  });
-};
-function which(tool, check) {
-  return __awaiter3(this, void 0, void 0, function* () {
-    if (!tool) {
-      throw new Error("parameter 'tool' is required");
-    }
-    if (check) {
-      const result = yield which(tool, false);
-      if (!result) {
-        if (IS_WINDOWS) {
-          throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the f\
-ile can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extensi\
-on for an executable file.`);
-        } else {
-          throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the f\
-ile can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the f\
-ile is executable.`);
-        }
-      }
-      return result;
-    }
-    const matches = yield findInPath(tool);
-    if (matches && matches.length > 0) {
-      return matches[0];
-    }
-    return "";
-  });
-}
-__name(which, "which");
-function findInPath(tool) {
-  return __awaiter3(this, void 0, void 0, function* () {
-    if (!tool) {
-      throw new Error("parameter 'tool' is required");
-    }
-    const extensions = [];
-    if (IS_WINDOWS && process.env["PATHEXT"]) {
-      for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
-        if (extension) {
-          extensions.push(extension);
-        }
-      }
-    }
-    if (isRooted(tool)) {
-      const filePath = yield tryGetExecutablePath(tool, extensions);
-      if (filePath) {
-        return [filePath];
-      }
-      return [];
-    }
-    if (tool.includes(path2.sep)) {
-      return [];
-    }
-    const directories = [];
-    if (process.env.PATH) {
-      for (const p of process.env.PATH.split(path2.delimiter)) {
-        if (p) {
-          directories.push(p);
-        }
-      }
-    }
-    const matches = [];
-    for (const directory of directories) {
-      const filePath = yield tryGetExecutablePath(path2.join(directory, tool), extensions);
-      if (filePath) {
-        matches.push(filePath);
-      }
-    }
-    return matches;
-  });
-}
-__name(findInPath, "findInPath");
 
 // node_modules/@actions/exec/lib/toolrunner.js
-var import_timers = require("timers");
-var __awaiter4 = function(thisArg, _arguments, P, generator) {
-  function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve2) {
-      resolve2(value);
-    });
-  }
-  __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve2, reject) {
-    function fulfilled(value) {
-      try {
-        step(generator.next(value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(fulfilled, "fulfilled");
-    function rejected(value) {
-      try {
-        step(generator["throw"](value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(rejected, "rejected");
-    function step(result) {
-      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
-    }
-    __name(step, "step");
-    step((generator = generator.apply(thisArg, _arguments || [])).next());
-  });
-};
 var IS_WINDOWS2 = process.platform === "win32";
-var ToolRunner = class extends events.EventEmitter {
-  static {
-    __name(this, "ToolRunner");
-  }
-  constructor(toolPath, args, options) {
-    super();
-    if (!toolPath) {
-      throw new Error("Parameter 'toolPath' cannot be null or empty.");
-    }
-    this.toolPath = toolPath;
-    this.args = args || [];
-    this.options = options || {};
-  }
-  _debug(message) {
-    if (this.options.listeners && this.options.listeners.debug) {
-      this.options.listeners.debug(message);
-    }
-  }
-  _getCommandString(options, noPrefix) {
-    const toolPath = this._getSpawnFileName();
-    const args = this._getSpawnArgs(options);
-    let cmd = noPrefix ? "" : "[command]";
-    if (IS_WINDOWS2) {
-      if (this._isCmdFile()) {
-        cmd += toolPath;
-        for (const a of args) {
-          cmd += ` ${a}`;
-        }
-      } else if (options.windowsVerbatimArguments) {
-        cmd += `"${toolPath}"`;
-        for (const a of args) {
-          cmd += ` ${a}`;
-        }
-      } else {
-        cmd += this._windowsQuoteCmdArg(toolPath);
-        for (const a of args) {
-          cmd += ` ${this._windowsQuoteCmdArg(a)}`;
-        }
-      }
-    } else {
-      cmd += toolPath;
-      for (const a of args) {
-        cmd += ` ${a}`;
-      }
-    }
-    return cmd;
-  }
-  _processLineBuffer(data, strBuffer, onLine) {
-    try {
-      let s = strBuffer + data.toString();
-      let n = s.indexOf(os3.EOL);
-      while (n > -1) {
-        const line = s.substring(0, n);
-        onLine(line);
-        s = s.substring(n + os3.EOL.length);
-        n = s.indexOf(os3.EOL);
-      }
-      return s;
-    } catch (err) {
-      this._debug(`error processing line. Failed with error ${err}`);
-      return "";
-    }
-  }
-  _getSpawnFileName() {
-    if (IS_WINDOWS2) {
-      if (this._isCmdFile()) {
-        return process.env["COMSPEC"] || "cmd.exe";
-      }
-    }
-    return this.toolPath;
-  }
-  _getSpawnArgs(options) {
-    if (IS_WINDOWS2) {
-      if (this._isCmdFile()) {
-        let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-        for (const a of this.args) {
-          argline += " ";
-          argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
-        }
-        argline += '"';
-        return [argline];
-      }
-    }
-    return this.args;
-  }
-  _endsWith(str, end) {
-    return str.endsWith(end);
-  }
-  _isCmdFile() {
-    const upperToolPath = this.toolPath.toUpperCase();
-    return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-  }
-  _windowsQuoteCmdArg(arg) {
-    if (!this._isCmdFile()) {
-      return this._uvQuoteCmdArg(arg);
-    }
-    if (!arg) {
-      return '""';
-    }
-    const cmdSpecialChars = [
-      " ",
-      "	",
-      "&",
-      "(",
-      ")",
-      "[",
-      "]",
-      "{",
-      "}",
-      "^",
-      "=",
-      ";",
-      "!",
-      "'",
-      "+",
-      ",",
-      "`",
-      "~",
-      "|",
-      "<",
-      ">",
-      '"'
-    ];
-    let needsQuotes = false;
-    for (const char of arg) {
-      if (cmdSpecialChars.some((x2) => x2 === char)) {
-        needsQuotes = true;
-        break;
-      }
-    }
-    if (!needsQuotes) {
-      return arg;
-    }
-    let reverse = '"';
-    let quoteHit = true;
-    for (let i2 = arg.length; i2 > 0; i2--) {
-      reverse += arg[i2 - 1];
-      if (quoteHit && arg[i2 - 1] === "\\") {
-        reverse += "\\";
-      } else if (arg[i2 - 1] === '"') {
-        quoteHit = true;
-        reverse += '"';
-      } else {
-        quoteHit = false;
-      }
-    }
-    reverse += '"';
-    return reverse.split("").reverse().join("");
-  }
-  _uvQuoteCmdArg(arg) {
-    if (!arg) {
-      return '""';
-    }
-    if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-      return arg;
-    }
-    if (!arg.includes('"') && !arg.includes("\\")) {
-      return `"${arg}"`;
-    }
-    let reverse = '"';
-    let quoteHit = true;
-    for (let i2 = arg.length; i2 > 0; i2--) {
-      reverse += arg[i2 - 1];
-      if (quoteHit && arg[i2 - 1] === "\\") {
-        reverse += "\\";
-      } else if (arg[i2 - 1] === '"') {
-        quoteHit = true;
-        reverse += "\\";
-      } else {
-        quoteHit = false;
-      }
-    }
-    reverse += '"';
-    return reverse.split("").reverse().join("");
-  }
-  _cloneExecOptions(options) {
-    options = options || {};
-    const result = {
-      cwd: options.cwd || process.cwd(),
-      env: options.env || process.env,
-      silent: options.silent || false,
-      windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-      failOnStdErr: options.failOnStdErr || false,
-      ignoreReturnCode: options.ignoreReturnCode || false,
-      delay: options.delay || 1e4
-    };
-    result.outStream = options.outStream || process.stdout;
-    result.errStream = options.errStream || process.stderr;
-    return result;
-  }
-  _getSpawnOptions(options, toolPath) {
-    options = options || {};
-    const result = {};
-    result.cwd = options.cwd;
-    result.env = options.env;
-    result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-    if (options.windowsVerbatimArguments) {
-      result.argv0 = `"${toolPath}"`;
-    }
-    return result;
-  }
-  /**
-   * Exec a tool.
-   * Output will be streamed to the live console.
-   * Returns promise with return code
-   *
-   * @param     tool     path to tool to exec
-   * @param     options  optional exec options.  See ExecOptions
-   * @returns   number
-   */
-  exec() {
-    return __awaiter4(this, void 0, void 0, function* () {
-      if (!isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS2 && this.toolPath.includes("\\"))) {
-        this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-      }
-      this.toolPath = yield which(this.toolPath, true);
-      return new Promise((resolve2, reject) => __awaiter4(this, void 0, void 0, function* () {
-        this._debug(`exec tool: ${this.toolPath}`);
-        this._debug("arguments:");
-        for (const arg of this.args) {
-          this._debug(`   ${arg}`);
-        }
-        const optionsNonNull = this._cloneExecOptions(this.options);
-        if (!optionsNonNull.silent && optionsNonNull.outStream) {
-          optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os3.EOL);
-        }
-        const state = new ExecState(optionsNonNull, this.toolPath);
-        state.on("debug", (message) => {
-          this._debug(message);
-        });
-        if (this.options.cwd && !(yield exists2(this.options.cwd))) {
-          return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
-        }
-        const fileName = this._getSpawnFileName();
-        const cp2 = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-        let stdbuffer = "";
-        if (cp2.stdout) {
-          cp2.stdout.on("data", (data) => {
-            if (this.options.listeners && this.options.listeners.stdout) {
-              this.options.listeners.stdout(data);
-            }
-            if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(data);
-            }
-            stdbuffer = this._processLineBuffer(data, stdbuffer, (line) => {
-              if (this.options.listeners && this.options.listeners.stdline) {
-                this.options.listeners.stdline(line);
-              }
-            });
-          });
-        }
-        let errbuffer = "";
-        if (cp2.stderr) {
-          cp2.stderr.on("data", (data) => {
-            state.processStderr = true;
-            if (this.options.listeners && this.options.listeners.stderr) {
-              this.options.listeners.stderr(data);
-            }
-            if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-              const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-              s.write(data);
-            }
-            errbuffer = this._processLineBuffer(data, errbuffer, (line) => {
-              if (this.options.listeners && this.options.listeners.errline) {
-                this.options.listeners.errline(line);
-              }
-            });
-          });
-        }
-        cp2.on("error", (err) => {
-          state.processError = err.message;
-          state.processExited = true;
-          state.processClosed = true;
-          state.CheckComplete();
-        });
-        cp2.on("exit", (code) => {
-          state.processExitCode = code;
-          state.processExited = true;
-          this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-          state.CheckComplete();
-        });
-        cp2.on("close", (code) => {
-          state.processExitCode = code;
-          state.processExited = true;
-          state.processClosed = true;
-          this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-          state.CheckComplete();
-        });
-        state.on("done", (error2, exitCode) => {
-          if (stdbuffer.length > 0) {
-            this.emit("stdline", stdbuffer);
-          }
-          if (errbuffer.length > 0) {
-            this.emit("errline", errbuffer);
-          }
-          cp2.removeAllListeners();
-          if (error2) {
-            reject(error2);
-          } else {
-            resolve2(exitCode);
-          }
-        });
-        if (this.options.input) {
-          if (!cp2.stdin) {
-            throw new Error("child process missing stdin");
-          }
-          cp2.stdin.end(this.options.input);
-        }
-      }));
-    });
-  }
-};
-function argStringToArray(argString) {
-  const args = [];
-  let inQuotes = false;
-  let escaped = false;
-  let arg = "";
-  function append2(c3) {
-    if (escaped && c3 !== '"') {
-      arg += "\\";
-    }
-    arg += c3;
-    escaped = false;
-  }
-  __name(append2, "append");
-  for (let i2 = 0; i2 < argString.length; i2++) {
-    const c3 = argString.charAt(i2);
-    if (c3 === '"') {
-      if (!escaped) {
-        inQuotes = !inQuotes;
-      } else {
-        append2(c3);
-      }
-      continue;
-    }
-    if (c3 === "\\" && escaped) {
-      append2(c3);
-      continue;
-    }
-    if (c3 === "\\" && inQuotes) {
-      escaped = true;
-      continue;
-    }
-    if (c3 === " " && !inQuotes) {
-      if (arg.length > 0) {
-        args.push(arg);
-        arg = "";
-      }
-      continue;
-    }
-    append2(c3);
-  }
-  if (arg.length > 0) {
-    args.push(arg.trim());
-  }
-  return args;
-}
-__name(argStringToArray, "argStringToArray");
-var ExecState = class _ExecState extends events.EventEmitter {
-  static {
-    __name(this, "ExecState");
-  }
-  constructor(options, toolPath) {
-    super();
-    this.processClosed = false;
-    this.processError = "";
-    this.processExitCode = 0;
-    this.processExited = false;
-    this.processStderr = false;
-    this.delay = 1e4;
-    this.done = false;
-    this.timeout = null;
-    if (!toolPath) {
-      throw new Error("toolPath must not be empty");
-    }
-    this.options = options;
-    this.toolPath = toolPath;
-    if (options.delay) {
-      this.delay = options.delay;
-    }
-  }
-  CheckComplete() {
-    if (this.done) {
-      return;
-    }
-    if (this.processClosed) {
-      this._setResult();
-    } else if (this.processExited) {
-      this.timeout = (0, import_timers.setTimeout)(_ExecState.HandleTimeout, this.delay, this);
-    }
-  }
-  _debug(message) {
-    this.emit("debug", message);
-  }
-  _setResult() {
-    let error2;
-    if (this.processExited) {
-      if (this.processError) {
-        error2 = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indic\
-ate the process failed to start. Error: ${this.processError}`);
-      } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-        error2 = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-      } else if (this.processStderr && this.options.failOnStdErr) {
-        error2 = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR s\
-tream`);
-      }
-    }
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-      this.timeout = null;
-    }
-    this.done = true;
-    this.emit("done", error2, this.processExitCode);
-  }
-  static HandleTimeout(state) {
-    if (state.done) {
-      return;
-    }
-    if (!state.processClosed && state.processExited) {
-      const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from proces\
-s '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-      state._debug(message);
-    }
-    state._setResult();
-  }
-};
-
-// node_modules/@actions/exec/lib/exec.js
-var __awaiter5 = function(thisArg, _arguments, P, generator) {
-  function adopt(value) {
-    return value instanceof P ? value : new P(function(resolve2) {
-      resolve2(value);
-    });
-  }
-  __name(adopt, "adopt");
-  return new (P || (P = Promise))(function(resolve2, reject) {
-    function fulfilled(value) {
-      try {
-        step(generator.next(value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(fulfilled, "fulfilled");
-    function rejected(value) {
-      try {
-        step(generator["throw"](value));
-      } catch (e) {
-        reject(e);
-      }
-    }
-    __name(rejected, "rejected");
-    function step(result) {
-      result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
-    }
-    __name(step, "step");
-    step((generator = generator.apply(thisArg, _arguments || [])).next());
-  });
-};
-function exec(commandLine, args, options) {
-  return __awaiter5(this, void 0, void 0, function* () {
-    const commandArgs = argStringToArray(commandLine);
-    if (commandArgs.length === 0) {
-      throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-    }
-    const toolPath = commandArgs[0];
-    args = commandArgs.slice(1).concat(args || []);
-    const runner = new ToolRunner(toolPath, args, options);
-    return runner.exec();
-  });
-}
-__name(exec, "exec");
-function getExecOutput(commandLine, args, options) {
-  return __awaiter5(this, void 0, void 0, function* () {
-    var _a2, _b;
-    let stdout = "";
-    let stderr = "";
-    const stdoutDecoder = new import_string_decoder.StringDecoder("utf8");
-    const stderrDecoder = new import_string_decoder.StringDecoder("utf8");
-    const originalStdoutListener = (_a2 = options === null || options === void 0 ? void 0 : options.listeners) === null ||
-    _a2 === void 0 ? void 0 : _a2.stdout;
-    const originalStdErrListener = (_b = options === null || options === void 0 ? void 0 : options.listeners) === null ||
-    _b === void 0 ? void 0 : _b.stderr;
-    const stdErrListener = /* @__PURE__ */ __name((data) => {
-      stderr += stderrDecoder.write(data);
-      if (originalStdErrListener) {
-        originalStdErrListener(data);
-      }
-    }, "stdErrListener");
-    const stdOutListener = /* @__PURE__ */ __name((data) => {
-      stdout += stdoutDecoder.write(data);
-      if (originalStdoutListener) {
-        originalStdoutListener(data);
-      }
-    }, "stdOutListener");
-    const listeners = Object.assign(Object.assign({}, options === null || options === void 0 ? void 0 : options.listeners),
-    { stdout: stdOutListener, stderr: stdErrListener });
-    const exitCode = yield exec(commandLine, args, Object.assign(Object.assign({}, options), { listeners }));
-    stdout += stdoutDecoder.end();
-    stderr += stderrDecoder.end();
-    return {
-      exitCode,
-      stdout,
-      stderr
-    };
-  });
-}
-__name(getExecOutput, "getExecOutput");
 
 // node_modules/@actions/core/lib/platform.js
 var platform = import_os2.default.platform();
@@ -29015,19 +28230,11 @@ function exportVariable(name, val) {
   issueCommand("set-env", { name }, convertedVal);
 }
 __name(exportVariable, "exportVariable");
-function setSecret(secret) {
-  issueCommand("add-mask", {}, secret);
-}
-__name(setSecret, "setSecret");
 function setFailed(message) {
   process.exitCode = ExitCode.Failure;
   error(message);
 }
 __name(setFailed, "setFailed");
-function isDebug() {
-  return process.env["RUNNER_DEBUG"] === "1";
-}
-__name(isDebug, "isDebug");
 function debug2(message) {
   issueCommand("debug", {}, message);
 }
@@ -29041,7 +28248,7 @@ function warning(message, properties = {}) {
 }
 __name(warning, "warning");
 function info(message) {
-  process.stdout.write(message + os5.EOL);
+  process.stdout.write(message + os4.EOL);
 }
 __name(info, "info");
 function getState(name) {
@@ -29103,32 +28310,6 @@ function clearAuthStack() {
 }
 __name(clearAuthStack, "clearAuthStack");
 
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
 // setup-gcloud/src/auth-gcloud.js
 var authType = {
   jsonKey: "json_key",
@@ -29142,28 +28323,6 @@ var env = {
 };
 var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
 tyString");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -29180,9 +28339,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
   projectId,
-  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -29195,11 +28352,6 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/setup-gcloud/dist/post.cjs
+++ b/setup-gcloud/dist/post.cjs
@@ -15904,7 +15904,7 @@ var require_fetch = __commonJS({
       finalizeAndReportTiming(response, "fetch");
     }
     __name(handleFetchDone, "handleFetchDone");
-    function fetch(input, init = void 0) {
+    function fetch2(input, init = void 0) {
       webidl.argumentLengthCheck(arguments, 1, "globalThis.fetch");
       let p = createDeferredPromise();
       let requestObject;
@@ -15961,7 +15961,7 @@ var require_fetch = __commonJS({
       });
       return p.promise;
     }
-    __name(fetch, "fetch");
+    __name(fetch2, "fetch");
     function finalizeAndReportTiming(response, initiatorType = "other") {
       if (response.type === "error" && response.aborted) {
         return;
@@ -16885,7 +16885,7 @@ processBodyError");
     }
     __name(httpNetworkFetch, "httpNetworkFetch");
     module2.exports = {
-      fetch,
+      fetch: fetch2,
       Fetch,
       fetching,
       finalizeAndReportTiming
@@ -21242,7 +21242,7 @@ var require_undici = __commonJS({
     module2.exports.setGlobalDispatcher = setGlobalDispatcher;
     module2.exports.getGlobalDispatcher = getGlobalDispatcher;
     var fetchImpl = require_fetch().fetch;
-    module2.exports.fetch = /* @__PURE__ */ __name(async function fetch(init, options = void 0) {
+    module2.exports.fetch = /* @__PURE__ */ __name(async function fetch2(init, options = void 0) {
       try {
         return await fetchImpl(init, options);
       } catch (err) {
@@ -29024,6 +29024,10 @@ function setFailed(message) {
   error(message);
 }
 __name(setFailed, "setFailed");
+function isDebug() {
+  return process.env["RUNNER_DEBUG"] === "1";
+}
+__name(isDebug, "isDebug");
 function debug2(message) {
   issueCommand("debug", {}, message);
 }
@@ -29138,13 +29142,20 @@ var env = {
 };
 var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
 tyString");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -29164,6 +29175,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -29180,7 +29192,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -29191,6 +29203,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/setup-gcloud/src/auth-gcloud.js
+++ b/setup-gcloud/src/auth-gcloud.js
@@ -6,9 +6,8 @@ import {
   workloadIdentityFederation,
 } from './auth-wid-federation.js';
 import createJobScopedCredential from './create-job-scoped-credential.js';
-import { execGcloud } from './exec-gcloud.js';
 
-const authType = {
+export const authType = {
   jsonKey: 'json_key',
   widFederation: 'wid_federation',
 };
@@ -93,34 +92,6 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 
-const getAccessToken = async (type, email) => {
-  const args = ['auth', 'print-access-token'];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, 'gcloud', true);
-  core.setSecret(accessToken);
-
-  if (core.isDebug()) {
-    const params = new URLSearchParams();
-    params.append('access_token', accessToken);
-    await fetch('https://oauth2.googleapis.com/tokeninfo', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: params,
-    })
-      .then((response) => response.json())
-      .then((tokenInfo) =>
-        core.debug(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`),
-      )
-      .catch((err) => core.error(`Failed to debug token info: ${err.message}`));
-  }
-
-  return accessToken;
-};
-
 const setEnvironmentVariable = (key, value, exportVariable) => {
   if (isNonEmptyString(value)) {
     if (exportVariable) {
@@ -138,9 +109,7 @@ const setEnvironmentVariable = (key, value, exportVariable) => {
 };
 
 const populateEnvironment = async ({
-  type,
   projectId,
-  email,
   credentialsFilePath,
   exportCredentials,
 }) => {
@@ -153,11 +122,6 @@ const populateEnvironment = async ({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
-    exportCredentials,
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : '',
     exportCredentials,
   );
 };

--- a/setup-gcloud/src/auth-gcloud.js
+++ b/setup-gcloud/src/auth-gcloud.js
@@ -93,13 +93,25 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 
-const getAccessToken = async () => {
+const getAccessToken = async (email) => {
   const accessToken = await execGcloud(
-    ['auth', 'print-access-token'],
+    ['auth', 'print-access-token', `--impersonate-service-account=${email}`],
     'gcloud',
     true,
   );
   core.setSecret(accessToken);
+
+  if (core.isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`,
+    )
+      .then((response) => response.json())
+      .then((tokenInfo) =>
+        core.debug(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`),
+      )
+      .catch((err) => core.error(`Failed to debug token info: ${err.message}`));
+  }
+
   return accessToken;
 };
 
@@ -121,6 +133,7 @@ const setEnvironmentVariable = (key, value, exportVariable) => {
 
 const populateEnvironment = async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials,
 }) => {
@@ -137,7 +150,7 @@ const populateEnvironment = async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === '' ? '' : await getAccessToken(),
+    email ? await getAccessToken(email) : '',
     exportCredentials,
   );
 };
@@ -253,6 +266,7 @@ export async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: '',
+      email: '',
       credentialsFilePath: '',
       exportCredentials: true,
     });

--- a/setup-gcloud/src/auth-gcloud.js
+++ b/setup-gcloud/src/auth-gcloud.js
@@ -93,21 +93,27 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 
-const getAccessToken = async (email) => {
-  const accessToken = await execGcloud(
-    ['auth', 'print-access-token', `--impersonate-service-account=${email}`],
-    'gcloud',
-    true,
-  );
+const getAccessToken = async (type, email) => {
+  const args = ['auth', 'print-access-token'];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, 'gcloud', true);
   core.setSecret(accessToken);
 
   if (core.isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`,
-    )
+    const params = new URLSearchParams();
+    params.append('access_token', accessToken);
+    await fetch('https://oauth2.googleapis.com/tokeninfo', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params,
+    })
       .then((response) => response.json())
       .then((tokenInfo) =>
-        core.debug(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`),
+        core.debug(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`),
       )
       .catch((err) => core.error(`Failed to debug token info: ${err.message}`));
   }
@@ -132,6 +138,7 @@ const setEnvironmentVariable = (key, value, exportVariable) => {
 };
 
 const populateEnvironment = async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -150,7 +157,7 @@ const populateEnvironment = async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : '',
+    email ? await getAccessToken(type, email) : '',
     exportCredentials,
   );
 };

--- a/setup-gcloud/src/auth-gcloud.js
+++ b/setup-gcloud/src/auth-gcloud.js
@@ -6,6 +6,7 @@ import {
   workloadIdentityFederation,
 } from './auth-wid-federation.js';
 import createJobScopedCredential from './create-job-scoped-credential.js';
+import { execGcloud } from './exec-gcloud.js';
 
 const authType = {
   jsonKey: 'json_key',
@@ -92,6 +93,16 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 
+const getAccessToken = async () => {
+  const accessToken = await execGcloud(
+    ['auth', 'print-access-token'],
+    'gcloud',
+    true,
+  );
+  core.setSecret(accessToken);
+  return accessToken;
+};
+
 const setEnvironmentVariable = (key, value, exportVariable) => {
   if (isNonEmptyString(value)) {
     if (exportVariable) {
@@ -108,7 +119,7 @@ const setEnvironmentVariable = (key, value, exportVariable) => {
   }
 };
 
-const populateEnvironment = ({
+const populateEnvironment = async ({
   projectId,
   credentialsFilePath,
   exportCredentials,
@@ -122,6 +133,11 @@ const populateEnvironment = ({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials,
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === '' ? '' : await getAccessToken(),
     exportCredentials,
   );
 };
@@ -196,7 +212,7 @@ export async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
 
   return projectId;
@@ -230,11 +246,11 @@ export function getCurrentAccount() {
 /**
  * Reset all tracked gcloud authentications and clear auth-related environment variables.
  */
-export function resetAuthStack() {
+export async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: '',
       credentialsFilePath: '',
@@ -266,7 +282,7 @@ export async function restorePreviousAccount(previousAccount) {
   saveAuthStack(authStack);
 
   // Restore the environment variables.
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
 
   return true;
 }

--- a/setup-gcloud/src/exec-gcloud.js
+++ b/setup-gcloud/src/exec-gcloud.js
@@ -18,9 +18,14 @@ const findExecutable = (executable) => {
  */
 const execGcloud = async (args, executable = 'gcloud', silent = false) => {
   const command = findExecutable(executable);
+
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+
   const result = await exec.getExecOutput(command, args, {
     silent,
     ignoreReturnCode: true,
+    env: gcloudEnv,
   });
 
   if (result.exitCode !== 0) {

--- a/setup-gcloud/src/get-access-token.js
+++ b/setup-gcloud/src/get-access-token.js
@@ -1,0 +1,58 @@
+import * as core from '@actions/core';
+
+import { authType, getCurrentAccount } from './auth-gcloud.js';
+import { execGcloud } from './exec-gcloud.js';
+
+async function introspectToken(accessToken) {
+  if (core.isDebug()) {
+    const params = new URLSearchParams();
+    params.append('access_token', accessToken);
+    await fetch('https://oauth2.googleapis.com/tokeninfo', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params,
+    })
+      .then((response) => response.json())
+      .then((tokenInfo) =>
+        core.debug(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`),
+      )
+      .catch((err) => core.error(`Failed to debug token info: ${err.message}`));
+  }
+}
+
+/**
+ * Get an access token valid for 60 minutes representing the GCP service account. This token will take precedence of
+ * all other credential types when google-auth SDKs are used.
+ *
+ * @return {Promise<string>} the access token
+ */
+export async function getAccessToken() {
+  const current = getCurrentAccount();
+  if (!current) {
+    return null;
+  }
+
+  const { type, email } = current;
+
+  const args = ['auth', 'print-access-token'];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+
+  const accessToken = await execGcloud(args, 'gcloud', true).catch((err) => {
+    core.warning(
+      'Missing permissions to create a long-lived access token. Short-lived 10 minute tokens will be used.',
+    );
+    core.debug(err.message);
+    return null;
+  });
+
+  if (accessToken) {
+    core.setSecret(accessToken);
+    await introspectToken(accessToken);
+  }
+
+  return accessToken;
+}

--- a/setup-gcloud/src/get-id-token.js
+++ b/setup-gcloud/src/get-id-token.js
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 
-import { getCurrentAccount } from './auth-gcloud.js';
+import { authType, getCurrentAccount } from './auth-gcloud.js';
 import { execGcloud } from './exec-gcloud.js';
 
 /**
@@ -17,7 +17,7 @@ export async function getIdToken(audience) {
 
   const args = ['auth', 'print-identity-token', `--audiences=${audience}`];
 
-  if (account.type === 'wid_federation') {
+  if (account.type === authType.widFederation) {
     args.push(
       `--impersonate-service-account=${account.email}`,
       '--include-email',

--- a/setup-gcloud/src/index.js
+++ b/setup-gcloud/src/index.js
@@ -1,5 +1,7 @@
 import * as core from '@actions/core';
 
+import { env } from './auth-gcloud.js';
+import { getAccessToken } from './get-access-token.js';
 import setupGcloud from './setup-gcloud.js';
 import withGcloud from './with-gcloud.js';
 
@@ -11,6 +13,12 @@ const action = async () => {
   const exportCredentials =
     core.getInput('export-default-credentials') || 'false';
   await setupGcloud(serviceAccountKey, version, exportCredentials === 'true');
+
+  const accessToken = await getAccessToken();
+  if (accessToken) {
+    core.info(`Export ${env.accessToken}`);
+    core.exportVariable(env.accessToken, accessToken);
+  }
 };
 
 export default action;

--- a/setup-gcloud/src/post.js
+++ b/setup-gcloud/src/post.js
@@ -1,12 +1,17 @@
-import { cleanupCredentials, getCredentialFilesFromState } from './cleanup.js';
+import { run } from 'action-utils';
 
+import { resetAuthStack } from './auth-gcloud.js';
+import { cleanupCredentials, getCredentialFilesFromState } from './cleanup.js';
 /**
  * Post-step cleanup for setup-gcloud action.
  * Runs at the end of the job to delete all credential files and directories.
  */
-const postAction = () => {
+const postAction = async () => {
   const credentialFiles = getCredentialFilesFromState();
   cleanupCredentials(credentialFiles);
+
+  // Reset auth stack to clear environment variables such as access tokens
+  await resetAuthStack();
 };
 
-postAction();
+run(postAction);

--- a/setup-gcloud/src/with-gcloud.js
+++ b/setup-gcloud/src/with-gcloud.js
@@ -45,7 +45,7 @@ const withGcloud = async (serviceAccountKey, fn) => {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
       // Unset exported env vars and remove persistent files.
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/setup-gcloud/test/auth-gcloud-refresh.test.js
+++ b/setup-gcloud/test/auth-gcloud-refresh.test.js
@@ -6,10 +6,12 @@ import {
   workloadIdentityFederation,
 } from '../src/auth-wid-federation.js';
 import createJobScopedCredential from '../src/create-job-scoped-credential.js';
+import { execGcloud } from '../src/exec-gcloud.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/create-job-scoped-credential.js');
 vi.mock('../src/auth-wid-federation.js');
+vi.mock('../src/exec-gcloud.js');
 
 vi.mock('../src/auth-stack.js', () => {
   let authStack = [];
@@ -29,15 +31,16 @@ const encodeCredentials = (credentials) =>
   Buffer.from(JSON.stringify(credentials), 'utf8').toString('base64');
 
 describe('auth-gcloud refresh token', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     process.env.CLOUDSDK_CORE_PROJECT = undefined;
     process.env.GOOGLE_APPLICATION_CREDENTIALS = undefined;
     process.env.CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE = undefined;
-    resetAuthStack();
+    await resetAuthStack();
+    execGcloud.mockResolvedValue('token-123');
   });
 
-  afterEach(() => {
-    resetAuthStack();
+  afterEach(async () => {
+    await resetAuthStack();
     vi.clearAllMocks();
   });
 

--- a/setup-gcloud/test/auth-gcloud-refresh.test.js
+++ b/setup-gcloud/test/auth-gcloud-refresh.test.js
@@ -6,12 +6,10 @@ import {
   workloadIdentityFederation,
 } from '../src/auth-wid-federation.js';
 import createJobScopedCredential from '../src/create-job-scoped-credential.js';
-import { execGcloud } from '../src/exec-gcloud.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/create-job-scoped-credential.js');
 vi.mock('../src/auth-wid-federation.js');
-vi.mock('../src/exec-gcloud.js');
 
 vi.mock('../src/auth-stack.js', () => {
   let authStack = [];
@@ -36,7 +34,6 @@ describe('auth-gcloud refresh token', () => {
     process.env.GOOGLE_APPLICATION_CREDENTIALS = undefined;
     process.env.CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE = undefined;
     await resetAuthStack();
-    execGcloud.mockResolvedValue('token-123');
   });
 
   afterEach(async () => {

--- a/setup-gcloud/test/auth-gcloud.test.js
+++ b/setup-gcloud/test/auth-gcloud.test.js
@@ -254,7 +254,11 @@ describe('auth-gcloud', () => {
     );
 
     expect(execGcloud).toHaveBeenCalledWith(
-      ['auth', 'print-access-token'],
+      [
+        'auth',
+        'print-access-token',
+        '--impersonate-service-account=json-sa@example.iam.gserviceaccount.com',
+      ],
       'gcloud',
       true,
     );

--- a/setup-gcloud/test/auth-gcloud.test.js
+++ b/setup-gcloud/test/auth-gcloud.test.js
@@ -11,10 +11,12 @@ import {
 } from '../src/auth-gcloud.js';
 import { workloadIdentityFederation } from '../src/auth-wid-federation.js';
 import createJobScopedCredential from '../src/create-job-scoped-credential.js';
+import { execGcloud } from '../src/exec-gcloud.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/create-job-scoped-credential.js');
 vi.mock('../src/auth-wid-federation.js');
+vi.mock('../src/exec-gcloud.js');
 
 const encodeCredentials = (credentials) =>
   Buffer.from(JSON.stringify(credentials), 'utf8').toString('base64');
@@ -22,7 +24,7 @@ const encodeCredentials = (credentials) =>
 describe('auth-gcloud', () => {
   let orgEnv;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockFs({
       '/runner/temp': {},
     });
@@ -36,11 +38,12 @@ describe('auth-gcloud', () => {
       GOOGLE_APPLICATION_CREDENTIALS: undefined,
       CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: undefined,
     };
-    resetAuthStack();
+    await resetAuthStack();
+    execGcloud.mockResolvedValue('token-123');
   });
 
-  afterEach(() => {
-    resetAuthStack();
+  afterEach(async () => {
+    await resetAuthStack();
     process.env = orgEnv;
     mockFs.restore();
     vi.clearAllMocks();
@@ -216,7 +219,7 @@ describe('auth-gcloud', () => {
     expect(getCurrentAccount()).toBeTruthy();
     expect(process.env.CLOUDSDK_CORE_PROJECT).toBe('project-a');
 
-    resetAuthStack();
+    await resetAuthStack();
 
     expect(getCurrentAccount()).toBeUndefined();
     expect(process.env.CLOUDSDK_CORE_PROJECT).toBeUndefined();
@@ -233,6 +236,101 @@ describe('auth-gcloud', () => {
     expect(core.exportVariable).toHaveBeenCalledWith(
       'CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE',
       '',
+    );
+  });
+
+  test('authenticateGcloud sets CLOUDSDK_AUTH_ACCESS_TOKEN and masks it via core.setSecret', async () => {
+    createJobScopedCredential.mockReturnValueOnce(
+      '/runner/temp/setup-gcloud-xxx/credential-key.json',
+    );
+
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key',
+        client_email: 'json-sa@example.iam.gserviceaccount.com',
+        project_id: 'project-a',
+      }),
+      true,
+    );
+
+    expect(execGcloud).toHaveBeenCalledWith(
+      ['auth', 'print-access-token'],
+      'gcloud',
+      true,
+    );
+    expect(core.setSecret).toHaveBeenCalledWith('token-123');
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      'token-123',
+    );
+  });
+
+  test('resetAuthStack clears CLOUDSDK_AUTH_ACCESS_TOKEN without shelling out to gcloud', async () => {
+    createJobScopedCredential.mockReturnValueOnce(
+      '/runner/temp/setup-gcloud-xxx/credential-key.json',
+    );
+
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key',
+        client_email: 'json-sa@example.iam.gserviceaccount.com',
+        project_id: 'project-a',
+      }),
+      true,
+    );
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
+
+    vi.clearAllMocks();
+    await resetAuthStack();
+
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBeUndefined();
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      '',
+    );
+    // credentialsFilePath is '' during reset — must not shell out to gcloud
+    expect(execGcloud).not.toHaveBeenCalled();
+  });
+
+  test('restorePreviousAccount re-fetches and sets CLOUDSDK_AUTH_ACCESS_TOKEN', async () => {
+    createJobScopedCredential
+      .mockReturnValueOnce(
+        '/runner/temp/setup-gcloud-xxx/credential-first.json',
+      )
+      .mockReturnValueOnce(
+        '/runner/temp/setup-gcloud-xxx/credential-second.json',
+      );
+
+    execGcloud.mockResolvedValue('token-first');
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key-a',
+        client_email: 'first@example.iam.gserviceaccount.com',
+        project_id: 'project-first',
+      }),
+      true,
+    );
+    const previousAccount = getCurrentAccount();
+
+    execGcloud.mockResolvedValue('token-second');
+    await authenticateGcloud(
+      encodeCredentials({
+        private_key: 'private-key-b',
+        client_email: 'second@example.iam.gserviceaccount.com',
+        project_id: 'project-second',
+      }),
+      true,
+    );
+
+    execGcloud.mockResolvedValue('token-restored');
+    await restorePreviousAccount(previousAccount);
+
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-restored');
+    expect(core.setSecret).toHaveBeenCalledWith('token-restored');
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      'token-restored',
     );
   });
 

--- a/setup-gcloud/test/auth-gcloud.test.js
+++ b/setup-gcloud/test/auth-gcloud.test.js
@@ -11,12 +11,10 @@ import {
 } from '../src/auth-gcloud.js';
 import { workloadIdentityFederation } from '../src/auth-wid-federation.js';
 import createJobScopedCredential from '../src/create-job-scoped-credential.js';
-import { execGcloud } from '../src/exec-gcloud.js';
 
 vi.mock('@actions/core');
 vi.mock('../src/create-job-scoped-credential.js');
 vi.mock('../src/auth-wid-federation.js');
-vi.mock('../src/exec-gcloud.js');
 
 const encodeCredentials = (credentials) =>
   Buffer.from(JSON.stringify(credentials), 'utf8').toString('base64');
@@ -39,7 +37,6 @@ describe('auth-gcloud', () => {
       CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: undefined,
     };
     await resetAuthStack();
-    execGcloud.mockResolvedValue('token-123');
   });
 
   afterEach(async () => {
@@ -239,131 +236,6 @@ describe('auth-gcloud', () => {
     );
   });
 
-  test('authenticateGcloud sets CLOUDSDK_AUTH_ACCESS_TOKEN and masks it via core.setSecret', async () => {
-    createJobScopedCredential.mockReturnValueOnce(
-      '/runner/temp/setup-gcloud-xxx/credential-key.json',
-    );
-
-    await authenticateGcloud(
-      encodeCredentials({
-        private_key: 'private-key',
-        client_email: 'json-sa@example.iam.gserviceaccount.com',
-        project_id: 'project-a',
-      }),
-      true,
-    );
-
-    expect(execGcloud).toHaveBeenCalledWith(
-      ['auth', 'print-access-token'],
-      'gcloud',
-      true,
-    );
-    expect(core.setSecret).toHaveBeenCalledWith('token-123');
-    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
-    expect(core.exportVariable).toHaveBeenCalledWith(
-      'CLOUDSDK_AUTH_ACCESS_TOKEN',
-      'token-123',
-    );
-  });
-
-  test('authenticateGcloud sets CLOUDSDK_AUTH_ACCESS_TOKEN for WIF', async () => {
-    createJobScopedCredential.mockReturnValueOnce(
-      '/runner/temp/setup-gcloud-xxx/credential-key.json',
-    );
-
-    const credentials = {
-      workload_identity_provider:
-        'projects/123/locations/global/workloadIdentityPools/pool/providers/provider',
-      email: 'wid-sa@example.iam.gserviceaccount.com',
-      project_id: 'project-wid',
-    };
-
-    await authenticateGcloud(encodeCredentials(credentials), true);
-
-    expect(execGcloud).toHaveBeenCalledWith(
-      [
-        'auth',
-        'print-access-token',
-        '--impersonate-service-account=wid-sa@example.iam.gserviceaccount.com',
-      ],
-      'gcloud',
-      true,
-    );
-    expect(core.setSecret).toHaveBeenCalledWith('token-123');
-    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
-    expect(core.exportVariable).toHaveBeenCalledWith(
-      'CLOUDSDK_AUTH_ACCESS_TOKEN',
-      'token-123',
-    );
-  });
-
-  test('resetAuthStack clears CLOUDSDK_AUTH_ACCESS_TOKEN without shelling out to gcloud', async () => {
-    createJobScopedCredential.mockReturnValueOnce(
-      '/runner/temp/setup-gcloud-xxx/credential-key.json',
-    );
-
-    await authenticateGcloud(
-      encodeCredentials({
-        private_key: 'private-key',
-        client_email: 'json-sa@example.iam.gserviceaccount.com',
-        project_id: 'project-a',
-      }),
-      true,
-    );
-    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
-
-    vi.clearAllMocks();
-    await resetAuthStack();
-
-    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBeUndefined();
-    expect(core.exportVariable).toHaveBeenCalledWith(
-      'CLOUDSDK_AUTH_ACCESS_TOKEN',
-      '',
-    );
-    // credentialsFilePath is '' during reset — must not shell out to gcloud
-    expect(execGcloud).not.toHaveBeenCalled();
-  });
-
-  test('restorePreviousAccount re-fetches and sets CLOUDSDK_AUTH_ACCESS_TOKEN', async () => {
-    createJobScopedCredential
-      .mockReturnValueOnce(
-        '/runner/temp/setup-gcloud-xxx/credential-first.json',
-      )
-      .mockReturnValueOnce(
-        '/runner/temp/setup-gcloud-xxx/credential-second.json',
-      );
-
-    execGcloud.mockResolvedValue('token-first');
-    await authenticateGcloud(
-      encodeCredentials({
-        private_key: 'private-key-a',
-        client_email: 'first@example.iam.gserviceaccount.com',
-        project_id: 'project-first',
-      }),
-      true,
-    );
-    const previousAccount = getCurrentAccount();
-
-    execGcloud.mockResolvedValue('token-second');
-    await authenticateGcloud(
-      encodeCredentials({
-        private_key: 'private-key-b',
-        client_email: 'second@example.iam.gserviceaccount.com',
-        project_id: 'project-second',
-      }),
-      true,
-    );
-
-    execGcloud.mockResolvedValue('token-restored');
-    await restorePreviousAccount(previousAccount);
-
-    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-restored');
-    expect(core.setSecret).toHaveBeenCalledWith('token-restored');
-    expect(core.exportVariable).toHaveBeenCalledWith(
-      'CLOUDSDK_AUTH_ACCESS_TOKEN',
-      'token-restored',
-    );
-  });
 
   test('rejects when decoded credentials are not valid JSON', async () => {
     await expect(

--- a/setup-gcloud/test/auth-gcloud.test.js
+++ b/setup-gcloud/test/auth-gcloud.test.js
@@ -254,10 +254,37 @@ describe('auth-gcloud', () => {
     );
 
     expect(execGcloud).toHaveBeenCalledWith(
+      ['auth', 'print-access-token'],
+      'gcloud',
+      true,
+    );
+    expect(core.setSecret).toHaveBeenCalledWith('token-123');
+    expect(process.env.CLOUDSDK_AUTH_ACCESS_TOKEN).toBe('token-123');
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      'token-123',
+    );
+  });
+
+  test('authenticateGcloud sets CLOUDSDK_AUTH_ACCESS_TOKEN for WIF', async () => {
+    createJobScopedCredential.mockReturnValueOnce(
+      '/runner/temp/setup-gcloud-xxx/credential-key.json',
+    );
+
+    const credentials = {
+      workload_identity_provider:
+        'projects/123/locations/global/workloadIdentityPools/pool/providers/provider',
+      email: 'wid-sa@example.iam.gserviceaccount.com',
+      project_id: 'project-wid',
+    };
+
+    await authenticateGcloud(encodeCredentials(credentials), true);
+
+    expect(execGcloud).toHaveBeenCalledWith(
       [
         'auth',
         'print-access-token',
-        '--impersonate-service-account=json-sa@example.iam.gserviceaccount.com',
+        '--impersonate-service-account=wid-sa@example.iam.gserviceaccount.com',
       ],
       'gcloud',
       true,

--- a/setup-gcloud/test/exec-gcloud.test.js
+++ b/setup-gcloud/test/exec-gcloud.test.js
@@ -35,6 +35,7 @@ describe('execGcloud', () => {
     expect(exec.getExecOutput).toHaveBeenCalledWith('gcloud', ['version'], {
       silent: true,
       ignoreReturnCode: true,
+      env: expect.any(Object),
     });
   });
 
@@ -78,6 +79,7 @@ describe('execGcloud', () => {
     expect(exec.getExecOutput).toHaveBeenCalledWith('gsutil', ['ls'], {
       silent: false,
       ignoreReturnCode: true,
+      env: expect.any(Object),
     });
   });
 });

--- a/setup-gcloud/test/get-access-token.test.js
+++ b/setup-gcloud/test/get-access-token.test.js
@@ -1,0 +1,151 @@
+import * as core from '@actions/core';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getCurrentAccount } from '../src/auth-gcloud.js';
+import { execGcloud } from '../src/exec-gcloud.js';
+import { getAccessToken } from '../src/get-access-token.js';
+
+vi.mock('@actions/core');
+vi.mock('../src/exec-gcloud.js');
+vi.mock('../src/auth-gcloud.js');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('returns access token for JSON key type', async () => {
+  execGcloud.mockResolvedValue('access-token-123');
+  getCurrentAccount.mockReturnValue({
+    type: 'json_key',
+    email: 'json-sa@example.iam.gserviceaccount.com',
+  });
+
+  const token = await getAccessToken();
+
+  expect(token).toBe('access-token-123');
+  expect(execGcloud).toHaveBeenCalledWith(
+    ['auth', 'print-access-token'],
+    'gcloud',
+    true,
+  );
+  expect(core.setSecret).toHaveBeenCalledWith('access-token-123');
+});
+
+test('returns access token for WIF type with impersonation flag', async () => {
+  execGcloud.mockResolvedValue('access-token-456');
+  getCurrentAccount.mockReturnValue({
+    type: 'wid_federation',
+    email: 'wid-sa@example.iam.gserviceaccount.com',
+  });
+
+  const token = await getAccessToken();
+
+  expect(token).toBe('access-token-456');
+  expect(execGcloud).toHaveBeenCalledWith(
+    [
+      'auth',
+      'print-access-token',
+      '--impersonate-service-account=wid-sa@example.iam.gserviceaccount.com',
+    ],
+    'gcloud',
+    true,
+  );
+  expect(core.setSecret).toHaveBeenCalledWith('access-token-456');
+});
+
+test('masks the access token as a secret', async () => {
+  execGcloud.mockResolvedValue('secret-token');
+  getCurrentAccount.mockReturnValue({
+    type: 'json_key',
+    email: 'json-sa@example.iam.gserviceaccount.com',
+  });
+
+  await getAccessToken();
+
+  expect(core.setSecret).toHaveBeenCalledTimes(1);
+  expect(core.setSecret).toHaveBeenCalledWith('secret-token');
+});
+
+test('returns null when no account is authenticated', async () => {
+  getCurrentAccount.mockReturnValue(undefined);
+
+  await expect(getAccessToken()).resolves.toBeNull();
+
+  expect(execGcloud).not.toHaveBeenCalled();
+  expect(core.setSecret).not.toHaveBeenCalled();
+});
+
+test('returns null and logs a warning when execGcloud fails', async () => {
+  getCurrentAccount.mockReturnValue({
+    type: 'json_key',
+    email: 'json-sa@example.iam.gserviceaccount.com',
+  });
+  execGcloud.mockRejectedValue(new Error('permission denied'));
+
+  await expect(getAccessToken()).resolves.toBeNull();
+
+  expect(core.warning).toHaveBeenCalledWith(
+    expect.stringContaining('Missing permissions'),
+  );
+  expect(core.debug).toHaveBeenCalledWith('permission denied');
+  expect(core.setSecret).not.toHaveBeenCalled();
+});
+
+describe('debug mode', () => {
+  test('logs token info when core.isDebug() is true', async () => {
+    execGcloud.mockResolvedValue('debug-token');
+    core.isDebug.mockReturnValue(true);
+    getCurrentAccount.mockReturnValue({
+      type: 'json_key',
+      email: 'json-sa@example.iam.gserviceaccount.com',
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      json: () => Promise.resolve({ expires_in: 3600, email: 'json-sa@example.iam.gserviceaccount.com' }),
+    });
+
+    const token = await getAccessToken();
+
+    expect(token).toBe('debug-token');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/tokeninfo',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(core.debug).toHaveBeenCalledWith(
+      expect.stringContaining('expires_in'),
+    );
+  });
+
+  test('does not propagate errors from tokeninfo fetch in debug mode', async () => {
+    execGcloud.mockResolvedValue('debug-token');
+    core.isDebug.mockReturnValue(true);
+    getCurrentAccount.mockReturnValue({
+      type: 'json_key',
+      email: 'json-sa@example.iam.gserviceaccount.com',
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('network failure'),
+    );
+
+    await expect(getAccessToken()).resolves.toBe('debug-token');
+    expect(core.error).toHaveBeenCalledWith(
+      expect.stringContaining('network failure'),
+    );
+  });
+
+  test('does not call tokeninfo when core.isDebug() is false', async () => {
+    execGcloud.mockResolvedValue('token');
+    core.isDebug.mockReturnValue(false);
+    getCurrentAccount.mockReturnValue({
+      type: 'json_key',
+      email: 'json-sa@example.iam.gserviceaccount.com',
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await getAccessToken();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/setup-gcloud/test/index.test.js
+++ b/setup-gcloud/test/index.test.js
@@ -1,18 +1,26 @@
 import * as core from '@actions/core';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { getAccessToken } from '../src/get-access-token.js';
 import { action } from '../src/index.js';
 import setupGcloud from '../src/setup-gcloud.js';
 
 vi.mock('../src/setup-gcloud.js');
+vi.mock('../src/get-access-token.js');
 vi.mock('@actions/core');
 
 describe('setup-gcloud action', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getAccessToken.mockResolvedValue(null);
+  });
+
   test('It can install latest', async () => {
     core.getInput.mockReturnValueOnce('key').mockReturnValue('');
     await action();
     expect(setupGcloud).toHaveBeenCalledWith('key', 'latest', false);
   });
+
   test('It can install specified version', async () => {
     core.getInput
       .mockReturnValueOnce('key')
@@ -20,5 +28,27 @@ describe('setup-gcloud action', () => {
       .mockReturnValue('');
     await action();
     expect(setupGcloud).toHaveBeenCalledWith('key', '300.0.0', false);
+  });
+
+  test('exports CLOUDSDK_AUTH_ACCESS_TOKEN when getAccessToken returns a token', async () => {
+    core.getInput.mockReturnValueOnce('key').mockReturnValue('');
+    getAccessToken.mockResolvedValue('my-access-token');
+
+    await action();
+
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'CLOUDSDK_AUTH_ACCESS_TOKEN',
+      'my-access-token',
+    );
+  });
+
+  test('does not export CLOUDSDK_AUTH_ACCESS_TOKEN when getAccessToken returns null', async () => {
+    core.getInput.mockReturnValueOnce('key').mockReturnValue('');
+
+    await action();
+
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(core.exportVariable).not.toHaveBeenCalled();
   });
 });

--- a/setup-gcloud/test/post.test.js
+++ b/setup-gcloud/test/post.test.js
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const getCredentialFilesFromState = vi.fn();
 const cleanupCredentials = vi.fn();
+const resetAuthStack = vi.fn();
 
 vi.mock('../src/cleanup.js', () => ({
   getCredentialFilesFromState,
   cleanupCredentials,
+}));
+
+vi.mock('../src/auth-gcloud.js', () => ({
+  resetAuthStack,
 }));
 
 describe('post cleanup', () => {
@@ -23,6 +28,7 @@ describe('post cleanup', () => {
       '/tmp/a.json',
       '/tmp/b.json',
     ]);
+    resetAuthStack.mockResolvedValueOnce(undefined);
 
     await import('../src/post.js');
 
@@ -31,14 +37,17 @@ describe('post cleanup', () => {
       '/tmp/a.json',
       '/tmp/b.json',
     ]);
+    expect(resetAuthStack).toHaveBeenCalledTimes(1);
   });
 
   test('passes empty list to cleanup when no state exists', async () => {
     getCredentialFilesFromState.mockReturnValueOnce([]);
+    resetAuthStack.mockResolvedValueOnce(undefined);
 
     await import('../src/post.js');
 
     expect(getCredentialFilesFromState).toHaveBeenCalledTimes(1);
     expect(cleanupCredentials).toHaveBeenCalledWith([]);
+    expect(resetAuthStack).toHaveBeenCalledTimes(1);
   });
 });

--- a/slack-message/dist/index.cjs
+++ b/slack-message/dist/index.cjs
@@ -106848,13 +106848,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -106874,6 +106881,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -106890,7 +106898,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -106971,6 +106979,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/slack-message/dist/index.cjs
+++ b/slack-message/dist/index.cjs
@@ -72181,15 +72181,363 @@ __name(fixResponseChunkedTransferBadEnding, "fixResponseChunkedTransferBadEnding
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs3.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs3.default.existsSync(authStackFilePath())) {
+    import_node_fs3.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs5 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
+    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs7 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs6 = __toESM(require("fs"), 1);
+var fs9 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -72227,10 +72575,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -72238,7 +72586,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -72278,7 +72626,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -72316,10 +72664,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -72390,13 +72738,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -72413,12 +72761,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -72437,8 +72785,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -72449,12 +72797,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i3 = 1; i3 < this.segments.length; i3++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i3];
     }
@@ -72490,7 +72838,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x3) => _Pattern.getLiteral(x3)).filter((x3) => !foundGlob && !(foundGlob =
@@ -72515,8 +72863,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -72554,10 +72902,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -72800,7 +73148,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs6.promises.lstat(searchPath));
+          yield __await(fs9.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -72824,7 +73172,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -72834,7 +73182,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs6.promises.readdir(item.path))).map((x3) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs9.promises.readdir(item.path))).map((x3) => new SearchState(path12.join(item.
           path, x3), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -72870,7 +73218,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs6.promises.stat(item.path);
+          stats = yield fs9.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -72882,10 +73230,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs6.promises.lstat(item.path);
+        stats = yield fs9.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs6.promises.realpath(item.path);
+        const realPath = yield fs9.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -72941,8 +73289,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs7 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs10 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -73042,16 +73390,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs7.statSync(filePath).size;
+  return fs10.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -73069,7 +73417,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -73092,7 +73440,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs7.unlink)(filePath);
+    return util4.promisify(fs10.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -73138,7 +73486,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs7.existsSync(GnuTarPathOnWindows)) {
+    if (fs10.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -73175,7 +73523,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs10 = __toESM(require("fs"), 1);
+var fs13 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -73190,11 +73538,11 @@ var AbortError2 = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util4 = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util4.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util4.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -75190,7 +75538,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -75198,7 +75546,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -101316,7 +101664,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_util6 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -101356,7 +101704,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs3.default.createWriteStream(file);
+    const ws = import_node_fs6.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -101368,8 +101716,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util6.default.promisify(import_node_fs3.default.stat);
-var fsCreateReadStream = import_node_fs3.default.createReadStream;
+var fsStat = import_node_util6.default.promisify(import_node_fs6.default.stat);
+var fsCreateReadStream = import_node_fs6.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -104293,7 +104641,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -104572,7 +104920,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs9.createWriteStream(archivePath);
+    const writeStream = fs12.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -104598,7 +104946,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs9.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs12.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -104717,7 +105065,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs9.openSync(archivePath, "w");
+      const fd = fs12.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -104736,12 +105084,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs9.writeFileSync(fd, result);
+            fs12.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs9.closeSync(fd);
+        fs12.closeSync(fd);
       }
     }
   });
@@ -105044,7 +105392,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs10.openSync(archivePath, "r");
+    const fd = fs13.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -105058,7 +105406,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs10.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs13.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -105069,7 +105417,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs10.closeSync(fd);
+      fs13.closeSync(fd);
     }
     return;
   });
@@ -105111,26 +105459,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime338 = __toESM(require_commonjs(), 1);
+var import_runtime345 = __toESM(require_commonjs(), 1);
+var import_runtime346 = __toESM(require_commonjs(), 1);
+var import_runtime347 = __toESM(require_commonjs(), 1);
+var import_runtime348 = __toESM(require_commonjs(), 1);
+var import_runtime349 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime339 = __toESM(require_commonjs(), 1);
 var import_runtime340 = __toESM(require_commonjs(), 1);
 var import_runtime341 = __toESM(require_commonjs(), 1);
 var import_runtime342 = __toESM(require_commonjs(), 1);
+var import_runtime343 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime332 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime333 = __toESM(require_commonjs(), 1);
 var import_runtime334 = __toESM(require_commonjs(), 1);
 var import_runtime335 = __toESM(require_commonjs(), 1);
 var import_runtime336 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime326 = __toESM(require_commonjs(), 1);
-var import_runtime327 = __toESM(require_commonjs(), 1);
-var import_runtime328 = __toESM(require_commonjs(), 1);
-var import_runtime329 = __toESM(require_commonjs(), 1);
-var import_runtime330 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime330.MessageType {
+var import_runtime337 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -105154,9 +105502,9 @@ var CacheScope$Type = class extends import_runtime330.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105178,26 +105526,26 @@ var CacheScope$Type = class extends import_runtime330.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime326.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime333.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime326.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime333.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime336.MessageType {
+var CacheMetadata$Type = class extends import_runtime343.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -105215,9 +105563,9 @@ var CacheMetadata$Type = class extends import_runtime336.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime335.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime334.reflectionMergePartial)(this, message, value);
+      (0, import_runtime341.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105239,27 +105587,27 @@ var CacheMetadata$Type = class extends import_runtime336.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime333.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime332.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime339.WireType.Varint).int64(message.repositoryId);
     for (let i3 = 0; i3 < message.scope.length; i3++)
-      CacheScope.internalBinaryWrite(message.scope[i3], writer.tag(2, import_runtime332.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i3], writer.tag(2, import_runtime339.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime333.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime342.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime349.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -105284,9 +105632,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime342.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime341.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime348.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime340.reflectionMergePartial)(this, message, value);
+      (0, import_runtime347.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105312,27 +105660,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime342.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime339.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime346.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime338.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime345.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime338.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime345.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime338.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime345.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime339.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime346.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime342.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime349.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -105363,9 +105711,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime342.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime341.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime348.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime340.reflectionMergePartial)(this, message, value);
+      (0, import_runtime347.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105391,26 +105739,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime342.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime339.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime346.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime338.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime345.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime338.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime345.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime338.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime345.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime339.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime346.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime342.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime349.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -105442,9 +105790,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime342.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime341.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime348.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime340.reflectionMergePartial)(this, message, value);
+      (0, import_runtime347.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105474,29 +105822,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime342.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime339.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime346.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime338.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime345.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime338.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime345.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime338.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime345.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime338.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime345.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime339.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime346.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime342.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime349.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -105527,9 +105875,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime342.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime341.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime348.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime340.reflectionMergePartial)(this, message, value);
+      (0, import_runtime347.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105555,26 +105903,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime342.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime339.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime346.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime338.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime345.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime338.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime345.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime338.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime345.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime339.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime346.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime342.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime349.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -105607,9 +105955,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime342.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime341.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime348.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime340.reflectionMergePartial)(this, message, value);
+      (0, import_runtime347.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105639,29 +105987,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime342.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime339.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime346.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime338.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime345.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime338.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime345.WireType.LengthDelimited).string(message.key);
     for (let i3 = 0; i3 < message.restoreKeys.length; i3++)
-      writer.tag(3, import_runtime338.WireType.LengthDelimited).string(message.restoreKeys[i3]);
+      writer.tag(3, import_runtime345.WireType.LengthDelimited).string(message.restoreKeys[i3]);
     if (message.version !== "")
-      writer.tag(4, import_runtime338.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime345.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime339.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime346.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime342.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime349.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -105692,9 +106040,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime342.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime341.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime348.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime340.reflectionMergePartial)(this, message, value);
+      (0, import_runtime347.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -105720,21 +106068,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime342.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime339.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime346.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime338.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime345.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime338.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime345.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime338.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime345.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime339.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime346.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -106006,7 +106354,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -106082,16 +106430,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -106141,7 +106489,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -106150,7 +106498,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -106166,7 +106514,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -106175,7 +106523,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -106218,7 +106566,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -106344,7 +106692,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -106415,7 +106763,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -106481,7 +106829,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -106556,7 +106904,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -106632,380 +106980,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs4.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs4.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs4.default.existsSync(authStackFilePath())) {
-    import_node_fs4.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs4.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs4.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs6 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs5.default.existsSync(jobScopedDir)) {
-    import_node_fs5.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs5.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs6.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/slack-message/dist/index.cjs
+++ b/slack-message/dist/index.cjs
@@ -75825,16 +75825,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -75943,13 +75943,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -75979,7 +75979,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -76005,7 +76005,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -76027,7 +76027,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -76038,7 +76038,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -76059,7 +76059,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -106848,6 +106848,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -106863,7 +106872,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -106877,6 +106886,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -106924,7 +106938,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -106950,11 +106964,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -106972,7 +106986,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -107192,7 +107206,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/slack-message/dist/index.cjs
+++ b/slack-message/dist/index.cjs
@@ -106848,18 +106848,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -106880,6 +106886,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -106898,7 +106905,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/slack-notify/dist/index.cjs
+++ b/slack-notify/dist/index.cjs
@@ -100015,18 +100015,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100047,6 +100053,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100065,7 +100072,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/slack-notify/dist/index.cjs
+++ b/slack-notify/dist/index.cjs
@@ -65348,15 +65348,363 @@ var import_node_fs8 = __toESM(require("node:fs"), 1);
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65394,10 +65742,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65405,7 +65753,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65445,7 +65793,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65483,10 +65831,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65557,13 +65905,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65580,12 +65928,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65604,8 +65952,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65616,12 +65964,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65657,7 +66005,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65682,8 +66030,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65721,10 +66069,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -65967,7 +66315,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -65991,7 +66339,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -66001,7 +66349,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66037,7 +66385,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66049,10 +66397,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66108,8 +66456,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66209,16 +66557,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66236,7 +66584,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66259,7 +66607,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66305,7 +66653,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66342,7 +66690,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66357,11 +66705,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68357,7 +68705,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68365,7 +68713,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94483,7 +94831,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94523,7 +94871,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94535,8 +94883,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97460,7 +97808,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97739,7 +98087,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97765,7 +98113,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97884,7 +98232,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -97903,12 +98251,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98211,7 +98559,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98225,7 +98573,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98236,7 +98584,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98278,26 +98626,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98321,9 +98669,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98345,26 +98693,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98382,9 +98730,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98406,27 +98754,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98451,9 +98799,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98479,27 +98827,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98530,9 +98878,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98558,26 +98906,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98609,9 +98957,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98641,29 +98989,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98694,9 +99042,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98722,26 +99070,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98774,9 +99122,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98806,29 +99154,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98859,9 +99207,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98887,21 +99235,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99173,7 +99521,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99249,16 +99597,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99308,7 +99656,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99317,7 +99665,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99333,7 +99681,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99342,7 +99690,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99385,7 +99733,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99511,7 +99859,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99582,7 +99930,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99648,7 +99996,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99723,7 +100071,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99799,380 +100147,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/slack-notify/dist/index.cjs
+++ b/slack-notify/dist/index.cjs
@@ -68992,16 +68992,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69110,13 +69110,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69146,7 +69146,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69172,7 +69172,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69194,7 +69194,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69205,7 +69205,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69226,7 +69226,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100015,6 +100015,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100030,7 +100039,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100044,6 +100053,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100091,7 +100105,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -100117,11 +100131,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -100139,7 +100153,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100359,7 +100373,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/slack-notify/dist/index.cjs
+++ b/slack-notify/dist/index.cjs
@@ -100015,13 +100015,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100041,6 +100048,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100057,7 +100065,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100138,6 +100146,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/status-check/dist/index.cjs
+++ b/status-check/dist/index.cjs
@@ -104774,13 +104774,20 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -104800,6 +104807,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -104816,7 +104824,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -104897,6 +104905,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/status-check/dist/index.cjs
+++ b/status-check/dist/index.cjs
@@ -104774,18 +104774,24 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -104806,6 +104812,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -104824,7 +104831,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/status-check/dist/index.cjs
+++ b/status-check/dist/index.cjs
@@ -73748,16 +73748,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -73866,13 +73866,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -73902,7 +73902,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -73928,7 +73928,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -73950,7 +73950,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -73961,7 +73961,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -73982,7 +73982,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -104774,6 +104774,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -104789,7 +104798,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -104803,6 +104812,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -104850,7 +104864,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -104876,11 +104890,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -104898,7 +104912,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -105118,7 +105132,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/status-check/dist/index.cjs
+++ b/status-check/dist/index.cjs
@@ -70104,15 +70104,363 @@ __name(getOctokit, "getOctokit");
 // gcp-secret-manager/src/secrets.js
 var import_yaml = __toESM(require_dist3(), 1);
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth2, current) {
+  if (current) {
+    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -70150,10 +70498,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -70161,7 +70509,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -70201,7 +70549,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -70239,10 +70587,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -70313,13 +70661,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -70336,12 +70684,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -70360,8 +70708,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -70372,12 +70720,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -70413,7 +70761,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -70438,8 +70786,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -70477,10 +70825,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -70723,7 +71071,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -70747,7 +71095,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -70757,7 +71105,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -70793,7 +71141,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -70805,10 +71153,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -70864,8 +71212,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -70965,16 +71313,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -70992,7 +71340,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -71015,7 +71363,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter15(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -71061,7 +71409,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter15(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -71098,7 +71446,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -71113,11 +71461,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -73113,7 +73461,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -73121,7 +73469,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -99242,7 +99590,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -99282,7 +99630,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -99294,8 +99642,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -102219,7 +102567,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -102498,7 +102846,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter18(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient2 = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter18(this, void 0, void 0, function* () {
       return httpClient2.get(archiveLocation);
@@ -102524,7 +102872,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient2 = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -102643,7 +102991,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -102662,12 +103010,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -102970,7 +103318,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
   return __awaiter19(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -102984,7 +103332,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient2, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient2, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -102995,7 +103343,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -103037,26 +103385,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime339 = __toESM(require_commonjs(), 1);
+var import_runtime346 = __toESM(require_commonjs(), 1);
+var import_runtime347 = __toESM(require_commonjs(), 1);
+var import_runtime348 = __toESM(require_commonjs(), 1);
+var import_runtime349 = __toESM(require_commonjs(), 1);
+var import_runtime350 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime340 = __toESM(require_commonjs(), 1);
 var import_runtime341 = __toESM(require_commonjs(), 1);
 var import_runtime342 = __toESM(require_commonjs(), 1);
 var import_runtime343 = __toESM(require_commonjs(), 1);
+var import_runtime344 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime333 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime334 = __toESM(require_commonjs(), 1);
 var import_runtime335 = __toESM(require_commonjs(), 1);
 var import_runtime336 = __toESM(require_commonjs(), 1);
 var import_runtime337 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime327 = __toESM(require_commonjs(), 1);
-var import_runtime328 = __toESM(require_commonjs(), 1);
-var import_runtime329 = __toESM(require_commonjs(), 1);
-var import_runtime330 = __toESM(require_commonjs(), 1);
-var import_runtime331 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime331.MessageType {
+var import_runtime338 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -103080,9 +103428,9 @@ var CacheScope$Type = class extends import_runtime331.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103104,26 +103452,26 @@ var CacheScope$Type = class extends import_runtime331.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime327.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime334.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime327.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime334.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime337.MessageType {
+var CacheMetadata$Type = class extends import_runtime344.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -103141,9 +103489,9 @@ var CacheMetadata$Type = class extends import_runtime337.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime343.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime335.reflectionMergePartial)(this, message, value);
+      (0, import_runtime342.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103165,27 +103513,27 @@ var CacheMetadata$Type = class extends import_runtime337.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime341.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime333.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime340.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime333.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime340.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime341.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime343.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -103210,9 +103558,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime343.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103238,27 +103586,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime343.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime339.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime346.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime343.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -103289,9 +103637,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime343.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103317,26 +103665,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime343.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime339.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime346.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime343.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -103368,9 +103716,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime343.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103400,29 +103748,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime343.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime339.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime346.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime339.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime346.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime339.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime346.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime343.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -103453,9 +103801,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime343.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103481,26 +103829,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime343.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime339.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime346.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime339.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime346.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime343.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -103533,9 +103881,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime343.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103565,29 +103913,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime343.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime339.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime346.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime339.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime346.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime343.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime350.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -103618,9 +103966,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime343.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime342.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime349.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime341.reflectionMergePartial)(this, message, value);
+      (0, import_runtime348.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -103646,21 +103994,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime343.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime340.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime347.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime339.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime346.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime339.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime346.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime339.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime346.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime340.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime347.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -103932,7 +104280,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs3 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter21 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -104008,16 +104356,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -104067,7 +104415,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -104076,7 +104424,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -104092,7 +104440,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -104101,7 +104449,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -104144,7 +104492,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter21(this, void 0, void 0, function* () {
-    (0, import_fs3.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs3.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -104270,7 +104618,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -104341,7 +104689,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -104407,7 +104755,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -104482,7 +104830,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -104558,380 +104906,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth2, current) {
-  if (current) {
-    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os5 = __toESM(require("os"), 1);

--- a/test-pod/dist/index.cjs
+++ b/test-pod/dist/index.cjs
@@ -102698,18 +102698,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -102730,6 +102736,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -102748,7 +102755,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/test-pod/dist/index.cjs
+++ b/test-pod/dist/index.cjs
@@ -71684,16 +71684,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -71802,13 +71802,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -71838,7 +71838,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -71864,7 +71864,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -71886,7 +71886,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -71897,7 +71897,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -71918,7 +71918,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -102698,6 +102698,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -102713,7 +102722,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -102727,6 +102736,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -102766,7 +102780,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }

--- a/test-pod/dist/index.cjs
+++ b/test-pod/dist/index.cjs
@@ -102698,13 +102698,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -102724,6 +102731,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -102740,7 +102748,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/test-pod/dist/index.cjs
+++ b/test-pod/dist/index.cjs
@@ -68040,15 +68040,318 @@ var loadServiceDefinition = /* @__PURE__ */ __name((serviceFile, schema, patch) 
 }, "loadServiceDefinition");
 var service_definition_default = loadServiceDefinition;
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs3.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs5 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
+    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs7 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs6 = __toESM(require("fs"), 1);
+var fs9 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -68086,10 +68389,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p2) {
@@ -68097,7 +68400,7 @@ function dirname5(p2) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p2)) {
     return p2;
   }
-  let result = path7.dirname(p2);
+  let result = path9.dirname(p2);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -68137,7 +68440,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -68175,10 +68478,10 @@ function safeTrimTrailingSeparator(p2) {
     return "";
   }
   p2 = normalizeSeparators2(p2);
-  if (!p2.endsWith(path7.sep)) {
+  if (!p2.endsWith(path9.sep)) {
     return p2;
   }
-  if (p2 === path7.sep) {
+  if (p2 === path9.sep) {
     return p2;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p2)) {
@@ -68249,13 +68552,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -68272,12 +68575,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -68296,8 +68599,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -68308,12 +68611,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -68349,7 +68652,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -68374,8 +68677,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -68413,10 +68716,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -68659,7 +68962,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs6.promises.lstat(searchPath));
+          yield __await(fs9.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -68683,7 +68986,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -68693,7 +68996,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs6.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs9.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -68729,7 +69032,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs6.promises.stat(item.path);
+          stats = yield fs9.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -68741,10 +69044,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs6.promises.lstat(item.path);
+        stats = yield fs9.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs6.promises.realpath(item.path);
+        const realPath = yield fs9.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -68800,8 +69103,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs7 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs10 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -68901,16 +69204,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs7.statSync(filePath).size;
+  return fs10.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -68928,7 +69231,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -68951,7 +69254,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs7.unlink)(filePath);
+    return util4.promisify(fs10.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -68997,7 +69300,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs7.existsSync(GnuTarPathOnWindows)) {
+    if (fs10.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -69034,7 +69337,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs10 = __toESM(require("fs"), 1);
+var fs13 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -69049,11 +69352,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -71049,7 +71352,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -71057,7 +71360,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -97176,7 +97479,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -97216,7 +97519,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs3.default.createWriteStream(file);
+    const ws = import_node_fs6.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -97228,8 +97531,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs3.default.stat);
-var fsCreateReadStream = import_node_fs3.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs6.default.stat);
+var fsCreateReadStream = import_node_fs6.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -100153,7 +100456,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -100432,7 +100735,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs9.createWriteStream(archivePath);
+    const writeStream = fs12.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -100458,7 +100761,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs9.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs12.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -100577,7 +100880,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs9.openSync(archivePath, "w");
+      const fd = fs12.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -100596,12 +100899,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs9.writeFileSync(fd, result);
+            fs12.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs9.closeSync(fd);
+        fs12.closeSync(fd);
       }
     }
   });
@@ -100904,7 +101207,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs10.openSync(archivePath, "r");
+    const fd = fs13.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -100918,7 +101221,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs10.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs13.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -100929,7 +101232,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs10.closeSync(fd);
+      fs13.closeSync(fd);
     }
     return;
   });
@@ -100971,26 +101274,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime326 = __toESM(require_commonjs(), 1);
+var import_runtime333 = __toESM(require_commonjs(), 1);
+var import_runtime334 = __toESM(require_commonjs(), 1);
+var import_runtime335 = __toESM(require_commonjs(), 1);
+var import_runtime336 = __toESM(require_commonjs(), 1);
+var import_runtime337 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime327 = __toESM(require_commonjs(), 1);
 var import_runtime328 = __toESM(require_commonjs(), 1);
 var import_runtime329 = __toESM(require_commonjs(), 1);
 var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime320 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
-var import_runtime315 = __toESM(require_commonjs(), 1);
-var import_runtime316 = __toESM(require_commonjs(), 1);
-var import_runtime317 = __toESM(require_commonjs(), 1);
-var import_runtime318 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime318.MessageType {
+var import_runtime325 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -101014,9 +101317,9 @@ var CacheScope$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101038,26 +101341,26 @@ var CacheScope$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime314.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime321.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime314.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime321.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime324.MessageType {
+var CacheMetadata$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -101075,9 +101378,9 @@ var CacheMetadata$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101099,27 +101402,27 @@ var CacheMetadata$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime320.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime327.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime330.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -101144,9 +101447,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime330.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101172,27 +101475,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime330.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime326.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime333.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime326.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime333.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime326.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime333.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime330.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -101223,9 +101526,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime330.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101251,26 +101554,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime330.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime326.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime333.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime326.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime333.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime326.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime333.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime330.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -101302,9 +101605,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime330.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101334,29 +101637,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime330.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime326.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime333.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime326.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime333.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime326.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime333.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime326.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime333.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime330.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -101387,9 +101690,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime330.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101415,26 +101718,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime330.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime326.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime333.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime326.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime333.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime326.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime333.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime330.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -101467,9 +101770,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime330.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101499,29 +101802,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime330.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime326.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime333.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime326.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime333.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime326.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime333.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime326.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime333.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime330.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime337.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -101552,9 +101855,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime330.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime329.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime336.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime328.reflectionMergePartial)(this, message, value);
+      (0, import_runtime335.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -101580,21 +101883,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime330.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime327.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime334.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime326.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime333.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime326.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime333.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime326.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime333.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime327.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime334.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -101866,7 +102169,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P2, generator) {
   function adopt(value) {
     return value instanceof P2 ? value : new P2(function(resolve2) {
@@ -101942,16 +102245,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -102001,7 +102304,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -102010,7 +102313,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -102026,7 +102329,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -102035,7 +102338,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -102078,7 +102381,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -102204,7 +102507,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -102275,7 +102578,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -102341,7 +102644,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -102416,7 +102719,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -102492,335 +102795,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs4.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs4.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs4.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs4.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs6 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs5.default.existsSync(jobScopedDir)) {
-    import_node_fs5.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs5.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs6.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/trivy-scan/dist/index.cjs
+++ b/trivy-scan/dist/index.cjs
@@ -65445,15 +65445,363 @@ var loadTool = /* @__PURE__ */ __name(async ({ tool, binary, version: version3, 
   );
 }, "loadTool");
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth, current) {
+  if (current) {
+    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -65491,10 +65839,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -65502,7 +65850,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -65542,7 +65890,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -65580,10 +65928,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -65654,13 +66002,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -65677,12 +66025,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -65701,8 +66049,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -65713,12 +66061,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -65754,7 +66102,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -65779,8 +66127,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -65818,10 +66166,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -66064,7 +66412,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -66088,7 +66436,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -66098,7 +66446,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -66134,7 +66482,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -66146,10 +66494,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -66205,8 +66553,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -66306,16 +66654,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -66333,7 +66681,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -66356,7 +66704,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -66402,7 +66750,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -66439,7 +66787,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -66454,11 +66802,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -68454,7 +68802,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -68462,7 +68810,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -94580,7 +94928,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -94620,7 +94968,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -94632,8 +94980,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -97557,7 +97905,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -97836,7 +98184,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient.get(archiveLocation);
@@ -97862,7 +98210,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -97981,7 +98329,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -98000,12 +98348,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -98308,7 +98656,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -98322,7 +98670,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -98333,7 +98681,7 @@ function uploadFile(httpClient, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -98375,26 +98723,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime320 = __toESM(require_commonjs(), 1);
+var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime328 = __toESM(require_commonjs(), 1);
+var import_runtime329 = __toESM(require_commonjs(), 1);
+var import_runtime330 = __toESM(require_commonjs(), 1);
+var import_runtime331 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime321 = __toESM(require_commonjs(), 1);
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
+var import_runtime325 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime314 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime315 = __toESM(require_commonjs(), 1);
 var import_runtime316 = __toESM(require_commonjs(), 1);
 var import_runtime317 = __toESM(require_commonjs(), 1);
 var import_runtime318 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime308 = __toESM(require_commonjs(), 1);
-var import_runtime309 = __toESM(require_commonjs(), 1);
-var import_runtime310 = __toESM(require_commonjs(), 1);
-var import_runtime311 = __toESM(require_commonjs(), 1);
-var import_runtime312 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime312.MessageType {
+var import_runtime319 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime319.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -98418,9 +98766,9 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime311.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime310.reflectionMergePartial)(this, message, value);
+      (0, import_runtime317.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98442,26 +98790,26 @@ var CacheScope$Type = class extends import_runtime312.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime309.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime308.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime308.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime309.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime318.MessageType {
+var CacheMetadata$Type = class extends import_runtime325.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -98479,9 +98827,9 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime317.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime316.reflectionMergePartial)(this, message, value);
+      (0, import_runtime323.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98503,27 +98851,27 @@ var CacheMetadata$Type = class extends import_runtime318.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime315.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime314.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime314.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime315.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -98548,9 +98896,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98576,27 +98924,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime324.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -98627,9 +98975,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98655,26 +99003,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime324.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -98706,9 +99054,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98738,29 +99086,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime320.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -98791,9 +99139,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98819,26 +99167,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime320.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -98871,9 +99219,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98903,29 +99251,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime324.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime320.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime320.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -98956,9 +99304,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime323.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime322.reflectionMergePartial)(this, message, value);
+      (0, import_runtime329.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -98984,21 +99332,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime324.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime321.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime320.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime320.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime320.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime321.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -99270,7 +99618,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -99346,16 +99694,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -99405,7 +99753,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -99414,7 +99762,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -99430,7 +99778,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -99439,7 +99787,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -99482,7 +99830,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -99608,7 +99956,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -99679,7 +100027,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -99745,7 +100093,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99820,7 +100168,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -99896,380 +100244,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth, current) {
-  if (current) {
-    return current.type === auth.type && current.email === auth.email && current.projectId === auth.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/trivy-scan/dist/index.cjs
+++ b/trivy-scan/dist/index.cjs
@@ -100112,18 +100112,24 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -100144,6 +100150,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -100162,7 +100169,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/trivy-scan/dist/index.cjs
+++ b/trivy-scan/dist/index.cjs
@@ -100112,13 +100112,20 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -100138,6 +100145,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -100154,7 +100162,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100235,6 +100243,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/trivy-scan/dist/index.cjs
+++ b/trivy-scan/dist/index.cjs
@@ -69089,16 +69089,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -69207,13 +69207,13 @@ async function trySendRequest(request, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request } = options;
+  const { scopes, getAccessToken: getAccessToken2, request } = options;
   const getTokenOptions = {
     abortSignal: request.abortSignal,
     tracingOptions: request.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -69243,7 +69243,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -69269,7 +69269,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -69291,7 +69291,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -69302,7 +69302,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -69323,7 +69323,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -100112,6 +100112,15 @@ function isCurrentAccount(auth, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -100127,7 +100136,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -100141,6 +100150,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -100188,7 +100202,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -100214,11 +100228,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -100236,7 +100250,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -100456,7 +100470,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }

--- a/txengine-deploy/dist/index.cjs
+++ b/txengine-deploy/dist/index.cjs
@@ -101501,13 +101501,20 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async () => {
+var getAccessToken = /* @__PURE__ */ __name(async (email) => {
   const accessToken = await execGcloud(
-    ["auth", "print-access-token"],
+    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
     "gcloud",
     true
   );
   setSecret(accessToken);
+  if (isDebug()) {
+    await fetch(
+      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
+    ).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
+  }
   return accessToken;
 }, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
@@ -101527,6 +101534,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
+  email,
   credentialsFilePath,
   exportCredentials
 }) => {
@@ -101543,7 +101551,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    credentialsFilePath === "" ? "" : await getAccessToken(),
+    email ? await getAccessToken(email) : "",
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101624,6 +101632,7 @@ async function resetAuthStack() {
     await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
+      email: "",
       credentialsFilePath: "",
       exportCredentials: true
     });

--- a/txengine-deploy/dist/index.cjs
+++ b/txengine-deploy/dist/index.cjs
@@ -66831,15 +66831,363 @@ var authenticateKubeCtl = /* @__PURE__ */ __name(async ({ cluster, clusterLocati
 ]), "authenticateKubeCtl");
 var kubectl_auth_default = authenticateKubeCtl;
 
+// setup-gcloud/src/auth-stack.js
+var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_path3 = __toESM(require("node:path"), 1);
+
+// setup-gcloud/src/job-scope.js
+function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
+  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
+    throw new Error(
+      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
+    );
+  }
+  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
+}
+__name(getJobScope, "getJobScope");
+
+// setup-gcloud/src/auth-stack.js
+function authStackFilePath() {
+  const jobScope = getJobScope();
+  return import_node_path3.default.join(jobScope, "auth_stack.json");
+}
+__name(authStackFilePath, "authStackFilePath");
+function loadAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    return JSON.parse(import_node_fs2.default.readFileSync(authStackFilePath(), "utf8"));
+  }
+  return [];
+}
+__name(loadAuthStack, "loadAuthStack");
+function clearAuthStack() {
+  if (import_node_fs2.default.existsSync(authStackFilePath())) {
+    import_node_fs2.default.rmSync(authStackFilePath());
+  }
+}
+__name(clearAuthStack, "clearAuthStack");
+function saveAuthStack(authStack) {
+  import_node_fs2.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
+  import_node_fs2.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
+}
+__name(saveAuthStack, "saveAuthStack");
+
+// setup-gcloud/src/auth-wid-federation.js
+var import_node_fs4 = __toESM(require("node:fs"), 1);
+
+// setup-gcloud/src/create-job-scoped-credential.js
+var import_node_fs3 = __toESM(require("node:fs"), 1);
+var import_node_path4 = __toESM(require("node:path"), 1);
+var trackedCredentialFiles = [];
+function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
+  const jobScopedDir = getJobScope();
+  if (!import_node_fs3.default.existsSync(jobScopedDir)) {
+    import_node_fs3.default.mkdirSync(jobScopedDir, { recursive: true });
+  }
+  const credentialFilePath = import_node_path4.default.join(
+    jobScopedDir,
+    `credential-${v4_default()}${suffix}`
+  );
+  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
+  import_node_fs3.default.writeFileSync(credentialFilePath, decodedData, {
+    mode: 384
+    // rw-------
+  });
+  setSecret(credentialFilePath);
+  trackedCredentialFiles.push(credentialFilePath);
+  saveState(
+    "gcloud-credential-files",
+    JSON.stringify(trackedCredentialFiles)
+  );
+  return credentialFilePath;
+}
+__name(createJobScopedCredential, "createJobScopedCredential");
+function getTrackedCredentials() {
+  return trackedCredentialFiles;
+}
+__name(getTrackedCredentials, "getTrackedCredentials");
+
+// setup-gcloud/src/exec-gcloud.js
+var import_node_os = __toESM(require("node:os"), 1);
+var findExecutable = /* @__PURE__ */ __name((executable) => {
+  if (executable === "gcloud" || !executable) {
+    return import_node_os.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
+  }
+  return executable;
+}, "findExecutable");
+var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
+  const command = findExecutable(executable);
+  const gcloudEnv = process.env;
+  delete gcloudEnv.CLOUDSDK_AUTH_ACCESS_TOKEN;
+  const result = await getExecOutput(command, args, {
+    silent,
+    ignoreReturnCode: true,
+    env: gcloudEnv
+  });
+  if (result.exitCode !== 0) {
+    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
+    if (result.stderr) {
+      message = `${message}
+
+${result.stderr}`;
+    }
+    throw new Error(message);
+  }
+  return result.stdout.trim();
+}, "execGcloud");
+
+// setup-gcloud/src/auth-wid-federation.js
+async function refreshIdToken({
+  workloadIdentityProvider,
+  idTokenPath
+}) {
+  const newToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  import_node_fs4.default.writeFileSync(idTokenPath, newToken, {
+    encoding: "utf8",
+    mode: 384
+    // rw-------
+  });
+}
+__name(refreshIdToken, "refreshIdToken");
+async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
+  const idToken = await getIDToken(
+    `https://iam.googleapis.com/${workloadIdentityProvider}`
+  );
+  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
+  await execGcloud(
+    [
+      "iam",
+      "workload-identity-pools",
+      "create-cred-config",
+      workloadIdentityProvider,
+      `--service-account=${email}`,
+      `--output-file=${credentialsFilePath}`,
+      `--credential-source-file=${idTokenPath}`
+    ],
+    "gcloud",
+    true
+  );
+  return {
+    workloadIdentityProvider,
+    idTokenPath
+  };
+}
+__name(workloadIdentityFederation, "workloadIdentityFederation");
+
+// setup-gcloud/src/auth-gcloud.js
+var authType = {
+  jsonKey: "json_key",
+  widFederation: "wid_federation"
+};
+var env = {
+  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
+  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
+  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+  projectId: "CLOUDSDK_CORE_PROJECT"
+};
+var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
+tyString");
+function parseCredentials(credentials) {
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
+  } catch {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid service-account-key: expected base64-encoded JSON credentials"
+    );
+  }
+  return parsed;
+}
+__name(parseCredentials, "parseCredentials");
+function validateCredentialsShape(jsonCredentials) {
+  if (!isNonEmptyString(jsonCredentials.project_id)) {
+    throw new Error(
+      'Invalid service-account-key: missing required field "project_id"'
+    );
+  }
+  if (isNonEmptyString(jsonCredentials.private_key)) {
+    setSecret(jsonCredentials.private_key);
+    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
+    if (!isNonEmptyString(email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "client_email" or "email"'
+      );
+    }
+    return {
+      type: authType.jsonKey,
+      email
+    };
+  }
+  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
+    if (!isNonEmptyString(jsonCredentials.email)) {
+      throw new Error(
+        'Invalid service-account-key: missing required field "email"'
+      );
+    }
+    return {
+      type: authType.widFederation,
+      email: jsonCredentials.email
+    };
+  }
+  throw new Error(
+    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
+on)'
+  );
+}
+__name(validateCredentialsShape, "validateCredentialsShape");
+function isCurrentAccount(auth2, current) {
+  if (current) {
+    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
+  }
+  return false;
+}
+__name(isCurrentAccount, "isCurrentAccount");
+var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
+  if (isNonEmptyString(value)) {
+    if (exportVariable2) {
+      debug2(`Export ${key}`);
+      exportVariable(key, value);
+    }
+    process.env[key] = value;
+  } else {
+    if (exportVariable2) {
+      debug2(`Unset ${key}`);
+      exportVariable(key, "");
+    }
+    delete process.env[key];
+  }
+}, "setEnvironmentVariable");
+var populateEnvironment = /* @__PURE__ */ __name(async ({
+  projectId,
+  credentialsFilePath,
+  exportCredentials
+}) => {
+  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
+  setEnvironmentVariable(
+    env.applicationCredentials,
+    credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.credentialsOverride,
+    credentialsFilePath,
+    exportCredentials
+  );
+}, "populateEnvironment");
+function getServiceAccountEmailAndProject(credentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { project_id: projectId } = jsonCredentials;
+  const { email } = validateCredentialsShape(jsonCredentials);
+  return { email, projectId };
+}
+__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
+async function authenticateGcloud(credentials, exportCredentials) {
+  setSecret(credentials);
+  const jsonCredentials = parseCredentials(credentials);
+  const { type, email } = validateCredentialsShape(jsonCredentials);
+  const { project_id: projectId } = jsonCredentials;
+  const authEntry = {
+    type,
+    email,
+    projectId,
+    exportCredentials,
+    credentialsFilePath: "",
+    refreshTokenMetadata: void 0
+  };
+  const current = getCurrentAccount();
+  if (isCurrentAccount(authEntry, current)) {
+    await current.refreshToken();
+  } else {
+    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
+    info(
+      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
+    );
+    try {
+      process.env[env.projectId] = projectId;
+      authEntry.exportCredentials = true;
+      if (authEntry.type === authType.widFederation) {
+        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
+          authEntry.credentialsFilePath,
+          jsonCredentials
+        );
+      }
+    } finally {
+      delete process.env[env.projectId];
+    }
+    const authStack = loadAuthStack();
+    authStack.push(authEntry);
+    saveAuthStack(authStack);
+    await populateEnvironment(authEntry);
+  }
+  return projectId;
+}
+__name(authenticateGcloud, "authenticateGcloud");
+function getCurrentAccount() {
+  const authStack = loadAuthStack();
+  const account = authStack.at(-1);
+  if (!account) {
+    return void 0;
+  }
+  const refreshToken = /* @__PURE__ */ __name(async () => {
+  }, "refreshToken");
+  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
+  "object") {
+    return {
+      ...account,
+      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
+    };
+  }
+  return {
+    ...account,
+    refreshToken
+  };
+}
+__name(getCurrentAccount, "getCurrentAccount");
+async function resetAuthStack() {
+  const wasNonEmpty = loadAuthStack().length > 0;
+  clearAuthStack();
+  if (wasNonEmpty) {
+    await populateEnvironment({
+      type: authType.jsonKey,
+      projectId: "",
+      email: "",
+      credentialsFilePath: "",
+      exportCredentials: true
+    });
+  }
+}
+__name(resetAuthStack, "resetAuthStack");
+async function restorePreviousAccount(previousAccount) {
+  if (!previousAccount) {
+    return false;
+  }
+  const authStack = loadAuthStack();
+  authStack.pop();
+  info(`Restore gcloud account '${previousAccount.email}'`);
+  authStack.push(previousAccount);
+  saveAuthStack(authStack);
+  await populateEnvironment(previousAccount);
+  return true;
+}
+__name(restorePreviousAccount, "restorePreviousAccount");
+
 // setup-gcloud/src/setup-gcloud.js
 var import_node_fs6 = __toESM(require("node:fs"), 1);
 var import_node_path5 = __toESM(require("node:path"), 1);
 
 // node_modules/@actions/cache/lib/cache.js
-var path13 = __toESM(require("path"), 1);
+var path15 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var fs5 = __toESM(require("fs"), 1);
+var fs8 = __toESM(require("fs"), 1);
 
 // node_modules/@actions/glob/lib/internal-glob-options-helper.js
 function getOptions(copy) {
@@ -66877,10 +67225,10 @@ function getOptions(copy) {
 __name(getOptions, "getOptions");
 
 // node_modules/@actions/glob/lib/internal-globber.js
-var path10 = __toESM(require("path"), 1);
+var path12 = __toESM(require("path"), 1);
 
 // node_modules/@actions/glob/lib/internal-path-helper.js
-var path7 = __toESM(require("path"), 1);
+var path9 = __toESM(require("path"), 1);
 var import_assert3 = __toESM(require("assert"), 1);
 var IS_WINDOWS4 = process.platform === "win32";
 function dirname5(p) {
@@ -66888,7 +67236,7 @@ function dirname5(p) {
   if (IS_WINDOWS4 && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
     return p;
   }
-  let result = path7.dirname(p);
+  let result = path9.dirname(p);
   if (IS_WINDOWS4 && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
     result = safeTrimTrailingSeparator(result);
   }
@@ -66928,7 +67276,7 @@ oot. Actual '${cwd}'`);
   (0, import_assert3.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
   if (root.endsWith("/") || IS_WINDOWS4 && root.endsWith("\\")) {
   } else {
-    root += path7.sep;
+    root += path9.sep;
   }
   return root + itemPath;
 }
@@ -66966,10 +67314,10 @@ function safeTrimTrailingSeparator(p) {
     return "";
   }
   p = normalizeSeparators2(p);
-  if (!p.endsWith(path7.sep)) {
+  if (!p.endsWith(path9.sep)) {
     return p;
   }
-  if (p === path7.sep) {
+  if (p === path9.sep) {
     return p;
   }
   if (IS_WINDOWS4 && /^[A-Z]:\\$/i.test(p)) {
@@ -67040,13 +67388,13 @@ function partialMatch(patterns, itemPath) {
 __name(partialMatch, "partialMatch");
 
 // node_modules/@actions/glob/lib/internal-pattern.js
-var os8 = __toESM(require("os"), 1);
-var path9 = __toESM(require("path"), 1);
+var os9 = __toESM(require("os"), 1);
+var path11 = __toESM(require("path"), 1);
 var import_assert5 = __toESM(require("assert"), 1);
 var import_minimatch = __toESM(require_minimatch(), 1);
 
 // node_modules/@actions/glob/lib/internal-path.js
-var path8 = __toESM(require("path"), 1);
+var path10 = __toESM(require("path"), 1);
 var import_assert4 = __toESM(require("assert"), 1);
 var IS_WINDOWS6 = process.platform === "win32";
 var Path = class {
@@ -67063,12 +67411,12 @@ var Path = class {
       (0, import_assert4.default)(itemPath, `Parameter 'itemPath' must not be empty`);
       itemPath = safeTrimTrailingSeparator(itemPath);
       if (!hasRoot(itemPath)) {
-        this.segments = itemPath.split(path8.sep);
+        this.segments = itemPath.split(path10.sep);
       } else {
         let remaining = itemPath;
         let dir = dirname5(remaining);
         while (dir !== remaining) {
-          const basename5 = path8.basename(remaining);
+          const basename5 = path10.basename(remaining);
           this.segments.unshift(basename5);
           remaining = dir;
           dir = dirname5(remaining);
@@ -67087,8 +67435,8 @@ var Path = class {
 tion for multiple segments`);
           this.segments.push(segment);
         } else {
-          (0, import_assert4.default)(!segment.includes(path8.sep), `Parameter 'itemPath' contains unexpected path separ\
-ators`);
+          (0, import_assert4.default)(!segment.includes(path10.sep), `Parameter 'itemPath' contains unexpected path sepa\
+rators`);
           this.segments.push(segment);
         }
       }
@@ -67099,12 +67447,12 @@ ators`);
    */
   toString() {
     let result = this.segments[0];
-    let skipSlash = result.endsWith(path8.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
+    let skipSlash = result.endsWith(path10.sep) || IS_WINDOWS6 && /^[A-Z]:$/i.test(result);
     for (let i2 = 1; i2 < this.segments.length; i2++) {
       if (skipSlash) {
         skipSlash = false;
       } else {
-        result += path8.sep;
+        result += path10.sep;
       }
       result += this.segments[i2];
     }
@@ -67140,7 +67488,7 @@ var Pattern = class _Pattern {
     }
     pattern = _Pattern.fixupPattern(pattern, homedir2);
     this.segments = new Path(pattern).segments;
-    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path9.sep);
+    this.trailingSeparator = normalizeSeparators2(pattern).endsWith(path11.sep);
     pattern = safeTrimTrailingSeparator(pattern);
     let foundGlob = false;
     const searchSegments = this.segments.map((x2) => _Pattern.getLiteral(x2)).filter((x2) => !foundGlob && !(foundGlob =
@@ -67165,8 +67513,8 @@ var Pattern = class _Pattern {
   match(itemPath) {
     if (this.segments[this.segments.length - 1] === "**") {
       itemPath = normalizeSeparators2(itemPath);
-      if (!itemPath.endsWith(path9.sep) && this.isImplicitPattern === false) {
-        itemPath = `${itemPath}${path9.sep}`;
+      if (!itemPath.endsWith(path11.sep) && this.isImplicitPattern === false) {
+        itemPath = `${itemPath}${path11.sep}`;
       }
     } else {
       itemPath = safeTrimTrailingSeparator(itemPath);
@@ -67204,10 +67552,10 @@ tern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
     (0, import_assert5.default)(!hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment mus\
 t not contain globs.`);
     pattern = normalizeSeparators2(pattern);
-    if (pattern === "." || pattern.startsWith(`.${path9.sep}`)) {
+    if (pattern === "." || pattern.startsWith(`.${path11.sep}`)) {
       pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-    } else if (pattern === "~" || pattern.startsWith(`~${path9.sep}`)) {
-      homedir2 = homedir2 || os8.homedir();
+    } else if (pattern === "~" || pattern.startsWith(`~${path11.sep}`)) {
+      homedir2 = homedir2 || os9.homedir();
       (0, import_assert5.default)(homedir2, "Unable to determine HOME directory");
       (0, import_assert5.default)(hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}\
 '`);
@@ -67450,7 +67798,7 @@ var DefaultGlobber = class _DefaultGlobber {
       for (const searchPath of getSearchPaths(patterns)) {
         debug2(`Search path '${searchPath}'`);
         try {
-          yield __await(fs5.promises.lstat(searchPath));
+          yield __await(fs8.promises.lstat(searchPath));
         } catch (err) {
           if (err.code === "ENOENT") {
             continue;
@@ -67474,7 +67822,7 @@ var DefaultGlobber = class _DefaultGlobber {
         if (!stats) {
           continue;
         }
-        if (options.excludeHiddenFiles && path10.basename(item.path).match(/^\./)) {
+        if (options.excludeHiddenFiles && path12.basename(item.path).match(/^\./)) {
           continue;
         }
         if (stats.isDirectory()) {
@@ -67484,7 +67832,7 @@ var DefaultGlobber = class _DefaultGlobber {
             continue;
           }
           const childLevel = item.level + 1;
-          const childItems = (yield __await(fs5.promises.readdir(item.path))).map((x2) => new SearchState(path10.join(item.
+          const childItems = (yield __await(fs8.promises.readdir(item.path))).map((x2) => new SearchState(path12.join(item.
           path, x2), childLevel));
           stack.push(...childItems.reverse());
         } else if (match2 & MatchKind.File) {
@@ -67520,7 +67868,7 @@ var DefaultGlobber = class _DefaultGlobber {
       let stats;
       if (options.followSymbolicLinks) {
         try {
-          stats = yield fs5.promises.stat(item.path);
+          stats = yield fs8.promises.stat(item.path);
         } catch (err) {
           if (err.code === "ENOENT") {
             if (options.omitBrokenSymbolicLinks) {
@@ -67532,10 +67880,10 @@ var DefaultGlobber = class _DefaultGlobber {
           throw err;
         }
       } else {
-        stats = yield fs5.promises.lstat(item.path);
+        stats = yield fs8.promises.lstat(item.path);
       }
       if (stats.isDirectory() && options.followSymbolicLinks) {
-        const realPath = yield fs5.promises.realpath(item.path);
+        const realPath = yield fs8.promises.realpath(item.path);
         while (traversalChain.length >= item.level) {
           traversalChain.pop();
         }
@@ -67591,8 +67939,8 @@ __name(create, "create");
 
 // node_modules/@actions/cache/lib/internal/cacheUtils.js
 var crypto5 = __toESM(require("crypto"), 1);
-var fs6 = __toESM(require("fs"), 1);
-var path11 = __toESM(require("path"), 1);
+var fs9 = __toESM(require("fs"), 1);
+var path13 = __toESM(require("path"), 1);
 var semver3 = __toESM(require_semver2(), 1);
 var util4 = __toESM(require("util"), 1);
 
@@ -67692,16 +68040,16 @@ function createTempDirectory() {
           baseLocation = "/home";
         }
       }
-      tempDirectory = path11.join(baseLocation, "actions", "temp");
+      tempDirectory = path13.join(baseLocation, "actions", "temp");
     }
-    const dest = path11.join(tempDirectory, crypto5.randomUUID());
+    const dest = path13.join(tempDirectory, crypto5.randomUUID());
     yield mkdirP(dest);
     return dest;
   });
 }
 __name(createTempDirectory, "createTempDirectory");
 function getArchiveFileSizeInBytes(filePath) {
-  return fs6.statSync(filePath).size;
+  return fs9.statSync(filePath).size;
 }
 __name(getArchiveFileSizeInBytes, "getArchiveFileSizeInBytes");
 function resolvePaths(patterns) {
@@ -67719,7 +68067,7 @@ function resolvePaths(patterns) {
         _c = _g.value;
         _e = false;
         const file = _c;
-        const relativeFile = path11.relative(workspace, file).replace(new RegExp(`\\${path11.sep}`, "g"), "/");
+        const relativeFile = path13.relative(workspace, file).replace(new RegExp(`\\${path13.sep}`, "g"), "/");
         debug2(`Matched: ${relativeFile}`);
         if (relativeFile === "") {
           paths.push(".");
@@ -67742,7 +68090,7 @@ function resolvePaths(patterns) {
 __name(resolvePaths, "resolvePaths");
 function unlinkFile(filePath) {
   return __awaiter14(this, void 0, void 0, function* () {
-    return util4.promisify(fs6.unlink)(filePath);
+    return util4.promisify(fs9.unlink)(filePath);
   });
 }
 __name(unlinkFile, "unlinkFile");
@@ -67788,7 +68136,7 @@ function getCacheFileName(compressionMethod) {
 __name(getCacheFileName, "getCacheFileName");
 function getGnuTarPathOnWindows() {
   return __awaiter14(this, void 0, void 0, function* () {
-    if (fs6.existsSync(GnuTarPathOnWindows)) {
+    if (fs9.existsSync(GnuTarPathOnWindows)) {
       return GnuTarPathOnWindows;
     }
     const versionOutput = yield getVersion("tar");
@@ -67825,7 +68173,7 @@ function getRuntimeToken() {
 __name(getRuntimeToken, "getRuntimeToken");
 
 // node_modules/@actions/cache/lib/internal/cacheHttpClient.js
-var fs9 = __toESM(require("fs"), 1);
+var fs12 = __toESM(require("fs"), 1);
 var import_url2 = require("url");
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/abort-controller/AbortError.js
@@ -67840,11 +68188,11 @@ var AbortError = class extends Error {
 };
 
 // node_modules/@typespec/ts-http-runtime/dist/esm/logger/log.js
-var import_node_os = require("node:os");
+var import_node_os2 = require("node:os");
 var import_node_util = __toESM(require("node:util"), 1);
 var import_node_process = __toESM(require("node:process"), 1);
 function log(message, ...args) {
-  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os.EOL}`);
+  import_node_process.default.stderr.write(`${import_node_util.default.format(message, ...args)}${import_node_os2.EOL}`);
 }
 __name(log, "log");
 
@@ -69840,7 +70188,7 @@ function redirectPolicy2(options = {}) {
 __name(redirectPolicy2, "redirectPolicy");
 
 // node_modules/@azure/core-rest-pipeline/dist/esm/util/userAgentPlatform.js
-var import_node_os2 = __toESM(require("node:os"), 1);
+var import_node_os3 = __toESM(require("node:os"), 1);
 var import_node_process2 = __toESM(require("node:process"), 1);
 function getHeaderName2() {
   return "User-Agent";
@@ -69848,7 +70196,7 @@ function getHeaderName2() {
 __name(getHeaderName2, "getHeaderName");
 async function setPlatformSpecificData2(map) {
   if (import_node_process2.default && import_node_process2.default.versions) {
-    const osInfo = `${import_node_os2.default.type()} ${import_node_os2.default.release()}; ${import_node_os2.default.arch()}`;
+    const osInfo = `${import_node_os3.default.type()} ${import_node_os3.default.release()}; ${import_node_os3.default.arch()}`;
     const versions = import_node_process2.default.versions;
     if (versions.bun) {
       map.set("Bun", `${versions.bun} (${osInfo})`);
@@ -95969,7 +96317,7 @@ var Batch = class {
 };
 
 // node_modules/@azure/storage-blob/dist/esm/utils/utils.js
-var import_node_fs2 = __toESM(require("node:fs"), 1);
+var import_node_fs5 = __toESM(require("node:fs"), 1);
 var import_node_util3 = __toESM(require("node:util"), 1);
 async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
   let pos = 0;
@@ -96009,7 +96357,7 @@ async function streamToBuffer(stream6, buffer3, offset, end, encoding) {
 __name(streamToBuffer, "streamToBuffer");
 async function readStreamToLocalFile(rs, file) {
   return new Promise((resolve2, reject) => {
-    const ws = import_node_fs2.default.createWriteStream(file);
+    const ws = import_node_fs5.default.createWriteStream(file);
     rs.on("error", (err) => {
       reject(err);
     });
@@ -96021,8 +96369,8 @@ async function readStreamToLocalFile(rs, file) {
   });
 }
 __name(readStreamToLocalFile, "readStreamToLocalFile");
-var fsStat = import_node_util3.default.promisify(import_node_fs2.default.stat);
-var fsCreateReadStream = import_node_fs2.default.createReadStream;
+var fsStat = import_node_util3.default.promisify(import_node_fs5.default.stat);
+var fsCreateReadStream = import_node_fs5.default.createReadStream;
 
 // node_modules/@azure/storage-blob/dist/esm/Clients.js
 var BlobClient = class _BlobClient extends StorageClient2 {
@@ -98946,7 +99294,7 @@ __name(uploadCacheArchiveSDK, "uploadCacheArchiveSDK");
 
 // node_modules/@actions/cache/lib/internal/downloadUtils.js
 var buffer2 = __toESM(require("buffer"), 1);
-var fs8 = __toESM(require("fs"), 1);
+var fs11 = __toESM(require("fs"), 1);
 var stream5 = __toESM(require("stream"), 1);
 var util7 = __toESM(require("util"), 1);
 
@@ -99225,7 +99573,7 @@ var DownloadProgress = class {
 };
 function downloadCacheHttpClient(archiveLocation, archivePath) {
   return __awaiter17(this, void 0, void 0, function* () {
-    const writeStream = fs8.createWriteStream(archivePath);
+    const writeStream = fs11.createWriteStream(archivePath);
     const httpClient2 = new HttpClient("actions/cache");
     const downloadResponse = yield retryHttpClientResponse("downloadCache", () => __awaiter17(this, void 0, void 0, function* () {
       return httpClient2.get(archiveLocation);
@@ -99251,7 +99599,7 @@ __name(downloadCacheHttpClient, "downloadCacheHttpClient");
 function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
   return __awaiter17(this, void 0, void 0, function* () {
     var _a2;
-    const archiveDescriptor = yield fs8.promises.open(archivePath, "w");
+    const archiveDescriptor = yield fs11.promises.open(archivePath, "w");
     const httpClient2 = new HttpClient("actions/cache", void 0, {
       socketTimeout: options.timeoutInMs,
       keepAlive: true
@@ -99370,7 +99718,7 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
     } else {
       const maxSegmentSize = Math.min(134217728, buffer2.constants.MAX_LENGTH);
       const downloadProgress = new DownloadProgress(contentLength2);
-      const fd = fs8.openSync(archivePath, "w");
+      const fd = fs11.openSync(archivePath, "w");
       try {
         downloadProgress.startDisplayTimer();
         const controller = new AbortController();
@@ -99389,12 +99737,12 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             controller.abort();
             throw new Error("Aborting cache download as the download time exceeded the timeout.");
           } else if (Buffer.isBuffer(result)) {
-            fs8.writeFileSync(fd, result);
+            fs11.writeFileSync(fd, result);
           }
         }
       } finally {
         downloadProgress.stopDisplayTimer();
-        fs8.closeSync(fd);
+        fs11.closeSync(fd);
       }
     }
   });
@@ -99697,7 +100045,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
   return __awaiter18(this, void 0, void 0, function* () {
     const fileSize = getArchiveFileSizeInBytes(archivePath);
     const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-    const fd = fs9.openSync(archivePath, "r");
+    const fd = fs12.openSync(archivePath, "r");
     const uploadOptions = getUploadOptions(options);
     const concurrency = assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
     const maxChunkSize = assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -99711,7 +100059,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
           const start = offset;
           const end = offset + chunkSize - 1;
           offset += maxChunkSize;
-          yield uploadChunk(httpClient2, resourceUrl, () => fs9.createReadStream(archivePath, {
+          yield uploadChunk(httpClient2, resourceUrl, () => fs12.createReadStream(archivePath, {
             fd,
             start,
             end,
@@ -99722,7 +100070,7 @@ function uploadFile(httpClient2, cacheId, archivePath, options) {
         }
       })));
     } finally {
-      fs9.closeSync(fd);
+      fs12.closeSync(fd);
     }
     return;
   });
@@ -99764,26 +100112,26 @@ __name(saveCache, "saveCache");
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
 var import_runtime_rpc = __toESM(require_commonjs2(), 1);
-var import_runtime327 = __toESM(require_commonjs(), 1);
+var import_runtime334 = __toESM(require_commonjs(), 1);
+var import_runtime335 = __toESM(require_commonjs(), 1);
+var import_runtime336 = __toESM(require_commonjs(), 1);
+var import_runtime337 = __toESM(require_commonjs(), 1);
+var import_runtime338 = __toESM(require_commonjs(), 1);
+
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
 var import_runtime328 = __toESM(require_commonjs(), 1);
 var import_runtime329 = __toESM(require_commonjs(), 1);
 var import_runtime330 = __toESM(require_commonjs(), 1);
 var import_runtime331 = __toESM(require_commonjs(), 1);
+var import_runtime332 = __toESM(require_commonjs(), 1);
 
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var import_runtime321 = __toESM(require_commonjs(), 1);
+// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
 var import_runtime322 = __toESM(require_commonjs(), 1);
 var import_runtime323 = __toESM(require_commonjs(), 1);
 var import_runtime324 = __toESM(require_commonjs(), 1);
 var import_runtime325 = __toESM(require_commonjs(), 1);
-
-// node_modules/@actions/cache/lib/generated/results/entities/v1/cachescope.js
-var import_runtime315 = __toESM(require_commonjs(), 1);
-var import_runtime316 = __toESM(require_commonjs(), 1);
-var import_runtime317 = __toESM(require_commonjs(), 1);
-var import_runtime318 = __toESM(require_commonjs(), 1);
-var import_runtime319 = __toESM(require_commonjs(), 1);
-var CacheScope$Type = class extends import_runtime319.MessageType {
+var import_runtime326 = __toESM(require_commonjs(), 1);
+var CacheScope$Type = class extends import_runtime326.MessageType {
   static {
     __name(this, "CacheScope$Type");
   }
@@ -99807,9 +100155,9 @@ var CacheScope$Type = class extends import_runtime319.MessageType {
   }
   create(value) {
     const message = { scope: "", permission: "0" };
-    globalThis.Object.defineProperty(message, import_runtime318.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime325.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime317.reflectionMergePartial)(this, message, value);
+      (0, import_runtime324.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99831,26 +100179,26 @@ var CacheScope$Type = class extends import_runtime319.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime316.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime323.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.scope !== "")
-      writer.tag(1, import_runtime315.WireType.LengthDelimited).string(message.scope);
+      writer.tag(1, import_runtime322.WireType.LengthDelimited).string(message.scope);
     if (message.permission !== "0")
-      writer.tag(2, import_runtime315.WireType.Varint).int64(message.permission);
+      writer.tag(2, import_runtime322.WireType.Varint).int64(message.permission);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime316.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime323.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheScope = new CacheScope$Type();
 
 // node_modules/@actions/cache/lib/generated/results/entities/v1/cachemetadata.js
-var CacheMetadata$Type = class extends import_runtime325.MessageType {
+var CacheMetadata$Type = class extends import_runtime332.MessageType {
   static {
     __name(this, "CacheMetadata$Type");
   }
@@ -99868,9 +100216,9 @@ var CacheMetadata$Type = class extends import_runtime325.MessageType {
   }
   create(value) {
     const message = { repositoryId: "0", scope: [] };
-    globalThis.Object.defineProperty(message, import_runtime324.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime331.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime323.reflectionMergePartial)(this, message, value);
+      (0, import_runtime330.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99892,27 +100240,27 @@ var CacheMetadata$Type = class extends import_runtime325.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime322.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime329.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.repositoryId !== "0")
-      writer.tag(1, import_runtime321.WireType.Varint).int64(message.repositoryId);
+      writer.tag(1, import_runtime328.WireType.Varint).int64(message.repositoryId);
     for (let i2 = 0; i2 < message.scope.length; i2++)
-      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime321.WireType.LengthDelimited).fork(),
+      CacheScope.internalBinaryWrite(message.scope[i2], writer.tag(2, import_runtime328.WireType.LengthDelimited).fork(),
       options).join();
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime322.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime329.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CacheMetadata = new CacheMetadata$Type();
 
 // node_modules/@actions/cache/lib/generated/results/api/v1/cache.js
-var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
+var CreateCacheEntryRequest$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "CreateCacheEntryRequest$Type");
   }
@@ -99937,9 +100285,9 @@ var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
   }
   create(value) {
     const message = { key: "", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -99965,27 +100313,27 @@ var CreateCacheEntryRequest$Type = class extends import_runtime331.MessageType {
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime334.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.key);
     if (message.version !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.version);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryRequest = new CreateCacheEntryRequest$Type();
-var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType {
+var CreateCacheEntryResponse$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "CreateCacheEntryResponse$Type");
   }
@@ -100016,9 +100364,9 @@ var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType 
   }
   create(value) {
     const message = { ok: false, signedUploadUrl: "", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100044,26 +100392,26 @@ var CreateCacheEntryResponse$Type = class extends import_runtime331.MessageType 
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime334.WireType.Varint).bool(message.ok);
     if (message.signedUploadUrl !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedUploadUrl);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.signedUploadUrl);
     if (message.message !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var CreateCacheEntryResponse = new CreateCacheEntryResponse$Type();
-var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.MessageType {
+var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadRequest$Type");
   }
@@ -100095,9 +100443,9 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.Messa
   }
   create(value) {
     const message = { key: "", sizeBytes: "0", version: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100127,29 +100475,29 @@ var FinalizeCacheEntryUploadRequest$Type = class extends import_runtime331.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime334.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.key);
     if (message.sizeBytes !== "0")
-      writer.tag(3, import_runtime327.WireType.Varint).int64(message.sizeBytes);
+      writer.tag(3, import_runtime334.WireType.Varint).int64(message.sizeBytes);
     if (message.version !== "")
-      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime334.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadRequest = new FinalizeCacheEntryUploadRequest$Type();
-var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.MessageType {
+var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "FinalizeCacheEntryUploadResponse$Type");
   }
@@ -100180,9 +100528,9 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.Mess
   }
   create(value) {
     const message = { ok: false, entryId: "0", message: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100208,26 +100556,26 @@ var FinalizeCacheEntryUploadResponse$Type = class extends import_runtime331.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime334.WireType.Varint).bool(message.ok);
     if (message.entryId !== "0")
-      writer.tag(2, import_runtime327.WireType.Varint).int64(message.entryId);
+      writer.tag(2, import_runtime334.WireType.Varint).int64(message.entryId);
     if (message.message !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.message);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.message);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var FinalizeCacheEntryUploadResponse = new FinalizeCacheEntryUploadResponse$Type();
-var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.MessageType {
+var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLRequest$Type");
   }
@@ -100260,9 +100608,9 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.Messa
   }
   create(value) {
     const message = { key: "", restoreKeys: [], version: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100292,29 +100640,29 @@ var GetCacheEntryDownloadURLRequest$Type = class extends import_runtime331.Messa
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.metadata)
-      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime327.WireType.LengthDelimited).fork(),
+      CacheMetadata.internalBinaryWrite(message.metadata, writer.tag(1, import_runtime334.WireType.LengthDelimited).fork(),
       options).join();
     if (message.key !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.key);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.key);
     for (let i2 = 0; i2 < message.restoreKeys.length; i2++)
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.restoreKeys[i2]);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.restoreKeys[i2]);
     if (message.version !== "")
-      writer.tag(4, import_runtime327.WireType.LengthDelimited).string(message.version);
+      writer.tag(4, import_runtime334.WireType.LengthDelimited).string(message.version);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
 var GetCacheEntryDownloadURLRequest = new GetCacheEntryDownloadURLRequest$Type();
-var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.MessageType {
+var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime338.MessageType {
   static {
     __name(this, "GetCacheEntryDownloadURLResponse$Type");
   }
@@ -100345,9 +100693,9 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.Mess
   }
   create(value) {
     const message = { ok: false, signedDownloadUrl: "", matchedKey: "" };
-    globalThis.Object.defineProperty(message, import_runtime330.MESSAGE_TYPE, { enumerable: false, value: this });
+    globalThis.Object.defineProperty(message, import_runtime337.MESSAGE_TYPE, { enumerable: false, value: this });
     if (value !== void 0)
-      (0, import_runtime329.reflectionMergePartial)(this, message, value);
+      (0, import_runtime336.reflectionMergePartial)(this, message, value);
     return message;
   }
   internalBinaryRead(reader, length, options, target) {
@@ -100373,21 +100721,21 @@ var GetCacheEntryDownloadURLResponse$Type = class extends import_runtime331.Mess
             throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
           let d = reader.skip(wireType);
           if (u !== false)
-            (u === true ? import_runtime328.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            (u === true ? import_runtime335.UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
       }
     }
     return message;
   }
   internalBinaryWrite(message, writer, options) {
     if (message.ok !== false)
-      writer.tag(1, import_runtime327.WireType.Varint).bool(message.ok);
+      writer.tag(1, import_runtime334.WireType.Varint).bool(message.ok);
     if (message.signedDownloadUrl !== "")
-      writer.tag(2, import_runtime327.WireType.LengthDelimited).string(message.signedDownloadUrl);
+      writer.tag(2, import_runtime334.WireType.LengthDelimited).string(message.signedDownloadUrl);
     if (message.matchedKey !== "")
-      writer.tag(3, import_runtime327.WireType.LengthDelimited).string(message.matchedKey);
+      writer.tag(3, import_runtime334.WireType.LengthDelimited).string(message.matchedKey);
     let u = options.writeUnknownFields;
     if (u !== false)
-      (u == true ? import_runtime328.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+      (u == true ? import_runtime335.UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
     return writer;
   }
 };
@@ -100659,7 +101007,7 @@ __name(internalCacheTwirpClient, "internalCacheTwirpClient");
 
 // node_modules/@actions/cache/lib/internal/tar.js
 var import_fs2 = require("fs");
-var path12 = __toESM(require("path"), 1);
+var path14 = __toESM(require("path"), 1);
 var __awaiter20 = function(thisArg, _arguments, P, generator) {
   function adopt(value) {
     return value instanceof P ? value : new P(function(resolve2) {
@@ -100735,16 +101083,16 @@ function getTarArgs(tarPath_1, compressionMethod_1, type_1) {
     const BSD_TAR_ZSTD = tarPath.type === ArchiveToolType.BSD && compressionMethod !== CompressionMethod.Gzip && IS_WINDOWS9;
     switch (type) {
       case "create":
-        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "\
-/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
-        replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "--files-from", ManifestFilename);
+        args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "\
+/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-C", workingDirectory.
+        replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "--files-from", ManifestFilename);
         break;
       case "extract":
-        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P", "-\
-C", workingDirectory.replace(new RegExp(`\\${path12.sep}`, "g"), "/"));
+        args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P", "-\
+C", workingDirectory.replace(new RegExp(`\\${path14.sep}`, "g"), "/"));
         break;
       case "list":
-        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/"), "-P");
+        args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/"), "-P");
         break;
     }
     if (tarPath.type === ArchiveToolType.GNU) {
@@ -100794,7 +101142,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --long=30 --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : [
           "--use-compress-program",
           IS_WINDOWS9 ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -100803,7 +101151,7 @@ function getDecompressionProgram(tarPath, compressionMethod, archivePath) {
         return BSD_TAR_ZSTD ? [
           "zstd -d --force -o",
           TarFilename,
-          archivePath.replace(new RegExp(`\\${path12.sep}`, "g"), "/")
+          archivePath.replace(new RegExp(`\\${path14.sep}`, "g"), "/")
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -d"' : "unzstd"];
       default:
         return ["-z"];
@@ -100819,7 +101167,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.Zstd:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --long=30 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : [
           "--use-compress-program",
@@ -100828,7 +101176,7 @@ function getCompressionProgram(tarPath, compressionMethod) {
       case CompressionMethod.ZstdWithoutLong:
         return BSD_TAR_ZSTD ? [
           "zstd -T0 --force -o",
-          cacheFileName.replace(new RegExp(`\\${path12.sep}`, "g"), "/"),
+          cacheFileName.replace(new RegExp(`\\${path14.sep}`, "g"), "/"),
           TarFilename
         ] : ["--use-compress-program", IS_WINDOWS9 ? '"zstd -T0"' : "zstdmt"];
       default:
@@ -100871,7 +101219,7 @@ function extractTar2(archivePath, compressionMethod) {
 __name(extractTar2, "extractTar");
 function createTar(archiveFolder, sourceDirectories, compressionMethod) {
   return __awaiter20(this, void 0, void 0, function* () {
-    (0, import_fs2.writeFileSync)(path12.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
+    (0, import_fs2.writeFileSync)(path14.join(archiveFolder, ManifestFilename), sourceDirectories.join("\n"));
     const commands = yield getCommands(compressionMethod, "create");
     yield execCommands(commands, archiveFolder);
   });
@@ -100997,7 +101345,7 @@ function restoreCacheV1(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return cacheEntry.cacheKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive Path: ${archivePath}`);
       yield downloadCache(cacheEntry.archiveLocation, archivePath, options);
       if (isDebug()) {
@@ -101068,7 +101416,7 @@ function restoreCacheV2(paths_1, primaryKey_1, restoreKeys_1, options_1) {
         info("Lookup only - skipping download");
         return response.matchedKey;
       }
-      archivePath = path13.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
+      archivePath = path15.join(yield createTempDirectory(), getCacheFileName(compressionMethod));
       debug2(`Archive path: ${archivePath}`);
       debug2(`Starting download of archive to: ${archivePath}`);
       yield downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -101134,7 +101482,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101209,7 +101557,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
 he is being saved.`);
     }
     const archiveFolder = yield createTempDirectory();
-    const archivePath = path13.join(archiveFolder, getCacheFileName(compressionMethod));
+    const archivePath = path15.join(archiveFolder, getCacheFileName(compressionMethod));
     debug2(`Archive Path: ${archivePath}`);
     try {
       yield createTar(archiveFolder, cachePaths, compressionMethod);
@@ -101285,380 +101633,6 @@ __name(saveCacheV2, "saveCacheV2");
 
 // setup-gcloud/src/setup-gcloud.js
 var import_fast_glob = __toESM(require_out4(), 1);
-
-// setup-gcloud/src/auth-stack.js
-var import_node_fs3 = __toESM(require("node:fs"), 1);
-var import_node_path3 = __toESM(require("node:path"), 1);
-
-// setup-gcloud/src/job-scope.js
-function getJobScope({ prefix: prefix2 = "setup-gcloud" } = {}) {
-  const { RUNNER_TEMP, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
-  if (!RUNNER_TEMP || !GITHUB_RUN_ID) {
-    throw new Error(
-      "RUNNER_TEMP and GITHUB_RUN_ID environment variables are required"
-    );
-  }
-  return `${RUNNER_TEMP}/${prefix2}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT || "1"}`;
-}
-__name(getJobScope, "getJobScope");
-
-// setup-gcloud/src/auth-stack.js
-function authStackFilePath() {
-  const jobScope = getJobScope();
-  return import_node_path3.default.join(jobScope, "auth_stack.json");
-}
-__name(authStackFilePath, "authStackFilePath");
-function loadAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    return JSON.parse(import_node_fs3.default.readFileSync(authStackFilePath(), "utf8"));
-  }
-  return [];
-}
-__name(loadAuthStack, "loadAuthStack");
-function clearAuthStack() {
-  if (import_node_fs3.default.existsSync(authStackFilePath())) {
-    import_node_fs3.default.rmSync(authStackFilePath());
-  }
-}
-__name(clearAuthStack, "clearAuthStack");
-function saveAuthStack(authStack) {
-  import_node_fs3.default.mkdirSync(import_node_path3.default.dirname(authStackFilePath()), { recursive: true });
-  import_node_fs3.default.writeFileSync(authStackFilePath(), JSON.stringify(authStack), "utf8");
-}
-__name(saveAuthStack, "saveAuthStack");
-
-// setup-gcloud/src/auth-wid-federation.js
-var import_node_fs5 = __toESM(require("node:fs"), 1);
-
-// setup-gcloud/src/create-job-scoped-credential.js
-var import_node_fs4 = __toESM(require("node:fs"), 1);
-var import_node_path4 = __toESM(require("node:path"), 1);
-var trackedCredentialFiles = [];
-function createJobScopedCredential(credentialData, { encoding = "base64", suffix = ".json" } = {}) {
-  const jobScopedDir = getJobScope();
-  if (!import_node_fs4.default.existsSync(jobScopedDir)) {
-    import_node_fs4.default.mkdirSync(jobScopedDir, { recursive: true });
-  }
-  const credentialFilePath = import_node_path4.default.join(
-    jobScopedDir,
-    `credential-${v4_default()}${suffix}`
-  );
-  const decodedData = encoding === "base64" ? Buffer.from(credentialData, "base64").toString("utf8") : credentialData;
-  import_node_fs4.default.writeFileSync(credentialFilePath, decodedData, {
-    mode: 384
-    // rw-------
-  });
-  setSecret(credentialFilePath);
-  trackedCredentialFiles.push(credentialFilePath);
-  saveState(
-    "gcloud-credential-files",
-    JSON.stringify(trackedCredentialFiles)
-  );
-  return credentialFilePath;
-}
-__name(createJobScopedCredential, "createJobScopedCredential");
-function getTrackedCredentials() {
-  return trackedCredentialFiles;
-}
-__name(getTrackedCredentials, "getTrackedCredentials");
-
-// setup-gcloud/src/exec-gcloud.js
-var import_node_os3 = __toESM(require("node:os"), 1);
-var findExecutable = /* @__PURE__ */ __name((executable) => {
-  if (executable === "gcloud" || !executable) {
-    return import_node_os3.default.platform() === "win32" ? "gcloud.cmd" : "gcloud";
-  }
-  return executable;
-}, "findExecutable");
-var execGcloud = /* @__PURE__ */ __name(async (args, executable = "gcloud", silent = false) => {
-  const command = findExecutable(executable);
-  const result = await getExecOutput(command, args, {
-    silent,
-    ignoreReturnCode: true
-  });
-  if (result.exitCode !== 0) {
-    let message = `The process '${command}' failed with exit code ${result.exitCode}`;
-    if (result.stderr) {
-      message = `${message}
-
-${result.stderr}`;
-    }
-    throw new Error(message);
-  }
-  return result.stdout.trim();
-}, "execGcloud");
-
-// setup-gcloud/src/auth-wid-federation.js
-async function refreshIdToken({
-  workloadIdentityProvider,
-  idTokenPath
-}) {
-  const newToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  import_node_fs5.default.writeFileSync(idTokenPath, newToken, {
-    encoding: "utf8",
-    mode: 384
-    // rw-------
-  });
-}
-__name(refreshIdToken, "refreshIdToken");
-async function workloadIdentityFederation(credentialsFilePath, { workload_identity_provider: workloadIdentityProvider, email }) {
-  const idToken = await getIDToken(
-    `https://iam.googleapis.com/${workloadIdentityProvider}`
-  );
-  const idTokenPath = createJobScopedCredential(idToken, { encoding: "utf8" });
-  await execGcloud(
-    [
-      "iam",
-      "workload-identity-pools",
-      "create-cred-config",
-      workloadIdentityProvider,
-      `--service-account=${email}`,
-      `--output-file=${credentialsFilePath}`,
-      `--credential-source-file=${idTokenPath}`
-    ],
-    "gcloud",
-    true
-  );
-  return {
-    workloadIdentityProvider,
-    idTokenPath
-  };
-}
-__name(workloadIdentityFederation, "workloadIdentityFederation");
-
-// setup-gcloud/src/auth-gcloud.js
-var authType = {
-  jsonKey: "json_key",
-  widFederation: "wid_federation"
-};
-var env = {
-  accessToken: "CLOUDSDK_AUTH_ACCESS_TOKEN",
-  applicationCredentials: "GOOGLE_APPLICATION_CREDENTIALS",
-  credentialsOverride: "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-  projectId: "CLOUDSDK_CORE_PROJECT"
-};
-var isNonEmptyString = /* @__PURE__ */ __name((value) => typeof value === "string" && value.trim().length > 0, "isNonEmp\
-tyString");
-function parseCredentials(credentials) {
-  let parsed;
-  try {
-    parsed = JSON.parse(Buffer.from(credentials, "base64").toString("utf8"));
-  } catch {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      "Invalid service-account-key: expected base64-encoded JSON credentials"
-    );
-  }
-  return parsed;
-}
-__name(parseCredentials, "parseCredentials");
-function validateCredentialsShape(jsonCredentials) {
-  if (!isNonEmptyString(jsonCredentials.project_id)) {
-    throw new Error(
-      'Invalid service-account-key: missing required field "project_id"'
-    );
-  }
-  if (isNonEmptyString(jsonCredentials.private_key)) {
-    setSecret(jsonCredentials.private_key);
-    const email = jsonCredentials.client_email ?? jsonCredentials.email ?? void 0;
-    if (!isNonEmptyString(email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "client_email" or "email"'
-      );
-    }
-    return {
-      type: authType.jsonKey,
-      email
-    };
-  }
-  if (isNonEmptyString(jsonCredentials.workload_identity_provider)) {
-    if (!isNonEmptyString(jsonCredentials.email)) {
-      throw new Error(
-        'Invalid service-account-key: missing required field "email"'
-      );
-    }
-    return {
-      type: authType.widFederation,
-      email: jsonCredentials.email
-    };
-  }
-  throw new Error(
-    'Invalid service-account-key: expected either "private_key" (json key) or "workload_identity_provider" (wid federati\
-on)'
-  );
-}
-__name(validateCredentialsShape, "validateCredentialsShape");
-function isCurrentAccount(auth2, current) {
-  if (current) {
-    return current.type === auth2.type && current.email === auth2.email && current.projectId === auth2.projectId;
-  }
-  return false;
-}
-__name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
-  const args = ["auth", "print-access-token"];
-  if (type === authType.widFederation) {
-    args.push(`--impersonate-service-account=${email}`);
-  }
-  const accessToken = await execGcloud(args, "gcloud", true);
-  setSecret(accessToken);
-  if (isDebug()) {
-    const params = new URLSearchParams();
-    params.append("access_token", accessToken);
-    await fetch("https://oauth2.googleapis.com/tokeninfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: params
-    }).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
-    ).catch((err) => error(`Failed to debug token info: ${err.message}`));
-  }
-  return accessToken;
-}, "getAccessToken");
-var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
-  if (isNonEmptyString(value)) {
-    if (exportVariable2) {
-      debug2(`Export ${key}`);
-      exportVariable(key, value);
-    }
-    process.env[key] = value;
-  } else {
-    if (exportVariable2) {
-      debug2(`Unset ${key}`);
-      exportVariable(key, "");
-    }
-    delete process.env[key];
-  }
-}, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(async ({
-  type,
-  projectId,
-  email,
-  credentialsFilePath,
-  exportCredentials
-}) => {
-  setEnvironmentVariable(env.projectId, projectId, exportCredentials);
-  setEnvironmentVariable(
-    env.applicationCredentials,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.credentialsOverride,
-    credentialsFilePath,
-    exportCredentials
-  );
-  setEnvironmentVariable(
-    env.accessToken,
-    email ? await getAccessToken(type, email) : "",
-    exportCredentials
-  );
-}, "populateEnvironment");
-function getServiceAccountEmailAndProject(credentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { project_id: projectId } = jsonCredentials;
-  const { email } = validateCredentialsShape(jsonCredentials);
-  return { email, projectId };
-}
-__name(getServiceAccountEmailAndProject, "getServiceAccountEmailAndProject");
-async function authenticateGcloud(credentials, exportCredentials) {
-  setSecret(credentials);
-  const jsonCredentials = parseCredentials(credentials);
-  const { type, email } = validateCredentialsShape(jsonCredentials);
-  const { project_id: projectId } = jsonCredentials;
-  const authEntry = {
-    type,
-    email,
-    projectId,
-    exportCredentials,
-    credentialsFilePath: "",
-    refreshTokenMetadata: void 0
-  };
-  const current = getCurrentAccount();
-  if (isCurrentAccount(authEntry, current)) {
-    await current.refreshToken();
-  } else {
-    authEntry.credentialsFilePath = createJobScopedCredential(credentials);
-    info(
-      `Authenticate gcloud account '${authEntry.email}' with ${authEntry.type}`
-    );
-    try {
-      process.env[env.projectId] = projectId;
-      authEntry.exportCredentials = true;
-      if (authEntry.type === authType.widFederation) {
-        authEntry.refreshTokenMetadata = await workloadIdentityFederation(
-          authEntry.credentialsFilePath,
-          jsonCredentials
-        );
-      }
-    } finally {
-      delete process.env[env.projectId];
-    }
-    const authStack = loadAuthStack();
-    authStack.push(authEntry);
-    saveAuthStack(authStack);
-    await populateEnvironment(authEntry);
-  }
-  return projectId;
-}
-__name(authenticateGcloud, "authenticateGcloud");
-function getCurrentAccount() {
-  const authStack = loadAuthStack();
-  const account = authStack.at(-1);
-  if (!account) {
-    return void 0;
-  }
-  const refreshToken = /* @__PURE__ */ __name(async () => {
-  }, "refreshToken");
-  if (account.type === authType.widFederation && account.refreshTokenMetadata && typeof account.refreshTokenMetadata ===
-  "object") {
-    return {
-      ...account,
-      refreshToken: /* @__PURE__ */ __name(async () => refreshIdToken(account.refreshTokenMetadata), "refreshToken")
-    };
-  }
-  return {
-    ...account,
-    refreshToken
-  };
-}
-__name(getCurrentAccount, "getCurrentAccount");
-async function resetAuthStack() {
-  const wasNonEmpty = loadAuthStack().length > 0;
-  clearAuthStack();
-  if (wasNonEmpty) {
-    await populateEnvironment({
-      type: authType.jsonKey,
-      projectId: "",
-      email: "",
-      credentialsFilePath: "",
-      exportCredentials: true
-    });
-  }
-}
-__name(resetAuthStack, "resetAuthStack");
-async function restorePreviousAccount(previousAccount) {
-  if (!previousAccount) {
-    return false;
-  }
-  const authStack = loadAuthStack();
-  authStack.pop();
-  info(`Restore gcloud account '${previousAccount.email}'`);
-  authStack.push(previousAccount);
-  saveAuthStack(authStack);
-  await populateEnvironment(previousAccount);
-  return true;
-}
-__name(restorePreviousAccount, "restorePreviousAccount");
 
 // setup-gcloud/src/download-url.js
 var import_os4 = __toESM(require("os"), 1);

--- a/txengine-deploy/dist/index.cjs
+++ b/txengine-deploy/dist/index.cjs
@@ -101501,18 +101501,24 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
-var getAccessToken = /* @__PURE__ */ __name(async (email) => {
-  const accessToken = await execGcloud(
-    ["auth", "print-access-token", `--impersonate-service-account=${email}`],
-    "gcloud",
-    true
-  );
+var getAccessToken = /* @__PURE__ */ __name(async (type, email) => {
+  const args = ["auth", "print-access-token"];
+  if (type === authType.widFederation) {
+    args.push(`--impersonate-service-account=${email}`);
+  }
+  const accessToken = await execGcloud(args, "gcloud", true);
   setSecret(accessToken);
   if (isDebug()) {
-    await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`
-    ).then((response) => response.json()).then(
-      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)})`)
+    const params = new URLSearchParams();
+    params.append("access_token", accessToken);
+    await fetch("https://oauth2.googleapis.com/tokeninfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    }).then((response) => response.json()).then(
+      (tokenInfo) => debug2(`Token info: ${JSON.stringify(tokenInfo, null, 2)}`)
     ).catch((err) => error(`Failed to debug token info: ${err.message}`));
   }
   return accessToken;
@@ -101533,6 +101539,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
   }
 }, "setEnvironmentVariable");
 var populateEnvironment = /* @__PURE__ */ __name(async ({
+  type,
   projectId,
   email,
   credentialsFilePath,
@@ -101551,7 +101558,7 @@ var populateEnvironment = /* @__PURE__ */ __name(async ({
   );
   setEnvironmentVariable(
     env.accessToken,
-    email ? await getAccessToken(email) : "",
+    email ? await getAccessToken(type, email) : "",
     exportCredentials
   );
 }, "populateEnvironment");

--- a/txengine-deploy/dist/index.cjs
+++ b/txengine-deploy/dist/index.cjs
@@ -70475,16 +70475,16 @@ var DEFAULT_CYCLER_OPTIONS = {
   refreshWindowInMs: 1e3 * 60 * 2
   // Start refreshing 2m before expiry
 };
-async function beginRefresh(getAccessToken, retryIntervalInMs, refreshTimeout) {
+async function beginRefresh(getAccessToken2, retryIntervalInMs, refreshTimeout) {
   async function tryGetAccessToken() {
     if (Date.now() < refreshTimeout) {
       try {
-        return await getAccessToken();
+        return await getAccessToken2();
       } catch {
         return null;
       }
     } else {
-      const finalToken = await getAccessToken();
+      const finalToken = await getAccessToken2();
       if (finalToken === null) {
         throw new Error("Failed to refresh access token.");
       }
@@ -70593,13 +70593,13 @@ async function trySendRequest(request2, next) {
 }
 __name(trySendRequest, "trySendRequest");
 async function defaultAuthorizeRequest(options) {
-  const { scopes, getAccessToken, request: request2 } = options;
+  const { scopes, getAccessToken: getAccessToken2, request: request2 } = options;
   const getTokenOptions = {
     abortSignal: request2.abortSignal,
     tracingOptions: request2.tracingOptions,
     enableCae: true
   };
-  const accessToken = await getAccessToken(scopes, getTokenOptions);
+  const accessToken = await getAccessToken2(scopes, getTokenOptions);
   if (accessToken) {
     options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
   }
@@ -70629,7 +70629,7 @@ function bearerTokenAuthenticationPolicy(options) {
     authorizeRequest: challengeCallbacks?.authorizeRequest?.bind(challengeCallbacks) ?? defaultAuthorizeRequest,
     authorizeRequestOnChallenge: challengeCallbacks?.authorizeRequestOnChallenge?.bind(challengeCallbacks)
   };
-  const getAccessToken = credential ? createTokenCycler(
+  const getAccessToken2 = credential ? createTokenCycler(
     credential
     /* , options */
   ) : () => Promise.resolve(null);
@@ -70655,7 +70655,7 @@ function bearerTokenAuthenticationPolicy(options) {
       await callbacks.authorizeRequest({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
         request: request2,
-        getAccessToken,
+        getAccessToken: getAccessToken2,
         logger: logger7
       });
       let response;
@@ -70677,7 +70677,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             response,
             request: request2,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           }, parsedClaim);
           if (shouldSendRequest) {
@@ -70688,7 +70688,7 @@ Continuous Access Evaluation authentication flow. Unparsable claims: ${claims}`)
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             request: request2,
             response,
-            getAccessToken,
+            getAccessToken: getAccessToken2,
             logger: logger7
           });
           if (shouldSendRequest) {
@@ -70709,7 +70709,7 @@ the Continuous Access Evaluation authentication flow. Unparsable claims: ${claim
                 scopes: Array.isArray(scopes) ? scopes : [scopes],
                 response,
                 request: request2,
-                getAccessToken,
+                getAccessToken: getAccessToken2,
                 logger: logger7
               }, parsedClaim);
               if (shouldSendRequest) {
@@ -101501,6 +101501,15 @@ function isCurrentAccount(auth2, current) {
   return false;
 }
 __name(isCurrentAccount, "isCurrentAccount");
+var getAccessToken = /* @__PURE__ */ __name(async () => {
+  const accessToken = await execGcloud(
+    ["auth", "print-access-token"],
+    "gcloud",
+    true
+  );
+  setSecret(accessToken);
+  return accessToken;
+}, "getAccessToken");
 var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2) => {
   if (isNonEmptyString(value)) {
     if (exportVariable2) {
@@ -101516,7 +101525,7 @@ var setEnvironmentVariable = /* @__PURE__ */ __name((key, value, exportVariable2
     delete process.env[key];
   }
 }, "setEnvironmentVariable");
-var populateEnvironment = /* @__PURE__ */ __name(({
+var populateEnvironment = /* @__PURE__ */ __name(async ({
   projectId,
   credentialsFilePath,
   exportCredentials
@@ -101530,6 +101539,11 @@ var populateEnvironment = /* @__PURE__ */ __name(({
   setEnvironmentVariable(
     env.credentialsOverride,
     credentialsFilePath,
+    exportCredentials
+  );
+  setEnvironmentVariable(
+    env.accessToken,
+    credentialsFilePath === "" ? "" : await getAccessToken(),
     exportCredentials
   );
 }, "populateEnvironment");
@@ -101577,7 +101591,7 @@ async function authenticateGcloud(credentials, exportCredentials) {
     const authStack = loadAuthStack();
     authStack.push(authEntry);
     saveAuthStack(authStack);
-    populateEnvironment(authEntry);
+    await populateEnvironment(authEntry);
   }
   return projectId;
 }
@@ -101603,11 +101617,11 @@ function getCurrentAccount() {
   };
 }
 __name(getCurrentAccount, "getCurrentAccount");
-function resetAuthStack() {
+async function resetAuthStack() {
   const wasNonEmpty = loadAuthStack().length > 0;
   clearAuthStack();
   if (wasNonEmpty) {
-    populateEnvironment({
+    await populateEnvironment({
       type: authType.jsonKey,
       projectId: "",
       credentialsFilePath: "",
@@ -101625,7 +101639,7 @@ async function restorePreviousAccount(previousAccount) {
   info(`Restore gcloud account '${previousAccount.email}'`);
   authStack.push(previousAccount);
   saveAuthStack(authStack);
-  populateEnvironment(previousAccount);
+  await populateEnvironment(previousAccount);
   return true;
 }
 __name(restorePreviousAccount, "restorePreviousAccount");
@@ -101845,7 +101859,7 @@ var withGcloud = /* @__PURE__ */ __name(async (serviceAccountKey, fn) => {
   } finally {
     const didRestoreAccount = await restorePreviousAccount(previousAccount);
     if (!didRestoreAccount) {
-      resetAuthStack();
+      await resetAuthStack();
       cleanupCredentials(getTrackedCredentials());
     }
   }


### PR DESCRIPTION
This CLOUDSDK_ACCESS_TOKEN is set to allow long-running builds (e.g. docker build + push) to still access GCP resources. Most GCP tooling will discover the access token and use it.

This reapply of #1331 improves on the solution by adding the `--impersonate-service-acccount` flag to the `auth print-access-token` command. If running in debug, it will also introspect the token to help debug missing permissions.