### PR TITLE
feat: Promote security-sidecar v2.0.1 to GA

### DIFF
--- a/cloud-deploy-plan/dist/index.cjs
+++ b/cloud-deploy-plan/dist/index.cjs
@@ -106350,7 +106350,7 @@ var import_jsonschema2 = __toESM(require_lib(), 1);
 var import_yaml3 = __toESM(require_dist7(), 1);
 
 // cloud-deploy/src/manifests/security-sidecar.js
-var STABLE_VERSION = "v1.7.4";
+var STABLE_VERSION = "v2.0.1";
 var getImageTag = /* @__PURE__ */ __name(({ "preview-tag": previewTag = null } = {}) => select_semver_default(
   process.env.SECURITY_IMAGE_TAG || previewTag || STABLE_VERSION,
   STABLE_VERSION

--- a/cloud-deploy/dist/index.cjs
+++ b/cloud-deploy/dist/index.cjs
@@ -108454,7 +108454,7 @@ ${result.toString()}`;
 
 // cloud-deploy/src/manifests/security-sidecar.js
 var IMAGE_NAME = "eu.gcr.io/extenda/security";
-var STABLE_VERSION = "v1.7.4";
+var STABLE_VERSION = "v2.0.1";
 var volumeMounts = /* @__PURE__ */ __name((protocol) => {
   const volumes = [];
   if (protocol === "http2") {

--- a/cloud-deploy/src/manifests/security-sidecar.js
+++ b/cloud-deploy/src/manifests/security-sidecar.js
@@ -7,7 +7,7 @@ import getImageWithSha256 from './image-sha256.js';
 const IMAGE_NAME = 'eu.gcr.io/extenda/security';
 
 // The generally available and stable security sidecar version.
-export const STABLE_VERSION = 'v1.7.4';
+export const STABLE_VERSION = 'v2.0.1';
 
 const volumeMounts = (protocol) => {
   const volumes = [];

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -103111,7 +103111,9 @@ var opaTest = /* @__PURE__ */ __name(async (bundleDir) => {
     binary: "opa_linux_amd64_static",
     version: version3,
     downloadUrl: `https://openpolicyagent.org/downloads/v${version3}/opa_linux_amd64_static`
-  }).then((opa) => exec(opa, ["test", "--verbose", "--bundle", bundleDir]));
+  }).then(
+    (opa) => exec(opa, ["test", "--verbose", "--v0-compatible", "--bundle", bundleDir])
+  );
 }, "opaTest");
 var opa_test_default = opaTest;
 

--- a/opa-policy-test/dist/index.cjs
+++ b/opa-policy-test/dist/index.cjs
@@ -103105,7 +103105,7 @@ var create_test_bundle_default = createTestBundle;
 
 // opa-policy-test/src/opa-test.js
 var opaTest = /* @__PURE__ */ __name(async (bundleDir) => {
-  const version3 = "0.58.0";
+  const version3 = "1.16.2";
   return loadTool({
     tool: "opa",
     binary: "opa_linux_amd64_static",

--- a/opa-policy-test/src/opa-test.js
+++ b/opa-policy-test/src/opa-test.js
@@ -9,7 +9,9 @@ const opaTest = async (bundleDir) => {
     binary: 'opa_linux_amd64_static',
     version,
     downloadUrl: `https://openpolicyagent.org/downloads/v${version}/opa_linux_amd64_static`,
-  }).then((opa) => exec(opa, ['test', '--verbose', '--bundle', bundleDir]));
+  }).then((opa) =>
+    exec(opa, ['test', '--verbose', '--v0-compatible', '--bundle', bundleDir]),
+  );
 };
 
 export default opaTest;

--- a/opa-policy-test/src/opa-test.js
+++ b/opa-policy-test/src/opa-test.js
@@ -3,7 +3,7 @@ import { exec } from '@actions/exec';
 import { loadTool } from '../../utils/src/index.js';
 
 const opaTest = async (bundleDir) => {
-  const version = '0.58.0';
+  const version = '1.16.2';
   return loadTool({
     tool: 'opa',
     binary: 'opa_linux_amd64_static',

--- a/opa-policy-test/test/opa-test.test.js
+++ b/opa-policy-test/test/opa-test.test.js
@@ -16,6 +16,7 @@ test('It can run an OPA test', async () => {
   expect(exec).toHaveBeenCalledWith('opa_linux_amd64_static', [
     'test',
     '--verbose',
+    '--v0-compatible',
     '--bundle',
     'test-bundle',
   ]);


### PR DESCRIPTION
* Promote security 2.0.1 to generally available for use with services. The new sidecar includes OPA v1.6.2 and supports both v0 and v1 Rego policies.
* Upgrade opa-policy-test to use matching OPA version in its policy tests